### PR TITLE
Update pg to pg@6 in sequelize docs

### DIFF
--- a/docs/packages/sequelize.md
+++ b/docs/packages/sequelize.md
@@ -6,7 +6,7 @@
 npm install --save express @foal/core @foal/express @foal/sequelize
 
 # And one of the following:
-$ npm install --save pg pg-hstore
+$ npm install --save pg@6 pg-hstore
 $ npm install --save mysql2
 $ npm install --save sqlite3
 $ npm install --save tedious // MSSQL


### PR DESCRIPTION
`pg@7` currently not supported (cf [sequelize website](http://docs.sequelizejs.com/manual/installation/getting-started.html))