### PR TITLE
Upgrade to es2017 and node8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "7"
+  - "8"
 services:
   - postgresql
 env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ![Logo](./docs/logo_64.png) FoalTS
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/FoalTS/foal/blob/master/LICENSE)
+![node version](https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg)
 [![npm version](https://badge.fury.io/js/%40foal%2Fcore.svg)](https://badge.fury.io/js/%40foal%2Fcore)
 [![Build Status](https://travis-ci.org/FoalTS/foal.svg?branch=add-travis)](https://travis-ci.org/FoalTS/foal)
 

--- a/packages/authorization/README.md
+++ b/packages/authorization/README.md
@@ -1,6 +1,7 @@
 # FoalTS
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/FoalTS/foal/blob/master/LICENSE)
+![node version](https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg)
 [![npm version](https://badge.fury.io/js/%40foal%2Fauthorization.svg)](https://badge.fury.io/js/%40foal%2Fauthorization)
 [![Build Status](https://travis-ci.org/FoalTS/foal.svg?branch=add-travis)](https://travis-ci.org/FoalTS/foal)
 

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -10,6 +10,9 @@
     "build": "tsc",
     "prepublish": "tsc && gulp add-header"
   },
+  "engines": {
+    "node": ">=8"
+  },
   "keywords": [
     "backend",
     "node",

--- a/packages/authorization/tsconfig.json
+++ b/packages/authorization/tsconfig.json
@@ -3,14 +3,14 @@
     "outDir": "./dist/",
     "noImplicitAny": false,
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2017",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "baseUrl": ".",
     "declaration": true,
     "lib": [
-      "es6",
+      "es2017",
       "dom"
     ]
   },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,7 @@
 # FoalTS
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/FoalTS/foal/blob/master/LICENSE)
+![node version](https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg)
 [![npm version](https://badge.fury.io/js/%40foal%2Fcore.svg)](https://badge.fury.io/js/%40foal%2Fcore)
 [![Build Status](https://travis-ci.org/FoalTS/foal.svg?branch=add-travis)](https://travis-ci.org/FoalTS/foal)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,9 @@
     "build": "tsc",
     "prepublish": "tsc && gulp add-header"
   },
+  "engines": {
+    "node": ">=8"
+  },
   "keywords": [
     "backend",
     "node",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,14 +3,14 @@
     "outDir": "./dist/",
     "noImplicitAny": false,
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2017",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "baseUrl": ".",
     "declaration": true,
     "lib": [
-      "es6",
+      "es2017",
       "dom"
     ]
   },

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -1,6 +1,7 @@
 # FoalTS
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/FoalTS/foal/blob/master/LICENSE)
+![node version](https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg)
 [![npm version](https://badge.fury.io/js/%40foal%2Fexamples.svg)](https://badge.fury.io/js/%40foal%2Fexamples)
 [![Build Status](https://travis-ci.org/FoalTS/foal.svg?branch=add-travis)](https://travis-ci.org/FoalTS/foal)
 

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -12,6 +12,9 @@
     "build": "tsc",
     "prepublish": "tsc && gulp add-header"
   },
+  "engines": {
+    "node": ">=8"
+  },
   "contributors": [
     "Loïc Poullain <loic.poullain@centraliens.net>"
   ],

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -3,14 +3,14 @@
     "outDir": "./dist/",
     "noImplicitAny": false,
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2017",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "baseUrl": ".",
     "declaration": true,
     "lib": [
-      "es6",
+      "es2017",
       "dom"
     ]
   },

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -1,6 +1,7 @@
 # FoalTS
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/FoalTS/foal/blob/master/LICENSE)
+![node version](https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg)
 [![npm version](https://badge.fury.io/js/%40foal%2Fexpress.svg)](https://badge.fury.io/js/%40foal%2Fexpress)
 [![Build Status](https://travis-ci.org/FoalTS/foal.svg?branch=add-travis)](https://travis-ci.org/FoalTS/foal)
 

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -10,6 +10,9 @@
     "build": "tsc",
     "prepublish": "tsc && gulp add-header"
   },
+  "engines": {
+    "node": ">=8"
+  },
   "keywords": [
     "backend",
     "node",

--- a/packages/express/tsconfig.json
+++ b/packages/express/tsconfig.json
@@ -3,14 +3,14 @@
     "outDir": "./dist/",
     "noImplicitAny": false,
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2017",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "baseUrl": ".",
     "declaration": true,
     "lib": [
-      "es6",
+      "es2017",
       "dom"
     ]
   },

--- a/packages/sequelize/README.md
+++ b/packages/sequelize/README.md
@@ -1,6 +1,7 @@
 # FoalTS
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/FoalTS/foal/blob/master/LICENSE)
+![node version](https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg)
 [![npm version](https://badge.fury.io/js/%40foal%2Fsequelize.svg)](https://badge.fury.io/js/%40foal%2Fsequelize)
 [![Build Status](https://travis-ci.org/FoalTS/foal.svg?branch=add-travis)](https://travis-ci.org/FoalTS/foal)
 

--- a/packages/sequelize/package.json
+++ b/packages/sequelize/package.json
@@ -10,6 +10,9 @@
     "build": "tsc",
     "prepublish": "tsc && gulp add-header"
   },
+  "engines": {
+    "node": ">=8"
+  },
   "keywords": [
     "backend",
     "node",

--- a/packages/sequelize/tsconfig.json
+++ b/packages/sequelize/tsconfig.json
@@ -3,14 +3,14 @@
     "outDir": "./dist/",
     "noImplicitAny": false,
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2017",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "baseUrl": ".",
     "declaration": true,
     "lib": [
-      "es6",
+      "es2017",
       "dom"
     ]
   },


### PR DESCRIPTION
# Issue / what we want
- Reduce the size of the distributed code.
- Having async/await in native for better performance.
- [util.promisify](https://nodejs.org/api/util.html#util_util_promisify_original) was added in v8.0.0

# Notes
- On the [Node website](https://nodejs.org/en/) the recommended version to download is v8.9.3
- What are the supported versions of Node on Heroku, ibm cloud, aws, azure, open shift, the linux distributions and the docker images?

# Steps
- [x] Update all the `tsconfig.json`.
- [x] Specify in all the `package.json` the minimum required version of node.
- [x] Add new badge to all `README.md`.
- [x] Update travis environnement config file.
- [x] Have a PR in https://github.com/FoalTS/generator-foal to update the generated `package.json` to require node version > 8.

# Resources
- [Node.js ES Support (node.green)](http://node.green/)
- [Node.js Release Working Group](https://github.com/nodejs/Release)
- [Node.js supported versions on AWS](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.platforms.html#concepts.platforms.nodejs)