### PR TITLE
Add getPreMiddleware and getPostMiddleware

### DIFF
--- a/docs/basics/hooks.md
+++ b/docs/basics/hooks.md
@@ -17,29 +17,17 @@ import {
   preHook,
 } from '@foal/core';
 
-export function makeMyPreLoggerMiddleware(message: string): PreMiddleware {
-  return function myPreLoggerMiddleware(ctx: Context, services: ServiceManager): void {
-    console.log(message);
-  };
+export function myLoggerPreHook(message: string) {
+  return preHook((ctx: Context, services: ServiceManager) => console.log(message));
 }
 
-export function myPreLoggerPreHook(message: string) {
-  return preHook(makeMyPreLoggerMiddleware(message));
-}
-
-export function makeMyPostLoggerMiddleware(message: string): PostMiddleware {
-  return function myPostLoggerMiddleware(ctx: Context, services: ServiceManager): void {
-    console.log(message);
-  };
-}
-
-export function myPostLoggerPreHook(message: string) {
-  return postHook(makeMyPostLoggerMiddleware(message));
+export function myLoggerPostHook(message: string) {
+  return postHook((ctx: Context, services: ServiceManager) => console.log(message));
 }
 
 @Service()
-@myPreLoggerPreHook('hello world')
-@myPostLoggerPreHook('hello world (post)')
+@myLoggerPreHook('hello world')
+@myLoggerPostHook('hello world (post)')
 class MyController {}
 
 ```
@@ -92,25 +80,7 @@ export class Foobar implements PartialCRUDService {
 
 ## Testing a hook
 
-To test a hook you can test its middleware. So prefer separate its declaration from the hook itself.
-
-DON'T DO:
-```typescript
-function addHelloWorldToContext() {
-  return preHook((ctx: Context) => ctx.helloWorld = 'Hello world');
-}
-```
-
-DO:
-```typescript
-function addHelloWorldToContextMiddleware(ctx: Context) {
-  ctx.helloWorld = 'Hello world';
-}
-
-function addHelloWorldToContext() {
-  return preHook(addHelloWorldToContextMiddleware);
-}
-```
+To test a hook you can use the `getPreMiddleware` and `getPostMiddeware` utils from `@foal/core`;
 
 ## Testing a service with hooks
 

--- a/docs/packages/core.md
+++ b/docs/packages/core.md
@@ -16,6 +16,8 @@ Core package of the framework.
 
 ## `combineHooks`
 
+## `getPreMiddleware` and `getPostMiddleware`
+
 ## Errors
 
 ## `Foal`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 export * from './factories';
 export * from './interfaces';
-export { combineHooks } from './utils';
+export { combineHooks, getPostMiddleware, getPreMiddleware } from './utils';
 
 export * from './errors';
 export { Foal } from './foal';

--- a/packages/core/src/utils/get-post-middleware.spec.ts
+++ b/packages/core/src/utils/get-post-middleware.spec.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+
+import { postHook, preHook } from '../factories';
+import { Hook, PostMiddleware, PreMiddleware } from '../interfaces';
+import { getPostMiddleware } from './get-post-middleware';
+
+describe('getPostMiddleware', () => {
+
+  it('should return the post-middleware of the given post-hook.', () => {
+    const middleware: PostMiddleware = ctx => {};
+    const hook: Hook = postHook(middleware);
+
+    const actual = getPostMiddleware(hook);
+
+    expect(actual).to.equal(middleware);
+  });
+
+  it('should throw an Error if the given hook is not a post-hook.', () => {
+    const middleware: PreMiddleware = ctx => {};
+    const hook: Hook = preHook(middleware);
+
+    expect(() => getPostMiddleware(hook)).to.throw();
+  });
+
+});

--- a/packages/core/src/utils/get-post-middleware.ts
+++ b/packages/core/src/utils/get-post-middleware.ts
@@ -1,0 +1,16 @@
+import 'reflect-metadata';
+
+import { Hook, PostMiddleware } from '../interfaces';
+
+export function getPostMiddleware(postHook: Hook): PostMiddleware {
+  @postHook
+  class Service {}
+
+  const postMiddlewares = Reflect.getMetadata('post-middlewares', Service) as undefined|PostMiddleware[];
+
+  if (!postMiddlewares) {
+    throw new Error('getPostMiddleware should receive a post-hook.');
+  }
+
+  return postMiddlewares[0];
+}

--- a/packages/core/src/utils/get-pre-middleware.spec.ts
+++ b/packages/core/src/utils/get-pre-middleware.spec.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+
+import { postHook, preHook } from '../factories';
+import { Hook, PostMiddleware, PreMiddleware } from '../interfaces';
+import { getPreMiddleware } from './get-pre-middleware';
+
+describe('getPreMiddleware', () => {
+
+  it('should return the pre-middleware of the given pre-hook.', () => {
+    const middleware: PreMiddleware = ctx => {};
+    const hook: Hook = preHook(middleware);
+
+    const actual = getPreMiddleware(hook);
+
+    expect(actual).to.equal(middleware);
+  });
+
+  it('should throw an Error if the given hook is not a pre-hook.', () => {
+    const middleware: PostMiddleware = ctx => {};
+    const hook: Hook = postHook(middleware);
+
+    expect(() => getPreMiddleware(hook)).to.throw();
+  });
+
+});

--- a/packages/core/src/utils/get-pre-middleware.ts
+++ b/packages/core/src/utils/get-pre-middleware.ts
@@ -1,0 +1,16 @@
+import 'reflect-metadata';
+
+import { Hook, PreMiddleware } from '../interfaces';
+
+export function getPreMiddleware(preHook: Hook): PreMiddleware {
+  @preHook
+  class Service {}
+
+  const preMiddlewares = Reflect.getMetadata('pre-middlewares', Service) as undefined|PreMiddleware[];
+
+  if (!preMiddlewares) {
+    throw new Error('getPreMiddleware should receive a pre-hook.');
+  }
+
+  return preMiddlewares[0];
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,2 +1,4 @@
 export * from './combine-hooks';
 export * from './metadatas';
+export * from './get-pre-middleware';
+export * from './get-post-middleware';


### PR DESCRIPTION
# Issue

Testing a hook is not really an easy task. For now, we can only test its middleware and so we have to use a complex code pattern to have a testable hook.

## Example

`code`
```typescript
import {
  Context,
  preHook,
  PreMiddleware
} from '@foal/core';

export function makeAddMsgToStateMiddleware(message: string): PreMiddleware {
  return function addMsgToStateMiddleware(ctx: Context): void {
    ctx.state.message = message;
  };
}

export function addMsgToState(message: string) {
  return preHook(makeAddMsgToStateMiddleware(message));
}

```

`test`
```typescript
const middleware = makeAddMsgToStateMiddleware('foo');
const ctx = {} as Context;
const ctx.state = {};
middleware(ctx);

expect(ctx.state.message).to.equal('foo');
```
# Solution

Create `getPreMiddleware` and `getPostMiddleware` which let us retrieve the middleware of a given hook for testing.

Writing a testable hook is easier this way.

## Example

`code`
```typescript
export function addMsgToState(message: string) {
  return preHook(ctx => ctx.state.message = message);
}
```

`test`
```typescript
const middleware = getPreMiddleware(addMsgToState('foo'));
const ctx = {} as Context;
const ctx.state = {};
middleware(ctx);

expect(ctx.state.message).to.equal('foo');
```