### PR TITLE
Prepare docs migrating from gitbook to foalts.org

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,14 +56,14 @@ Press enter to choose the `REST` option.
 
 Open `horse-controller.service.ts` and implement the `getAll` method:
 
-```ts
+```typescript
 public async getAll(params: any): Promise<any> {
   return ['Horse 1', 'Horse 2', 'Horse 3'];
 }
 ```
 
 Open `app.module.ts` and replace the content by:
-```ts
+```typescript
 import { FoalModule, rest } from '@foal/core';
 
 import { HorseController } from './horse-controller.service';

--- a/docs/api/rest-controller.md
+++ b/docs/api/rest-controller.md
@@ -2,7 +2,7 @@
 
 `RestController` is an interface that should be used with the `rest` controller binder.
 
-```ts
+```typescript
 interface RestParams {
   query: { [name: string]: any };
 }

--- a/docs/basics/controllers.md
+++ b/docs/basics/controllers.md
@@ -9,7 +9,7 @@ Let's a take an example on how to set up a REST API endpoint. To do so, we'll ne
 - and the `rest` *controller binder* which will bind the controller to the request handler through a module.
 
 First, we need to create a service that implements the interface:
-```ts
+```typescript
 @Service()
 class User implements RestController {
   constructor () {}
@@ -24,7 +24,7 @@ class User implements RestController {
 There are other methods such as `update`, `delete`, `modify`, `get` or `getAll`. We choose to only implement the `create` method here which matches the `POST` requests.
 
 Now let's wire it to the request handler at the endpoint `/users`:
-```ts
+```typescript
 import { rest } from '@foal/core';
 
 const AppModule: FoalModule = {
@@ -36,7 +36,7 @@ const AppModule: FoalModule = {
 That's it!
 
 The final code looks like this:
-```ts
+```typescript
 // RestController
 import * as bodyParser from 'body-parser';
 import * as express from 'express';

--- a/docs/basics/modules.md
+++ b/docs/basics/modules.md
@@ -4,7 +4,7 @@ Every app starts with a module. A module instantiates services and binds control
 
 ## Example
 
-```ts
+```typescript
 import { Module, rest } from '@foal/core';
 // module and service imports ...
 

--- a/docs/basics/pre-hooks.md
+++ b/docs/basics/pre-hooks.md
@@ -4,7 +4,7 @@ Pre-hooks are TypeScript decorators used on either a controller method, a contro
 
 ## How to create one
 
-```ts
+```typescript
 import {
   Context,
   Service,
@@ -33,7 +33,7 @@ class MyController {}
 
 You can either bind your pre-hook to a controller method, its class or a module. Attaching a pre-hook to a class is equivalent to attaching it to all its methods. Providing a pre-hook to a module is equivalent to attaching it to all its controllers.
 
-```ts
+```typescript
 import { Context, Service, preHook, RestController } from '@foal/core';
 
 function contextLogger(context: Context): Promise<any> {
@@ -55,7 +55,7 @@ class MyController extends RestController {
 
 You can combine several pre-hooks into one thanks to `combinePreHooks`.
 
-```ts
+```typescript
 import { combinePreHooks, Service, RestController } from '@foal/core';
 
 function myCombinedPreHooks() {
@@ -78,14 +78,14 @@ export class Foobar implements RestController {
 To test a pre-hook you can test its middleware. So prefer separate its declaration from the pre-hook itself.
 
 DON'T DO:
-```ts
+```typescript
 function addHelloWorldToContext() {
   return preHook((ctx: Context) => ctx.helloWorld = 'Hello world');
 }
 ```
 
 DO:
-```ts
+```typescript
 function addHelloWorldToContextMiddleware(ctx: Context) {
   ctx.helloWorld = 'Hello world';
 }
@@ -99,7 +99,7 @@ function addHelloWorldToContext() {
 
 When testing controller methods, pre-hooks are skipped. So with the previous example you have:
 
-```ts
+```typescript
 import { expect } from 'chai';
 
 async function test() {

--- a/docs/basics/services.md
+++ b/docs/basics/services.md
@@ -4,7 +4,7 @@ Services are the core of FoalTS. They are used to perform many different tasks s
 
 Basically a service can be any class that serves a restricted and well-defined purpose. You just need to insert the `@Service()` decorator on its top. Once done the service must be provided to a module so that it can be instantiated as a singleton.
 
-```ts
+```typescript
 import { Foal, Service } from '@foal/core';
 
 @Service()
@@ -25,7 +25,7 @@ console.log(myServiceA.name);
 
 If you want to call a service from another one, you need to inject it in the constructor as follows.
 
-```ts
+```typescript
 import { Foal, Service } from '@foal/core';
 
 @Service()
@@ -57,7 +57,7 @@ As foal uses the inversion of control principle, a service is very easy to test.
 npm install --save-dev chai
 ```
 
-```ts
+```typescript
 import { Service } from '@foal/core';
 import { expect } from 'chai';
 

--- a/docs/packages/sequelize.md
+++ b/docs/packages/sequelize.md
@@ -2,7 +2,7 @@
 
 ## Prerequisities 
 
-```ts
+```typescript
 npm install --save express @foal/core @foal/express @foal/sequelize
 
 # And one of the following:
@@ -28,7 +28,7 @@ $ npm install --save tedious // MSSQL
 
 ## Setting up a connection
 
-```ts
+```typescript
 import { Service } from '@foal/core';
 import { SequelizeConnectionService } from '@foal/sequelize';
 
@@ -42,7 +42,7 @@ export class Connection extends SequelizeConnectionService {
 
 ## Get connected to a table
 
-```ts
+```typescript
 import { Service } from '@foal/core';
 import { Sequelize, SequelizeService } from '@foal/sequelize';
 
@@ -60,7 +60,7 @@ export class User extends SequelizeService {
 
 ## Serve your service as an API (optional)
 
-```ts
+```typescript
 import * as bodyParser from 'body-parser';
 import * as express from 'express';
 import { getCallback } from '@foal/express';
@@ -85,7 +85,7 @@ app.listen(3000, () => console.log('Listening...'));
 
 Let's say that we want to forbid to use the method `delete` when using the service as a controller.
 
-```ts
+```typescript
 import { Service, MethodNotAllowed, RestParams } from '@foal/core';
 import { Sequelize, SequelizeService } from '@foal/sequelize';
 
@@ -110,7 +110,7 @@ export class User extends SequelizeService {
 
 Let's say that we want to return all the users when updating one.
 
-```ts
+```typescript
 import { Service, MethodNotAllowed, RestParams } from '@foal/core';
 import { Sequelize, SequelizeService } from '@foal/sequelize';
 
@@ -135,7 +135,7 @@ export class User extends SequelizeService {
 
 If you have overrided some methods and want to test them, you can do it with a fake DB thanks to the injection of the connection.
 
-```ts
+```typescript
 import { Connection } from './connection.service';
 import { User } from './user.service';
 


### PR DESCRIPTION
Rename `ts` to `typescript` in doc block code to support [prism](http://prismjs.com/).