### PR TITLE
Add tsconfig-build.json

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "mocha --require ts-node/register \"./src/**/*.spec.ts\"",
     "dev:test": "mocha --require ts-node/register --watch --watch-extensions ts \"./src/**/*.spec.ts\"",
-    "build": "gulp clean && tsc && gulp add-header",
-    "prepublish": "gulp clean && tsc && gulp add-header"
+    "build": "gulp clean && tsc -p tsconfig-build.json && gulp add-header",
+    "prepublish": "gulp clean && tsc -p tsconfig-build.json && gulp add-header"
   },
   "engines": {
     "node": ">=8"

--- a/packages/common/tsconfig-build.json
+++ b/packages/common/tsconfig-build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "./src/**/*.spec.ts"
+  ]
+}

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -17,8 +17,5 @@
   "include": [
     "./index.ts",
     "./src/**/*.ts"
-  ],
-  "exclude": [
-    "./src/**/*.spec.ts"
   ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "mocha --require ts-node/register \"./src/**/*.spec.ts\"",
     "dev:test": "mocha --require ts-node/register --watch --watch-extensions ts \"./src/**/*.spec.ts\"",
-    "build": "gulp clean && tsc && gulp add-header",
-    "prepublish": "gulp clean && tsc && gulp add-header"
+    "build": "gulp clean && tsc -p tsconfig-build.json && gulp add-header",
+    "prepublish": "gulp clean && tsc -p tsconfig-build.json && gulp add-header"
   },
   "engines": {
     "node": ">=8"

--- a/packages/core/tsconfig-build.json
+++ b/packages/core/tsconfig-build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "./src/**/*.spec.ts"
+  ]
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,8 +17,5 @@
   "include": [
     "./index.ts",
     "./src/**/*.ts"
-  ],
-  "exclude": [
-    "./src/**/*.spec.ts"
   ]
 }

--- a/packages/ejs/package.json
+++ b/packages/ejs/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "mocha --require ts-node/register \"./src/**/*.spec.ts\"",
     "dev:test": "mocha --require ts-node/register --watch --watch-extensions ts \"./src/**/*.spec.ts\"",
-    "build": "gulp clean && tsc && gulp add-header",
-    "prepublish": "gulp clean && tsc && gulp add-header"
+    "build": "gulp clean && tsc && gulp -p tsconfig-build.json add-header",
+    "prepublish": "gulp clean && tsc && gulp -p tsconfig-build.json add-header"
   },
   "engines": {
     "node": ">=8"

--- a/packages/ejs/tsconfig-build.json
+++ b/packages/ejs/tsconfig-build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "./src/**/*.spec.ts"
+  ]
+}

--- a/packages/ejs/tsconfig.json
+++ b/packages/ejs/tsconfig.json
@@ -17,8 +17,5 @@
   "include": [
     "./index.ts",
     "./src/**/*.ts"
-  ],
-  "exclude": [
-    "./src/**/*.spec.ts"
   ]
 }

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -9,8 +9,8 @@
     "dev:test": "mocha --require ts-node/register --watch --watch-extensions ts \"./src/**/*.spec.ts\"",
     "start": "ts-node ./src/index.ts",
     "dev:app": "nodemon ./src/index.ts",
-    "build": "gulp clean && tsc && gulp add-header",
-    "prepublish": "gulp clean && tsc && gulp add-header"
+    "build": "gulp clean && tsc -p tsconfig-build.json && gulp add-header",
+    "prepublish": "gulp clean && tsc -p tsconfig-build.json && gulp add-header"
   },
   "engines": {
     "node": ">=8"

--- a/packages/examples/tsconfig-build.json
+++ b/packages/examples/tsconfig-build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "./src/**/*.spec.ts"
+  ]
+}

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -17,8 +17,5 @@
   "include": [
     "./index.ts",
     "./src/**/*.ts"
-  ],
-  "exclude": [
-    "./src/**/*.spec.ts"
   ]
 }

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "mocha --require ts-node/register \"./src/**/*.spec.ts\"",
     "dev:test": "mocha --require ts-node/register --watch --watch-extensions ts \"./src/**/*.spec.ts\"",
-    "build": "gulp clean && tsc && gulp add-header",
-    "prepublish": "gulp clean && tsc && gulp add-header"
+    "build": "gulp clean && tsc -p tsconfig-build.json && gulp add-header",
+    "prepublish": "gulp clean && tsc -p tsconfig-build.json && gulp add-header"
   },
   "engines": {
     "node": ">=8"

--- a/packages/express/tsconfig-build.json
+++ b/packages/express/tsconfig-build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "./src/**/*.spec.ts"
+  ]
+}

--- a/packages/express/tsconfig.json
+++ b/packages/express/tsconfig.json
@@ -17,8 +17,5 @@
   "include": [
     "./index.ts",
     "./src/**/*.ts"
-  ],
-  "exclude": [
-    "./src/**/*.spec.ts"
   ]
 }

--- a/packages/sequelize/package.json
+++ b/packages/sequelize/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "mocha --require ts-node/register \"./src/**/*.spec.ts\"",
     "dev:test": "mocha --require ts-node/register --watch --watch-extensions ts \"./src/**/*.spec.ts\"",
-    "build": "gulp clean && tsc && gulp add-header",
-    "prepublish": "gulp clean && tsc && gulp add-header"
+    "build": "gulp clean && tsc -p tsconfig-build.json && gulp add-header",
+    "prepublish": "gulp clean && tsc -p tsconfig-build.json && gulp add-header"
   },
   "engines": {
     "node": ">=8"

--- a/packages/sequelize/tsconfig-build.json
+++ b/packages/sequelize/tsconfig-build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "./src/**/*.spec.ts"
+  ]
+}

--- a/packages/sequelize/tsconfig.json
+++ b/packages/sequelize/tsconfig.json
@@ -17,8 +17,5 @@
   "include": [
     "./index.ts",
     "./src/**/*.ts"
-  ],
-  "exclude": [
-    "./src/**/*.spec.ts"
   ]
 }


### PR DESCRIPTION
Distributed files should not include the tests. However excluding the spec files in the `tsconfig` prevents the IDE from correctly highlighting the code. Creating a separate `tsconfig-build` file fixes that.