### PR TITLE
Prepare docs migrating from gitbook to foalts.org (v0.4.0)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,8 +38,7 @@ Go the project directory and start the server.
 
 ```sh
 cd my-app
-npm run compile
-npm run start
+npm run dev:app
 ```
 
 Open you browser on `http://localhost:3000` and find our `Hello world` welcoming message!
@@ -57,14 +56,14 @@ Press enter to choose the `REST` option.
 
 Open `horse-controller.service.ts` and implement the `getAll` method:
 
-```ts
+```typescript
 public async getAll(params: any): Promise<any> {
   return ['Horse 1', 'Horse 2', 'Horse 3'];
 }
 ```
 
 Open `app.module.ts` and replace the content by:
-```ts
+```typescript
 import { FoalModule, rest } from '@foal/core';
 
 import { HorseController } from './horse-controller.service';

--- a/docs/advanced/contexts.md
+++ b/docs/advanced/contexts.md
@@ -2,7 +2,7 @@
 
 Here's the definition of the `Context` interface used in hooks:
 
-```ts
+```typescript
 {
   session: any;
   params: ObjectType;

--- a/docs/basics/controllers.md
+++ b/docs/basics/controllers.md
@@ -9,7 +9,7 @@ Let's a take an example on how to set up a REST API endpoint. To do so, we'll ne
 - and the `rest` *controller binder* which will bind the controller to the request handler through a module.
 
 First, we need to create a service that implements the interface:
-```ts
+```typescript
 @Service()
 class User implements RestController {
   constructor () {}
@@ -24,7 +24,7 @@ class User implements RestController {
 There are other methods such as `update`, `delete`, `modify`, `get` or `getAll`. We choose to only implement the `create` method here which matches the `POST` requests.
 
 Now let's wire it to the request handler at the endpoint `/users`:
-```ts
+```typescript
 import { rest } from '@foal/core';
 
 const AppModule: FoalModule = {
@@ -36,7 +36,7 @@ const AppModule: FoalModule = {
 That's it!
 
 The final code looks like this:
-```ts
+```typescript
 // RestController
 import * as bodyParser from 'body-parser';
 import * as express from 'express';

--- a/docs/basics/hooks.md
+++ b/docs/basics/hooks.md
@@ -48,7 +48,7 @@ class MyController {}
 
 You can either bind your hook to a controller method, its class or a module. Attaching a hook to a class is equivalent to attaching it to all its methods. Providing a hook to a module is equivalent to attaching it to all its controllers.
 
-```ts
+```typescript
 import { Context, Service, preHook, RestController } from '@foal/core';
 
 function contextLogger(context: Context): Promise<any> {
@@ -70,7 +70,7 @@ class MyController extends RestController {
 
 You can combine several hooks into one thanks to `combinePreHooks` and `combinePostHooks`.
 
-```ts
+```typescript
 import { combinePreHooks, Service, RestController } from '@foal/core';
 
 function myCombinedPreHooks() {
@@ -93,14 +93,14 @@ export class Foobar implements RestController {
 To test a hook you can test its middleware. So prefer separate its declaration from the hook itself.
 
 DON'T DO:
-```ts
+```typescript
 function addHelloWorldToContext() {
   return preHook((ctx: Context) => ctx.helloWorld = 'Hello world');
 }
 ```
 
 DO:
-```ts
+```typescript
 function addHelloWorldToContextMiddleware(ctx: Context) {
   ctx.helloWorld = 'Hello world';
 }
@@ -114,7 +114,7 @@ function addHelloWorldToContext() {
 
 When testing controller methods, hooks are skipped. So with the previous example you have:
 
-```ts
+```typescript
 import { expect } from 'chai';
 
 async function test() {

--- a/docs/basics/modules.md
+++ b/docs/basics/modules.md
@@ -4,7 +4,7 @@ Every app starts with a module. A module instantiates services and binds control
 
 ## Example
 
-```ts
+```typescript
 import { Module, rest } from '@foal/core';
 // module and service imports ...
 

--- a/docs/basics/services.md
+++ b/docs/basics/services.md
@@ -4,7 +4,7 @@ Services are the core of FoalTS. They are used to perform many different tasks s
 
 Basically a service can be any class that serves a restricted and well-defined purpose. You just need to insert the `@Service()` decorator on its top. Once done the service must be provided to a module so that it can be instantiated as a singleton.
 
-```ts
+```typescript
 import { Foal, Service } from '@foal/core';
 
 @Service()
@@ -25,7 +25,7 @@ console.log(myServiceA.name);
 
 If you want to call a service from another one, you need to declare it in the constructor as follows.
 
-```ts
+```typescript
 import { Foal, Service } from '@foal/core';
 
 @Service()
@@ -57,7 +57,7 @@ As foal uses the inversion of control principle, a service is very easy to test.
 npm install --save-dev chai
 ```
 
-```ts
+```typescript
 import { Service } from '@foal/core';
 import { expect } from 'chai';
 

--- a/docs/cookbook/authentication.md
+++ b/docs/cookbook/authentication.md
@@ -17,7 +17,7 @@ In this example we'll be able to:
 
 `connection.service.ts`
 
-```ts
+```typescript
 import { Service } from '@foal/core';
 import { SequelizeConnectionService } from '@foal/sequelize';
 
@@ -33,7 +33,7 @@ export class ConnectionService extends SequelizeConnectionService {
 
 `user.ts`
 
-```ts
+```typescript
 export interface User {
   id: string;
   username: string;
@@ -46,7 +46,7 @@ export interface User {
 
 `user.service.ts`
 
-```ts
+```typescript
 import { restrictAccessToAdmin, restrictAccessToAuthenticated } from '@foal/authorization';
 import { Context, ObjectType, preHook, Service } from '@foal/core';
 import { Sequelize, SequelizeService } from '@foal/sequelize';

--- a/docs/packages/sequelize.md
+++ b/docs/packages/sequelize.md
@@ -2,11 +2,11 @@
 
 ## Prerequisities 
 
-```ts
+```typescript
 npm install --save express @foal/core @foal/express @foal/sequelize
 
 # And one of the following:
-$ npm install --save pg pg-hstore
+$ npm install --save pg@6 pg-hstore
 $ npm install --save mysql2
 $ npm install --save sqlite3
 $ npm install --save tedious // MSSQL
@@ -28,7 +28,7 @@ $ npm install --save tedious // MSSQL
 
 ## Setting up a connection
 
-```ts
+```typescript
 import { Service } from '@foal/core';
 import { SequelizeConnectionService } from '@foal/sequelize';
 
@@ -42,7 +42,7 @@ export class Connection extends SequelizeConnectionService {
 
 ## Get connected to a table
 
-```ts
+```typescript
 import { Service } from '@foal/core';
 import { Sequelize, SequelizeService } from '@foal/sequelize';
 
@@ -60,7 +60,7 @@ export class User extends SequelizeService {
 
 ## Serve your service as an API (optional)
 
-```ts
+```typescript
 import * as bodyParser from 'body-parser';
 import * as express from 'express';
 import { getCallback } from '@foal/express';
@@ -85,7 +85,7 @@ app.listen(3000, () => console.log('Listening...'));
 
 Let's say that we want to forbid to use the method `delete` when using the service as a controller.
 
-```ts
+```typescript
 import { Service, MethodNotAllowed, RestParams } from '@foal/core';
 import { Sequelize, SequelizeService } from '@foal/sequelize';
 
@@ -110,7 +110,7 @@ export class User extends SequelizeService {
 
 Let's say that we want to return all the users when updating one.
 
-```ts
+```typescript
 import { Service, MethodNotAllowed, RestParams } from '@foal/core';
 import { Sequelize, SequelizeService } from '@foal/sequelize';
 
@@ -135,7 +135,7 @@ export class User extends SequelizeService {
 
 If you have overrided some methods and want to test them, you can do it with a fake DB thanks to the injection of the connection.
 
-```ts
+```typescript
 import { Connection } from './connection.service';
 import { User } from './user.service';
 


### PR DESCRIPTION
Rename `ts` to `typescript` in doc block code to support [prism](http://prismjs.com/).