### PR TITLE
Redefine Context

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,58 +1,13 @@
-# FoalTS
+# ![Logo](./docs/logo_64.png) FoalTS
+
+[![npm version](https://badge.fury.io/js/%40foal%2Fcore.svg)](https://badge.fury.io/js/%40foal%2Fcore)
+[![Build Status](https://travis-ci.org/FoalTS/foal.svg?branch=add-travis)](https://travis-ci.org/FoalTS/foal)
 
 **This work is in progress. Future releases may break current features, so use it at your own risk!**
 
-## Installation
+FoalTS is the framework you need to build the backend of small to large web applications. As a brief overview, FoalTS lets you quickly set up a connection to a DB and then create, read, update or delete its data through a REST API. All of that in TypeScript. Read the docs now to learn more about all FoalTS features!
 
-```ts
-npm install --save express body-parser @foal/core @foal/express
-```
-
-## Get started
-
-```json
-// tsconfig.json
-{
-  "compilerOptions": {
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "lib": [
-      "es6",
-      "dom"
-    ]
-    ...
-}
-```
-
-```ts
-import * as bodyParser from 'body-parser';
-import * as express from 'express';
-import { getCallback } from '@foal/express';
-import { Foal, Service, rest, RestController, RestParams } from '@foal/core';
-
-@Service()
-class User implements RestController {
-  constructor () {}
-
-  async create(data: any, params: RestParams) {
-    console.log(params.query);
-    data.createdAt = Date.now();
-    return data;
-  }
-}
-
-const foal = new Foal({
-  services: [ User ],
-  controllerBindings: [ rest.bindController('/users', User) ]
-});
-
-const app = express();
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
-app.use(getCallback(foal));
-app.listen(3000, () => console.log('Listening...'));
-
-```
+[>> Get started <<](https://foalts.gitbooks.io/docs/content/)
 
 ## Documentation
 
@@ -70,6 +25,7 @@ There are several ways to contribute.
 ## Packages
 
 - @foal/core
+- @foal/express
 - @foal/sequelize
 
 ## License

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@foal/core",
   "version": "0.3.0",
-  "description": "Backend framework written in TypeScript",
+  "description": "A Node.Js framework for ambitious web apps.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
@@ -14,7 +14,9 @@
     "backend",
     "node",
     "typescript",
-    "server"
+    "server",
+    "foal",
+    "rest"
   ],
   "bugs": {
     "url": "https://github.com/FoalTS/foal/issues"

--- a/packages/core/src/controllers/binders/controller.binder.spec.ts
+++ b/packages/core/src/controllers/binders/controller.binder.spec.ts
@@ -2,17 +2,17 @@ import { expect } from 'chai';
 
 import { Injector, Service } from '../../di/injector';
 import { preHook } from '../factories';
-import { Context, MethodPrimitiveBinding, PreMiddleware } from '../interfaces';
+import { Context, MethodPrimitiveBinding, PostContext, PreMiddleware } from '../interfaces';
 import { ControllerBinder } from './controller.binder';
 
 describe('ControllerBinder<T>', () => {
 
   interface ServiceInterface { foobar: () => Promise<any>; }
   const classPreMiddleware: PreMiddleware = (ctx: Context, injector: Injector) => {
-    ctx.class = { injector };
+    ctx.state.class = { injector };
   };
   const methodPreMiddleware: PreMiddleware = (ctx: Context, injector: Injector) => {
-    ctx.method = { injector };
+    ctx.state.method = { injector };
   };
 
   @Service()
@@ -74,11 +74,11 @@ describe('ControllerBinder<T>', () => {
         expect(actual.successStatus).to.equal(10000);
 
         expect(actual.middlewares).to.be.an('array').and.to.have.lengthOf(3);
-        const ctx: Context = {};
+        const ctx = { state: {} } as PostContext<any>;
         actual.middlewares[0](ctx);
-        expect(ctx.class).to.deep.equal({ injector });
+        expect(ctx.state.class).to.deep.equal({ injector });
         actual.middlewares[1](ctx);
-        expect(ctx.method).to.deep.equal({ injector });
+        expect(ctx.state.method).to.deep.equal({ injector });
         await actual.middlewares[2](ctx);
         expect(ctx.result).to.equal('Hello world');
       });

--- a/packages/core/src/controllers/binders/controller.binder.ts
+++ b/packages/core/src/controllers/binders/controller.binder.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 
 import { Injector } from '../../di/injector';
 import { Type } from '../../interfaces';
-import { Context, MethodBinding, MethodPrimitiveBinding, PreMiddleware } from '../interfaces';
+import { Context, MethodBinding, MethodPrimitiveBinding, PostContext, PreMiddleware } from '../interfaces';
 
 export abstract class ControllerBinder<T> {
 
@@ -19,7 +19,9 @@ export abstract class ControllerBinder<T> {
       return this.bind(controller).map(binding => {
         const preMiddlewares = this.getPreMiddlewares(ControllerClass, binding.controllerMethodName)
           .map(pM => ((ctx: Context) => pM(ctx, injector)));
-        const methodMiddleware = async (ctx: Context) => ctx.result = await binding.controllerMethodBinder(ctx);
+        const methodMiddleware = async (ctx: PostContext<any>) => {
+          ctx.result = await binding.controllerMethodBinder(ctx);
+        };
         const middlewares = [ ...preMiddlewares, methodMiddleware ];
         return {
           httpMethod: binding.httpMethod,

--- a/packages/core/src/controllers/binders/rest/rest-controller.binder.ts
+++ b/packages/core/src/controllers/binders/rest/rest-controller.binder.ts
@@ -1,18 +1,18 @@
 import { NotImplementedError } from '../../errors';
-import { MethodPrimitiveBinding } from '../../interfaces';
+import { Context, MethodPrimitiveBinding } from '../../interfaces';
 import { ControllerBinder } from '../controller.binder';
 
-import { RestContext, RestController } from './rest-controller.interface';
+import { RestController } from './rest-controller.interface';
 
 export class RestBinder extends ControllerBinder<RestController> {
   protected bind(controller: RestController): MethodPrimitiveBinding[] {
     return [
       {
-        controllerMethodBinder: (ctx: RestContext) => {
+        controllerMethodBinder: (ctx: Context) => {
           if (!controller.getAll) {
             throw new NotImplementedError();
           }
-          return controller.getAll(ctx.params);
+          return controller.getAll(ctx.query);
         },
         controllerMethodName: 'getAll',
         httpMethod: 'GET',
@@ -20,11 +20,11 @@ export class RestBinder extends ControllerBinder<RestController> {
         successStatus: 200,
       },
       {
-        controllerMethodBinder: (ctx: RestContext) => {
+        controllerMethodBinder: (ctx: Context) => {
           if (!controller.create) {
             throw new NotImplementedError();
           }
-          return controller.create(ctx.data, ctx.params);
+          return controller.create(ctx.body, ctx.query);
         },
         controllerMethodName: 'create',
         httpMethod: 'POST',
@@ -32,11 +32,11 @@ export class RestBinder extends ControllerBinder<RestController> {
         successStatus: 201,
       },
       {
-        controllerMethodBinder: (ctx: RestContext) => {
+        controllerMethodBinder: (ctx: Context) => {
           if (!controller.delete) {
             throw new NotImplementedError();
           }
-          return controller.delete(ctx.id, ctx.params);
+          return controller.delete(ctx.params.id, ctx.query);
         },
         controllerMethodName: 'delete',
         httpMethod: 'DELETE',
@@ -44,11 +44,11 @@ export class RestBinder extends ControllerBinder<RestController> {
         successStatus: 200,
       },
       {
-        controllerMethodBinder: (ctx: RestContext) => {
+        controllerMethodBinder: (ctx: Context) => {
           if (!controller.get) {
             throw new NotImplementedError();
           }
-          return controller.get(ctx.id, ctx.params);
+          return controller.get(ctx.params.id, ctx.query);
         },
         controllerMethodName: 'get',
         httpMethod: 'GET',
@@ -56,11 +56,11 @@ export class RestBinder extends ControllerBinder<RestController> {
         successStatus: 200,
       },
       {
-        controllerMethodBinder: (ctx: RestContext) => {
+        controllerMethodBinder: (ctx: Context) => {
           if (!controller.patch) {
             throw new NotImplementedError();
           }
-          return controller.patch(ctx.id, ctx.data, ctx.params);
+          return controller.patch(ctx.params.id, ctx.body, ctx.query);
         },
         controllerMethodName: 'patch',
         httpMethod: 'PATCH',
@@ -68,11 +68,11 @@ export class RestBinder extends ControllerBinder<RestController> {
         successStatus: 200,
       },
       {
-        controllerMethodBinder: (ctx: RestContext) => {
+        controllerMethodBinder: (ctx: Context) => {
           if (!controller.update) {
             throw new NotImplementedError();
           }
-          return controller.update(ctx.id, ctx.data, ctx.params);
+          return controller.update(ctx.params.id, ctx.body, ctx.query);
         },
         controllerMethodName: 'update',
         httpMethod: 'PUT',

--- a/packages/core/src/controllers/binders/rest/rest-controller.interface.ts
+++ b/packages/core/src/controllers/binders/rest/rest-controller.interface.ts
@@ -1,18 +1,8 @@
-export interface RestParams {
-  query: { [name: string]: any };
-}
-
-export interface RestContext {
-  id: any;
-  data: any;
-  params: RestParams;
-}
-
 export interface RestController {
-  create?: (data: any, params: any) => Promise<any>;
-  get?: (id: any, params: any) => Promise<any>;
-  getAll?: (params: any) => Promise<any>;
-  update?: (id: any, data: any, params: any) => Promise<any>;
-  patch?: (id: any, data: any, params: any) => Promise<any>;
-  delete?: (id: any, params: any) => Promise<any>;
+  create?: (data: any, query: object) => Promise<any>;
+  get?: (id: any, query: object) => Promise<any>;
+  getAll?: (query: object) => Promise<any>;
+  update?: (id: any, data: any, query: object) => Promise<any>;
+  patch?: (id: any, data: any, query: object) => Promise<any>;
+  delete?: (id: any, query: object) => Promise<any>;
 }

--- a/packages/core/src/controllers/binders/rest/rest-controller.interface.ts
+++ b/packages/core/src/controllers/binders/rest/rest-controller.interface.ts
@@ -1,8 +1,10 @@
+import { ObjectType } from '../../interfaces';
+
 export interface RestController {
-  create?: (data: any, query: object) => Promise<any>;
-  get?: (id: any, query: object) => Promise<any>;
-  getAll?: (query: object) => Promise<any>;
-  update?: (id: any, data: any, query: object) => Promise<any>;
-  patch?: (id: any, data: any, query: object) => Promise<any>;
-  delete?: (id: any, query: object) => Promise<any>;
+  create?: (data: any, query: ObjectType) => Promise<any>;
+  get?: (id: any, query: ObjectType) => Promise<any>;
+  getAll?: (query: ObjectType) => Promise<any>;
+  update?: (id: any, data: any, query: ObjectType) => Promise<any>;
+  patch?: (id: any, data: any, query: ObjectType) => Promise<any>;
+  delete?: (id: any, query: ObjectType) => Promise<any>;
 }

--- a/packages/core/src/controllers/interfaces.ts
+++ b/packages/core/src/controllers/interfaces.ts
@@ -1,6 +1,21 @@
 import { Injector } from '../di/injector';
 
-export interface Context { [name: string]: any; }
+export interface ObjectType {
+  [name: string]: any;
+}
+export interface Context {
+  session: ObjectType|undefined;
+  params: ObjectType;
+  body: any;
+  query: ObjectType;
+  state: ObjectType;
+  result?: any;
+  getHeader(field: string): string;
+}
+
+export interface PostContext<ResultType> extends Context {
+  result: ResultType;
+}
 
 export type Middleware = (ctx: Context) => Promise<any>|any;
 export type PreMiddleware = (ctx: Context, injector: Injector) => Promise<any>|any;

--- a/packages/examples/src/app/services/user.controller.ts
+++ b/packages/examples/src/app/services/user.controller.ts
@@ -2,9 +2,9 @@ import {
   log,
   methodNotAllowed,
   NotFoundError,
+  ObjectType,
   preHook,
   RestController,
-  RestParams,
   Service
 } from '@foal/core';
 
@@ -14,7 +14,7 @@ import {
 export class User implements RestController {
   constructor() {}
 
-  public async create(data: any, params: RestParams): Promise<any> {
+  public async create(data: any, query: ObjectType): Promise<any> {
     console.log(data);
     return 1;
   }
@@ -22,35 +22,35 @@ export class User implements RestController {
   @preHook(ctx => {
     console.log(ctx);
   })
-  public async get(id: any, params: RestParams): Promise<any> {
+  public async get(id: any, query: ObjectType): Promise<any> {
     throw new NotFoundError();
   }
 
   @methodNotAllowed()
-  public async getAll(params: RestParams): Promise<any> {
+  public async getAll(query: ObjectType): Promise<any> {
     return 'You got it all';
   }
 
   @log('update (1)')
   @log('update (2)')
-  public async update(id: any, data: any, params: RestParams): Promise<any> {
+  public async update(id: any, data: any, query: ObjectType): Promise<any> {
     console.log('id', id);
     console.log('data', data);
-    console.log('params', params);
+    console.log('query', query);
     return Promise.resolve();
   }
 
   @preHook(ctx => Promise.resolve(ctx))
-  public async patch(id: any, data: any, params: RestParams): Promise<any> {
+  public async patch(id: any, data: any, query: ObjectType): Promise<any> {
     console.log('id', id);
     console.log('data', data);
-    console.log('params', params);
+    console.log('query', query);
     return Promise.resolve();
   }
 
-  public async delete(id: any, params: RestParams): Promise<any> {
+  public async delete(id: any, query: ObjectType): Promise<any> {
     console.log('id', id);
-    console.log('params', params);
+    console.log('query', query);
     return Promise.resolve();
   }
 }

--- a/packages/express/src/get-express-middleware.ts
+++ b/packages/express/src/get-express-middleware.ts
@@ -1,16 +1,17 @@
-import { HttpError, MethodBinding } from '@foal/core';
+import { Context, HttpError, MethodBinding } from '@foal/core';
 import { Router } from 'express';
 
 import { ExpressMiddleware } from './interfaces';
 
 export function getExpressMiddleware(methodBinding: MethodBinding): ExpressMiddleware {
   const expressMiddleware: ExpressMiddleware = async (req, res, next) => {
-    const ctx: any = {
-      data: req.body,
-      id: req.params.id,
-      params: {
-        query: req.query
-      }
+    const ctx: Context = {
+      body: req.body,
+      getHeader: req.get.bind(req),
+      params: req.params,
+      query: req.query,
+      session: undefined,
+      state: {},
     };
     try {
       for (const middleware of methodBinding.middlewares) {

--- a/packages/sequelize/src/sequelize.service.spec.ts
+++ b/packages/sequelize/src/sequelize.service.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as Sequelize from 'sequelize';
 
-import { NotFoundError, RestParams } from '@foal/core';
+import { NotFoundError } from '@foal/core';
 
 import { SequelizeConnectionService } from './sequelize-connection.service';
 import { SequelizeService } from './sequelize.service';
@@ -18,7 +18,6 @@ describe('SequelizeService', () => {
   let model: any;
   let user: User;
   let user2: User;
-  let emptyParams: RestParams;
 
   before(() => {
     class ConcreteSequelizeConnectionService extends SequelizeConnectionService {
@@ -49,16 +48,15 @@ describe('SequelizeService', () => {
       firstName: 'Estelle',
       lastName: 'Dupont'
     };
-    emptyParams = { query: {} };
   });
 
   // Clear table before each test
   beforeEach(() => model.sync({ force: true }));
 
-  describe('when create(data: any, params: RestParams): Promise<any> is called', () => {
+  describe('when create(data: any, query: ObjectType): Promise<any> is called', () => {
 
     it('should create one user in the db and return it if `data` is an object.', async () => {
-      const result = await service.create(user, emptyParams);
+      const result = await service.create(user, {});
 
       const users = await model.findAll();
 
@@ -68,7 +66,7 @@ describe('SequelizeService', () => {
     });
 
     it('should create many users in the db and return them if `data` is an array.', async () => {
-      const result = await service.create([ user, user2 ], emptyParams);
+      const result = await service.create([ user, user2 ], {});
 
       const users = await model.findAll();
 
@@ -80,29 +78,29 @@ describe('SequelizeService', () => {
 
   });
 
-  describe('when getAll(params: RestParams): Promise<any> is called', () => {
+  describe('when getAll(query: ObjectType): Promise<any> is called', () => {
 
-    describe('with empty params', () => {
+    describe('with empty query', () => {
 
       it('should return all users from the db.', async () => {
         const createdUser = (await model.create(user)).dataValues;
         const createdUser2 = (await model.create(user2)).dataValues;
 
-        const result = await service.getAll(emptyParams);
+        const result = await service.getAll({});
         expect(result).to.deep.equal([ createdUser, createdUser2 ]);
       });
 
     });
 
-    describe('with non empty params', () => {
+    describe('with non empty query', () => {
 
-      it('should use params.query to get users from the db.', async () => {
+      it('should use `query` to get users from the db.', async () => {
         const createdUser = (await model.create(user)).dataValues;
         await model.create(user2);
 
         const query: any = { firstName: user.firstName };
 
-        const result = await service.getAll({ query });
+        const result = await service.getAll(query);
         expect(result).to.deep.equal([ createdUser ]);
       });
 
@@ -110,19 +108,19 @@ describe('SequelizeService', () => {
 
   });
 
-  describe('when get(id: any, params: RestParams): Promise<any> is called', () => {
+  describe('when get(id: any, query: ObjectType): Promise<any> is called', () => {
 
     it('should return the user with the given id from the db.', async () => {
       const createdUser = (await model.create(user)).dataValues;
 
-      const result = await service.get(createdUser.id, emptyParams);
+      const result = await service.get(createdUser.id, {});
 
       expect(result).to.deep.equal(createdUser);
     });
 
     it('should throw an NotFoundError if no user exists in the db with the given id.', async () => {
       try {
-        await service.get(666, emptyParams);
+        await service.get(666, {});
         throw  new Error('No error was thrown in get()');
       } catch (err) {
         expect(err).to.be.instanceof(NotFoundError);
@@ -131,7 +129,7 @@ describe('SequelizeService', () => {
 
   });
 
-  describe('when update(id: any, data: any, params: RestParams): Promise<any> is called', () => {
+  describe('when update(id: any, data: any, query: ObjectType): Promise<any> is called', () => {
 
     it('should update and return the user with the given id with the given data.', async () => {
       const createdUser = (await model.create(user)).dataValues;
@@ -139,7 +137,7 @@ describe('SequelizeService', () => {
 
       const updatedUser = await service.update(createdUser.id, {
         lastName: 'Washington'
-      }, emptyParams);
+      }, {});
 
       const userFromDB = (await model.findById(createdUser.id)).dataValues;
       const user2FromDB = (await model.findById(createdUser2.id)).dataValues;
@@ -151,7 +149,7 @@ describe('SequelizeService', () => {
 
     it('should throw an NotFoundError if no user exists in the db with the given id.', async () => {
       try {
-        await service.update(666, {}, emptyParams);
+        await service.update(666, {}, {});
         throw  new Error('No error was thrown in get()');
       } catch (err) {
         expect(err).to.be.instanceof(NotFoundError);
@@ -160,7 +158,7 @@ describe('SequelizeService', () => {
 
   });
 
-  describe('when patch(id: any, data: any, params: RestParams): Promise<any> is called', () => {
+  describe('when patch(id: any, data: any, query: ObjectType): Promise<any> is called', () => {
 
     it('should update and return the user with the given id with the given data.', async () => {
       const createdUser = (await model.create(user)).dataValues;
@@ -168,7 +166,7 @@ describe('SequelizeService', () => {
 
       const updatedUser = await service.patch(createdUser.id, {
         lastName: 'Washington'
-      }, emptyParams);
+      }, {});
 
       const userFromDB = (await model.findById(createdUser.id)).dataValues;
       const user2FromDB = (await model.findById(createdUser2.id)).dataValues;
@@ -180,7 +178,7 @@ describe('SequelizeService', () => {
 
     it('should throw an NotFoundError if no user exists in the db with the given id.', async () => {
       try {
-        await service.patch(666, {}, emptyParams);
+        await service.patch(666, {}, {});
         throw  new Error('No error was thrown in get()');
       } catch (err) {
         expect(err).to.be.instanceof(NotFoundError);
@@ -189,7 +187,7 @@ describe('SequelizeService', () => {
 
   });
 
-  describe('when delete(id: any, params: RestParams): Promise<any> is called', () => {
+  describe('when delete(id: any, query: ObjectType): Promise<any> is called', () => {
 
     it('should delete the user with the given id from the db.', async () => {
       const createdUser = (await model.create(user)).dataValues;
@@ -198,7 +196,7 @@ describe('SequelizeService', () => {
       let users = await model.findAll();
       expect(users).to.be.an('array').and.to.have.lengthOf(2);
 
-      await service.delete(createdUser.id, emptyParams);
+      await service.delete(createdUser.id, {});
 
       users = await model.findAll();
       expect(users).to.be.an('array').and.to.have.lengthOf(1);
@@ -207,7 +205,7 @@ describe('SequelizeService', () => {
 
     it('should throw an NotFoundError if no user exists in the db with the given id.', async () => {
       try {
-        await service.delete(666, emptyParams);
+        await service.delete(666, {});
         throw  new Error('No error was thrown in get()');
       } catch (err) {
         expect(err).to.be.instanceof(NotFoundError);

--- a/packages/sequelize/src/sequelize.service.ts
+++ b/packages/sequelize/src/sequelize.service.ts
@@ -1,4 +1,4 @@
-import { NotFoundError, RestController, RestParams } from '@foal/core';
+import { NotFoundError, ObjectType, RestController } from '@foal/core';
 
 import { SequelizeConnectionService } from './sequelize-connection.service';
 
@@ -9,7 +9,7 @@ export abstract class SequelizeService implements RestController {
     this.model = connection.sequelize.define(name, schema);
   }
 
-  public async create(data: any, params: RestParams): Promise<any> {
+  public async create(data: any, query: ObjectType): Promise<any> {
     await this.model.sync();
 
     if (Array.isArray(data)) {
@@ -24,7 +24,7 @@ export abstract class SequelizeService implements RestController {
     return model.dataValues;
   }
 
-  public async get(id: any, params: RestParams): Promise<any> {
+  public async get(id: any, query: ObjectType): Promise<any> {
     await this.model.sync();
 
     const result = await this.model.findById(id);
@@ -34,16 +34,16 @@ export abstract class SequelizeService implements RestController {
     return result.dataValues;
   }
 
-  public async getAll(params: RestParams): Promise<any> {
+  public async getAll(query: ObjectType): Promise<any> {
     await this.model.sync();
 
     const models = await this.model.findAll({
-      where: params.query
+      where: query
     });
     return models.map(e => e.dataValues);
   }
 
-  public async update(id: any, data: any, params: RestParams): Promise<any> {
+  public async update(id: any, data: any, query: ObjectType): Promise<any> {
     await this.model.sync();
 
     if (data.id) {
@@ -61,11 +61,11 @@ export abstract class SequelizeService implements RestController {
     return model.dataValues;
   }
 
-  public async patch(id: any, data: any, params: RestParams): Promise<any> {
-    return this.update(id, data, params);
+  public async patch(id: any, data: any, query: ObjectType): Promise<any> {
+    return this.update(id, data, query);
   }
 
-  public async delete(id: any, params: RestParams): Promise<any> {
+  public async delete(id: any, query: ObjectType): Promise<any> {
     await this.model.sync();
 
     const result = await this.model.destroy({


### PR DESCRIPTION
# Issues

- Having contexts defined as `any` prevents from using TypeScript features.
- Adding in a hook custom attributes to the context may conflict with future foal releases if new official attributes appear.
- Having an `id` attribute in the context is only relevant in REST cases.

# Solutions

Define a `Context` interface. It should include:
- useful attributes from the request (headers, session, params, query, etc),
- a `state` attribute where custom attributes can be specified,
- attributes that are not only relevant in REST cases.