### PR TITLE
Convert SequelizeService to a generic class.

### DIFF
--- a/packages/examples/src/app/my-module/services/user2.controller.ts
+++ b/packages/examples/src/app/my-module/services/user2.controller.ts
@@ -1,6 +1,11 @@
 import { Service } from '@foal/core';
 import { Sequelize, SequelizeConnectionService, SequelizeService } from '@foal/sequelize';
 
+export interface User {
+  firstName: string;
+  lastName: string;
+}
+
 @Service()
 export class Connection extends SequelizeConnectionService {
   constructor() {
@@ -9,7 +14,7 @@ export class Connection extends SequelizeConnectionService {
 }
 
 @Service()
-export class User2 extends SequelizeService {
+export class User2 extends SequelizeService<User> {
 
   constructor(protected connection: Connection) {
     super('users', {

--- a/packages/sequelize/src/sequelize.service.spec.ts
+++ b/packages/sequelize/src/sequelize.service.spec.ts
@@ -11,10 +11,10 @@ interface User {
   lastName: string;
 }
 
-describe('SequelizeService', () => {
+describe('SequelizeService<User>', () => {
 
   let connection: SequelizeConnectionService;
-  let service: SequelizeService;
+  let service: SequelizeService<User>;
   let model: any;
   let user: User;
   let user2: User;
@@ -30,7 +30,7 @@ describe('SequelizeService', () => {
     }
     connection = new ConcreteSequelizeConnectionService();
 
-    class ConcreteSequelizeService extends SequelizeService {
+    class ConcreteSequelizeService extends SequelizeService<User> {
       constructor(connection: SequelizeConnectionService) {
         super('users', {
           firstName: Sequelize.STRING,
@@ -55,7 +55,7 @@ describe('SequelizeService', () => {
   // Clear table before each test
   beforeEach(() => model.sync({ force: true }));
 
-  describe('when create(data: any, params: RestParams): Promise<any> is called', () => {
+  describe('when create(data: any, params: RestParams): Promise<User|User[]> is called', () => {
 
     it('should create one user in the db and return it if `data` is an object.', async () => {
       const result = await service.create(user, emptyParams);
@@ -80,7 +80,7 @@ describe('SequelizeService', () => {
 
   });
 
-  describe('when getAll(params: RestParams): Promise<any> is called', () => {
+  describe('when getAll(params: RestParams): Promise<User[]> is called', () => {
 
     describe('with empty params', () => {
 
@@ -110,7 +110,7 @@ describe('SequelizeService', () => {
 
   });
 
-  describe('when get(id: any, params: RestParams): Promise<any> is called', () => {
+  describe('when get(id: any, params: RestParams): Promise<User> is called', () => {
 
     it('should return the user with the given id from the db.', async () => {
       const createdUser = (await model.create(user)).dataValues;
@@ -131,7 +131,7 @@ describe('SequelizeService', () => {
 
   });
 
-  describe('when update(id: any, data: any, params: RestParams): Promise<any> is called', () => {
+  describe('when update(id: any, data: any, params: RestParams): Promise<User> is called', () => {
 
     it('should update and return the user with the given id with the given data.', async () => {
       const createdUser = (await model.create(user)).dataValues;
@@ -160,7 +160,7 @@ describe('SequelizeService', () => {
 
   });
 
-  describe('when patch(id: any, data: any, params: RestParams): Promise<any> is called', () => {
+  describe('when patch(id: any, data: any, params: RestParams): Promise<User> is called', () => {
 
     it('should update and return the user with the given id with the given data.', async () => {
       const createdUser = (await model.create(user)).dataValues;

--- a/packages/sequelize/src/sequelize.service.ts
+++ b/packages/sequelize/src/sequelize.service.ts
@@ -2,14 +2,14 @@ import { NotFoundError, RestController, RestParams } from '@foal/core';
 
 import { SequelizeConnectionService } from './sequelize-connection.service';
 
-export abstract class SequelizeService implements RestController {
+export abstract class SequelizeService<Model> implements RestController {
   protected model: any;
 
   constructor(name: string, schema: any, connection: SequelizeConnectionService) {
     this.model = connection.sequelize.define(name, schema);
   }
 
-  public async create(data: any, params: RestParams): Promise<any> {
+  public async create(data: any, params: RestParams): Promise<Model|Model[]> {
     await this.model.sync();
 
     if (Array.isArray(data)) {
@@ -24,7 +24,7 @@ export abstract class SequelizeService implements RestController {
     return model.dataValues;
   }
 
-  public async get(id: any, params: RestParams): Promise<any> {
+  public async get(id: any, params: RestParams): Promise<Model> {
     await this.model.sync();
 
     const result = await this.model.findById(id);
@@ -34,7 +34,7 @@ export abstract class SequelizeService implements RestController {
     return result.dataValues;
   }
 
-  public async getAll(params: RestParams): Promise<any> {
+  public async getAll(params: RestParams): Promise<Model[]> {
     await this.model.sync();
 
     const models = await this.model.findAll({
@@ -43,7 +43,7 @@ export abstract class SequelizeService implements RestController {
     return models.map(e => e.dataValues);
   }
 
-  public async update(id: any, data: any, params: RestParams): Promise<any> {
+  public async update(id: any, data: any, params: RestParams): Promise<Model> {
     await this.model.sync();
 
     if (data.id) {
@@ -61,7 +61,7 @@ export abstract class SequelizeService implements RestController {
     return model.dataValues;
   }
 
-  public async patch(id: any, data: any, params: RestParams): Promise<any> {
+  public async patch(id: any, data: any, params: RestParams): Promise<Model> {
     return this.update(id, data, params);
   }
 


### PR DESCRIPTION
Convert SequelizeService to a generic class so that we can add types on returning values.