### PR TITLE
Rename middlewares

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -12,6 +12,7 @@
 ### Advanced
 
 * [Contexts](./advanced/contexts.md)
+* [Controller factories](./advanced/controller-factories.md)
 
 ### Packages
 

--- a/docs/advanced/controller-factories.md
+++ b/docs/advanced/controller-factories.md
@@ -1,8 +1,8 @@
 # Controller factories
 
-Controller factories let you create a controller from service. Some already exist such as `rest` or `view` in the `@foal/common` package. But you can also create your own.
+Controller factories let you create a controller from a given service. Some already exist such as `rest` or `view` in the `@foal/common` package. But you can also create your own.
 
-First define the interface of the `Service`s that you will use. For example:
+First define the interface of the `Service`s you will use. For example:
 
 ```typescript
 interface MyService {
@@ -37,5 +37,5 @@ export class MyControllerFactory extends ControllerFactory<MyService> {
   }
 }
 
-export const view = new MyControllerFactory();
+export const myControllerFactory = new MyControllerFactory();
 ```

--- a/docs/advanced/controller-factories.md
+++ b/docs/advanced/controller-factories.md
@@ -1,0 +1,41 @@
+# Controller factories
+
+Controller factories let you create a controller from service. Some already exist such as `rest` or `view` in the `@foal/common` package. But you can also create your own.
+
+First define the interface of the `Service`s that you will use. For example:
+
+```typescript
+interface MyService {
+  giveMeANumber(start: number, end: number): number
+}
+```
+
+Then create your controller factory from the `ControllerFactory` abstract class.
+
+```typescript
+import {
+  Context,
+  ControllerFactory,
+  Route
+} from '@foal/core';
+
+import { MyService } from '../services';
+
+export class MyControllerFactory extends ControllerFactory<MyService> {
+  protected getRoutes(service: MyService): Route[] {
+    return [
+      {
+        httpMethod: 'GET',
+        middleware: (context: Context) => {
+          return service.giveMeANumber(5, 10)
+        },
+        path: '/',
+        serviceMethodName: 'giveMeANumber',
+        successStatus: 200,
+      }
+    ];
+  }
+}
+
+export const view = new MyControllerFactory();
+```

--- a/packages/common/src/controller-factories/rest.controller-factory.ts
+++ b/packages/common/src/controller-factories/rest.controller-factory.ts
@@ -8,15 +8,15 @@ import {
 import { PartialCRUDService } from '../services';
 
 export class RestControllerFactory extends ControllerFactory<PartialCRUDService> {
-  protected getRoutes(controller: PartialCRUDService): Route[] {
+  protected getRoutes(service: PartialCRUDService): Route[] {
     return [
       {
         httpMethod: 'GET',
         middleware: (ctx: Context) => {
-          if (!controller.getAll) {
+          if (!service.getAll) {
             throw new NotImplementedError();
           }
-          return controller.getAll(ctx.query);
+          return service.getAll(ctx.query);
         },
         path: '/',
         serviceMethodName: 'getAll',
@@ -25,10 +25,10 @@ export class RestControllerFactory extends ControllerFactory<PartialCRUDService>
       {
         httpMethod: 'POST',
         middleware: (ctx: Context) => {
-          if (!controller.create) {
+          if (!service.create) {
             throw new NotImplementedError();
           }
-          return controller.create(ctx.body, ctx.query);
+          return service.create(ctx.body, ctx.query);
         },
         path: '/',
         serviceMethodName: 'create',
@@ -37,10 +37,10 @@ export class RestControllerFactory extends ControllerFactory<PartialCRUDService>
       {
         httpMethod: 'DELETE',
         middleware: (ctx: Context) => {
-          if (!controller.delete) {
+          if (!service.delete) {
             throw new NotImplementedError();
           }
-          return controller.delete(ctx.params.id, ctx.query);
+          return service.delete(ctx.params.id, ctx.query);
         },
         path: '/:id',
         serviceMethodName: 'delete',
@@ -49,10 +49,10 @@ export class RestControllerFactory extends ControllerFactory<PartialCRUDService>
       {
         httpMethod: 'GET',
         middleware: (ctx: Context) => {
-          if (!controller.get) {
+          if (!service.get) {
             throw new NotImplementedError();
           }
-          return controller.get(ctx.params.id, ctx.query);
+          return service.get(ctx.params.id, ctx.query);
         },
         path: '/:id',
         serviceMethodName: 'get',
@@ -61,10 +61,10 @@ export class RestControllerFactory extends ControllerFactory<PartialCRUDService>
       {
         httpMethod: 'PATCH',
         middleware: (ctx: Context) => {
-          if (!controller.modify) {
+          if (!service.modify) {
             throw new NotImplementedError();
           }
-          return controller.modify(ctx.params.id, ctx.body, ctx.query);
+          return service.modify(ctx.params.id, ctx.body, ctx.query);
         },
         path: '/:id',
         serviceMethodName: 'patch',
@@ -73,10 +73,10 @@ export class RestControllerFactory extends ControllerFactory<PartialCRUDService>
       {
         httpMethod: 'PUT',
         middleware: (ctx: Context) => {
-          if (!controller.replace) {
+          if (!service.replace) {
             throw new NotImplementedError();
           }
-          return controller.replace(ctx.params.id, ctx.body, ctx.query);
+          return service.replace(ctx.params.id, ctx.body, ctx.query);
         },
         path: '/:id',
         serviceMethodName: 'update',

--- a/packages/common/src/controller-factories/rest.controller-factory.ts
+++ b/packages/common/src/controller-factories/rest.controller-factory.ts
@@ -12,73 +12,73 @@ export class RestControllerFactory extends ControllerFactory<PartialCRUDService>
     return [
       {
         httpMethod: 'GET',
-        path: '/',
-        serviceMethodBinder: (ctx: Context) => {
+        middleware: (ctx: Context) => {
           if (!controller.getAll) {
             throw new NotImplementedError();
           }
           return controller.getAll(ctx.query);
         },
+        path: '/',
         serviceMethodName: 'getAll',
         successStatus: 200,
       },
       {
         httpMethod: 'POST',
-        path: '/',
-        serviceMethodBinder: (ctx: Context) => {
+        middleware: (ctx: Context) => {
           if (!controller.create) {
             throw new NotImplementedError();
           }
           return controller.create(ctx.body, ctx.query);
         },
+        path: '/',
         serviceMethodName: 'create',
         successStatus: 201,
       },
       {
         httpMethod: 'DELETE',
-        path: '/:id',
-        serviceMethodBinder: (ctx: Context) => {
+        middleware: (ctx: Context) => {
           if (!controller.delete) {
             throw new NotImplementedError();
           }
           return controller.delete(ctx.params.id, ctx.query);
         },
+        path: '/:id',
         serviceMethodName: 'delete',
         successStatus: 200,
       },
       {
         httpMethod: 'GET',
-        path: '/:id',
-        serviceMethodBinder: (ctx: Context) => {
+        middleware: (ctx: Context) => {
           if (!controller.get) {
             throw new NotImplementedError();
           }
           return controller.get(ctx.params.id, ctx.query);
         },
+        path: '/:id',
         serviceMethodName: 'get',
         successStatus: 200,
       },
       {
         httpMethod: 'PATCH',
-        path: '/:id',
-        serviceMethodBinder: (ctx: Context) => {
+        middleware: (ctx: Context) => {
           if (!controller.modify) {
             throw new NotImplementedError();
           }
           return controller.modify(ctx.params.id, ctx.body, ctx.query);
         },
+        path: '/:id',
         serviceMethodName: 'patch',
         successStatus: 200,
       },
       {
         httpMethod: 'PUT',
-        path: '/:id',
-        serviceMethodBinder: (ctx: Context) => {
+        middleware: (ctx: Context) => {
           if (!controller.replace) {
             throw new NotImplementedError();
           }
           return controller.replace(ctx.params.id, ctx.body, ctx.query);
         },
+        path: '/:id',
         serviceMethodName: 'update',
         successStatus: 200,
       },

--- a/packages/common/src/controller-factories/view.controller-factory.spec.ts
+++ b/packages/common/src/controller-factories/view.controller-factory.spec.ts
@@ -36,7 +36,7 @@ describe('ViewControllerFactory', () => {
       const actualItem = actual[0];
       const ctx = createEmptyContext();
       ctx.state.name = 'foo';
-      expect(actualItem.serviceMethodBinder(ctx)).to.equal('foo');
+      expect(actualItem.middleware(ctx)).to.equal('foo');
       expect(actualItem.serviceMethodName).to.equal('render');
       expect(actualItem.httpMethod).to.equal('GET');
       expect(actualItem.path).to.equal('/');

--- a/packages/common/src/controller-factories/view.controller-factory.ts
+++ b/packages/common/src/controller-factories/view.controller-factory.ts
@@ -11,8 +11,8 @@ export class ViewControllerFactory extends ControllerFactory<ViewService> {
     return [
       {
         httpMethod: 'GET',
+        middleware: (context: Context) => controller.render(context.state),
         path: '/',
-        serviceMethodBinder: (context: Context) => controller.render(context.state),
         serviceMethodName: 'render',
         successStatus: 200,
       }

--- a/packages/common/src/controller-factories/view.controller-factory.ts
+++ b/packages/common/src/controller-factories/view.controller-factory.ts
@@ -7,11 +7,11 @@ import {
 import { ViewService } from '../services';
 
 export class ViewControllerFactory extends ControllerFactory<ViewService> {
-  protected getRoutes(controller: ViewService): Route[] {
+  protected getRoutes(service: ViewService): Route[] {
     return [
       {
         httpMethod: 'GET',
-        middleware: (context: Context) => controller.render(context.state),
+        middleware: (context: Context) => service.render(context.state),
         path: '/',
         serviceMethodName: 'render',
         successStatus: 200,

--- a/packages/common/src/pre-hooks/restrict-access-to-admin.pre-hook.spec.ts
+++ b/packages/common/src/pre-hooks/restrict-access-to-admin.pre-hook.spec.ts
@@ -2,7 +2,7 @@ import {
   Context,
   ForbiddenError,
   getPreMiddleware,
-  PreMiddleware,
+  Middleware,
   ServiceManager,
   UnauthorizedError
 } from '@foal/core';
@@ -12,7 +12,7 @@ import { restrictAccessToAdmin } from './restrict-access-to-admin.pre-hook';
 
 describe('restrictAccessToAdmin', () => {
 
-  let middleware: PreMiddleware;
+  let middleware: Middleware;
   let emptyContext: Context;
 
   before(() => {

--- a/packages/common/src/pre-hooks/restrict-access-to-authenticated.pre-hook.spec.ts
+++ b/packages/common/src/pre-hooks/restrict-access-to-authenticated.pre-hook.spec.ts
@@ -1,7 +1,7 @@
 import {
   Context,
   getPreMiddleware,
-  PreMiddleware,
+  Middleware,
   ServiceManager,
   UnauthorizedError
 } from '@foal/core';
@@ -11,7 +11,7 @@ import { restrictAccessToAuthenticated } from './restrict-access-to-authenticate
 
 describe('restrictAccessToAuthenticated', () => {
 
-  let middleware: PreMiddleware;
+  let middleware: Middleware;
   let emptyContext: Context;
 
   before(() => {

--- a/packages/core/src/factories/controller-factory.spec.ts
+++ b/packages/core/src/factories/controller-factory.spec.ts
@@ -50,11 +50,11 @@ describe('ControllerFactory<T>', () => {
   }
 
   class ConcreteControllerFactory extends ControllerFactory<ServiceInterface> {
-    protected getRoutes(controller: ServiceInterface): Route[] {
+    protected getRoutes(service: ServiceInterface): Route[] {
       return [
         {
           httpMethod: 'GET',
-          middleware: async (context: Context) => controller.foobar(),
+          middleware: async (context: Context) => service.foobar(),
           path: '/foobar',
           serviceMethodName: 'foobar',
           successStatus: 10000

--- a/packages/core/src/factories/controller-factory.spec.ts
+++ b/packages/core/src/factories/controller-factory.spec.ts
@@ -74,13 +74,13 @@ describe('ControllerFactory<T>', () => {
 
     describe('with good parameters', () => {
 
-      it('should return a LowLevelRoute array from the Route array of the getRoutes method.', async () => {
-        const func = controllerFactory.attachService('/my_path', ServiceClass);
-        const lowLevelRoutes = func(services);
+      it('should return a ReducedRoute array from the Route array of the getRoutes method.', async () => {
+        const controller = controllerFactory.attachService('/my_path', ServiceClass);
+        const routes = controller(services);
 
-        expect(lowLevelRoutes).to.be.an('array').and.to.have.lengthOf(1);
+        expect(routes).to.be.an('array').and.to.have.lengthOf(1);
 
-        const actual = lowLevelRoutes[0];
+        const actual = routes[0];
 
         expect(actual.httpMethod).to.equal('GET');
         expect(actual.paths).to.deep.equal(['/my_path', '/foobar']);

--- a/packages/core/src/factories/controller-factory.spec.ts
+++ b/packages/core/src/factories/controller-factory.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
 import { postHook, preHook } from '../factories';
-import { Context, PostMiddleware, PreMiddleware, Route } from '../interfaces';
+import { Context, Middleware, Route } from '../interfaces';
 import { Service, ServiceManager } from '../service-manager';
 import { createEmptyContext } from '../testing';
 import { ControllerFactory } from './controller-factory';
@@ -9,28 +9,28 @@ import { ControllerFactory } from './controller-factory';
 describe('ControllerFactory<T>', () => {
 
   interface ServiceInterface { foobar: () => Promise<any>; }
-  const classPreMiddleware1: PreMiddleware = (ctx: Context, services: ServiceManager) => {
+  const classPreMiddleware1: Middleware = (ctx: Context, services: ServiceManager) => {
     ctx.state.preClass1 = { services };
   };
-  const classPreMiddleware2: PreMiddleware = (ctx: Context, services: ServiceManager) => {
+  const classPreMiddleware2: Middleware = (ctx: Context, services: ServiceManager) => {
     ctx.state.preClass2 = { services };
   };
-  const methodPreMiddleware1: PreMiddleware = (ctx: Context, services: ServiceManager) => {
+  const methodPreMiddleware1: Middleware = (ctx: Context, services: ServiceManager) => {
     ctx.state.preMethod1 = { services };
   };
-  const methodPreMiddleware2: PreMiddleware = (ctx: Context, services: ServiceManager) => {
+  const methodPreMiddleware2: Middleware = (ctx: Context, services: ServiceManager) => {
     ctx.state.preMethod2 = { services };
   };
-  const classPostMiddleware1: PostMiddleware = (ctx: Context, services: ServiceManager) => {
+  const classPostMiddleware1: Middleware = (ctx: Context, services: ServiceManager) => {
     ctx.state.postClass1 = { services };
   };
-  const classPostMiddleware2: PostMiddleware = (ctx: Context, services: ServiceManager) => {
+  const classPostMiddleware2: Middleware = (ctx: Context, services: ServiceManager) => {
     ctx.state.postClass2 = { services };
   };
-  const methodPostMiddleware1: PostMiddleware = (ctx: Context, services: ServiceManager) => {
+  const methodPostMiddleware1: Middleware = (ctx: Context, services: ServiceManager) => {
     ctx.state.postMethod1 = { services };
   };
-  const methodPostMiddleware2: PostMiddleware = (ctx: Context, services: ServiceManager) => {
+  const methodPostMiddleware2: Middleware = (ctx: Context, services: ServiceManager) => {
     ctx.state.postMethod2 = { services };
   };
 

--- a/packages/core/src/factories/controller-factory.spec.ts
+++ b/packages/core/src/factories/controller-factory.spec.ts
@@ -54,8 +54,8 @@ describe('ControllerFactory<T>', () => {
       return [
         {
           httpMethod: 'GET',
+          middleware: async (context: Context) => controller.foobar(),
           path: '/foobar',
-          serviceMethodBinder: async (context: Context) => controller.foobar(),
           serviceMethodName: 'foobar',
           successStatus: 10000
         }

--- a/packages/core/src/factories/controller-factory.ts
+++ b/packages/core/src/factories/controller-factory.ts
@@ -2,8 +2,9 @@ import 'reflect-metadata';
 
 import {
   Context,
-  LowLevelRoute,
+  Controller,
   Middleware,
+  ReducedRoute,
   Route,
   Type
 } from '../interfaces';
@@ -13,8 +14,8 @@ export abstract class ControllerFactory<T> {
 
   constructor() {}
 
-  public attachService(path: string, ServiceClass: Type<T>): (services: ServiceManager) => LowLevelRoute[] {
-    return (services: ServiceManager): LowLevelRoute[] => {
+  public attachService(path: string, ServiceClass: Type<T>): Controller {
+    return (services: ServiceManager): ReducedRoute[] => {
       const service = services.get(ServiceClass);
 
       return this.getRoutes(service).map(route => {

--- a/packages/core/src/factories/controller-factory.ts
+++ b/packages/core/src/factories/controller-factory.ts
@@ -3,8 +3,7 @@ import 'reflect-metadata';
 import {
   Context,
   LowLevelRoute,
-  PostMiddleware,
-  PreMiddleware,
+  Middleware,
   Route,
   Type
 } from '../interfaces';
@@ -36,16 +35,16 @@ export abstract class ControllerFactory<T> {
 
   protected abstract getRoutes(service: T): Route[];
 
-  private getPreMiddlewares(ServiceClass: Type<T>, methodName: string): PreMiddleware[] {
-    const classPreMiddlewares: PreMiddleware[] = Reflect.getMetadata('pre-middlewares', ServiceClass) || [];
-    const methodPreMiddlewares: PreMiddleware[] = Reflect.getMetadata('pre-middlewares', ServiceClass.prototype,
+  private getPreMiddlewares(ServiceClass: Type<T>, methodName: string): Middleware[] {
+    const classPreMiddlewares: Middleware[] = Reflect.getMetadata('pre-middlewares', ServiceClass) || [];
+    const methodPreMiddlewares: Middleware[] = Reflect.getMetadata('pre-middlewares', ServiceClass.prototype,
       methodName) || [];
     return classPreMiddlewares.concat(methodPreMiddlewares);
   }
 
-  private getPostMiddlewares(ServiceClass: Type<T>, methodName: string): PostMiddleware[] {
-    const classPostMiddlewares: PostMiddleware[] = Reflect.getMetadata('post-middlewares', ServiceClass) || [];
-    const methodPostMiddlewares: PostMiddleware[] = Reflect.getMetadata('post-middlewares', ServiceClass.prototype,
+  private getPostMiddlewares(ServiceClass: Type<T>, methodName: string): Middleware[] {
+    const classPostMiddlewares: Middleware[] = Reflect.getMetadata('post-middlewares', ServiceClass) || [];
+    const methodPostMiddlewares: Middleware[] = Reflect.getMetadata('post-middlewares', ServiceClass.prototype,
       methodName) || [];
     return methodPostMiddlewares.concat(classPostMiddlewares);
   }

--- a/packages/core/src/factories/controller-factory.ts
+++ b/packages/core/src/factories/controller-factory.ts
@@ -20,7 +20,7 @@ export abstract class ControllerFactory<T> {
       return this.getRoutes(service).map(route => {
         const middlewares = [
           ...this.getPreMiddlewares(ServiceClass, route.serviceMethodName),
-          async (ctx: Context) => ctx.result = await route.serviceMethodBinder(ctx),
+          async (ctx: Context) => ctx.result = await route.middleware(ctx),
           ...this.getPostMiddlewares(ServiceClass, route.serviceMethodName)
         ].map(middleware => ((ctx: Context) => middleware(ctx, services)));
         return {

--- a/packages/core/src/factories/post-hook.spec.ts
+++ b/packages/core/src/factories/post-hook.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import 'reflect-metadata';
 
-import { PostMiddleware } from '../interfaces';
+import { Middleware } from '../interfaces';
 import { postHook } from './post-hook';
 import { preHook } from './pre-hook';
 
@@ -9,8 +9,8 @@ describe('postHook', () => {
 
   describe('called with a postMiddleware should return a hook (decorator) that', () => {
 
-    let postMiddleware: PostMiddleware;
-    let postMiddleware2: PostMiddleware;
+    let postMiddleware: Middleware;
+    let postMiddleware2: Middleware;
 
     beforeEach(() => {
       postMiddleware = (ctx, services) => { ctx.state.k = 1; };

--- a/packages/core/src/factories/post-hook.ts
+++ b/packages/core/src/factories/post-hook.ts
@@ -1,7 +1,7 @@
-import { Hook, PostMiddleware } from '../interfaces';
+import { Hook, Middleware } from '../interfaces';
 import { defineMetadata, getMetadata } from '../utils';
 
-export function postHook(postMiddleware: PostMiddleware): Hook {
+export function postHook(postMiddleware: Middleware): Hook {
   return (target: any, methodName?: string) => {
     const preMiddlewares = getMetadata('pre-middlewares', target, methodName) || [];
     if (preMiddlewares.length > 0) {

--- a/packages/core/src/factories/pre-hook.spec.ts
+++ b/packages/core/src/factories/pre-hook.spec.ts
@@ -1,15 +1,15 @@
 import { expect } from 'chai';
 import 'reflect-metadata';
 
-import { PreMiddleware } from '../interfaces';
+import { Middleware } from '../interfaces';
 import { preHook } from './pre-hook';
 
 describe('preHook', () => {
 
   describe('called with a preMiddleware should return a hook (decorator) that', () => {
 
-    let preMiddleware: PreMiddleware;
-    let preMiddleware2: PreMiddleware;
+    let preMiddleware: Middleware;
+    let preMiddleware2: Middleware;
 
     beforeEach(() => {
       preMiddleware = (ctx, services) => { ctx.state.k = 1; };

--- a/packages/core/src/factories/pre-hook.ts
+++ b/packages/core/src/factories/pre-hook.ts
@@ -1,7 +1,7 @@
-import { Hook, PreMiddleware } from '../interfaces';
+import { Hook, Middleware } from '../interfaces';
 import { defineMetadata, getMetadata } from '../utils';
 
-export function preHook(preMiddleware: PreMiddleware): Hook {
+export function preHook(preMiddleware: Middleware): Hook {
   return (target: any, methodName?: string) => {
     const preMiddlewares = getMetadata('pre-middlewares', target, methodName) || [];
     preMiddlewares.unshift(preMiddleware);

--- a/packages/core/src/foal.spec.ts
+++ b/packages/core/src/foal.spec.ts
@@ -42,15 +42,15 @@ describe('Foal', () => {
       expect(foal2.services.get(Foobar)).not.to.equal(foal1.services.get(Foobar));
     });
 
-    xit('should create LowLevelRoute[] from the controller routes.', () => {
+    xit('should create ReducedRoute[] from the controller routes.', () => {
 
     });
 
-    xit('should create LowLevelRoute[] from the module imported.', () => {
+    xit('should create ReducedRoute[] from the module imported.', () => {
 
     });
 
-    xit('should add the module hooks to the LowLevelRoute[].', () => {
+    xit('should add the module hooks to the ReducedRoute[].', () => {
       // This test relies on the two previous tests. It's not great.
 
     });

--- a/packages/core/src/foal.spec.ts
+++ b/packages/core/src/foal.spec.ts
@@ -42,15 +42,15 @@ describe('Foal', () => {
       expect(foal2.services.get(Foobar)).not.to.equal(foal1.services.get(Foobar));
     });
 
-    xit('should create lowLevelRoutes from the controller routes.', () => {
+    xit('should create LowLevelRoute[] from the controller routes.', () => {
 
     });
 
-    xit('should create lowLevelRoutes from the module imported.', () => {
+    xit('should create LowLevelRoute[] from the module imported.', () => {
 
     });
 
-    xit('should add the module hooks to the lowLevelRoutes.', () => {
+    xit('should add the module hooks to the LowLevelRoute[].', () => {
       // This test relies on the two previous tests. It's not great.
 
     });

--- a/packages/core/src/foal.ts
+++ b/packages/core/src/foal.ts
@@ -3,14 +3,14 @@ import 'reflect-metadata';
 import {
   FoalModule,
   Hook,
-  LowLevelRoute,
   Middleware,
+  ReducedRoute,
 } from './interfaces';
 import { ServiceManager } from './service-manager';
 
 export class Foal {
   public readonly services: ServiceManager;
-  public readonly lowLevelRoutes: LowLevelRoute[] = [];
+  public readonly routes: ReducedRoute[] = [];
 
   constructor(foalModule: FoalModule, parentModule?: Foal) {
     const controllers = foalModule.controllers || [];
@@ -30,12 +30,12 @@ export class Foal {
     const { modulePreMiddlewares, modulePostMiddlewares } = this.getMiddlewares(moduleHooks);
 
     for (const controller of controllers) {
-      for (const lowLevelRoute of controller(this.services)) {
-        this.lowLevelRoutes.push({
-          ...lowLevelRoute,
+      for (const route of controller(this.services)) {
+        this.routes.push({
+          ...route,
           middlewares: [
             ...modulePreMiddlewares.map(e => (ctx => e(ctx, this.services))),
-            ...lowLevelRoute.middlewares,
+            ...route.middlewares,
             ...modulePostMiddlewares.map(e => (ctx => e(ctx, this.services))),
           ],
         });
@@ -45,15 +45,15 @@ export class Foal {
     for (const mod of modules) {
       const importedModule = new Foal(mod.module, this);
       const path = mod.path || '';
-      for (const lowLevelRoute of importedModule.lowLevelRoutes) {
-        this.lowLevelRoutes.push({
-          ...lowLevelRoute,
+      for (const route of importedModule.routes) {
+        this.routes.push({
+          ...route,
           middlewares: [
             ...modulePreMiddlewares.map(e => (ctx => e(ctx, this.services))),
-            ...lowLevelRoute.middlewares,
+            ...route.middlewares,
             ...modulePostMiddlewares.map(e => (ctx => e(ctx, this.services))),
           ],
-          paths: [path, ...lowLevelRoute.paths],
+          paths: [path, ...route.paths],
         });
       }
     }

--- a/packages/core/src/foal.ts
+++ b/packages/core/src/foal.ts
@@ -4,8 +4,7 @@ import {
   FoalModule,
   Hook,
   LowLevelRoute,
-  PostMiddleware,
-  PreMiddleware,
+  Middleware,
 } from './interfaces';
 import { ServiceManager } from './service-manager';
 
@@ -60,8 +59,8 @@ export class Foal {
     }
   }
 
-  private getMiddlewares(hooks: Hook[]): { modulePreMiddlewares: PreMiddleware[],
-      modulePostMiddlewares: PostMiddleware[] } {
+  private getMiddlewares(hooks: Hook[]): { modulePreMiddlewares: Middleware[],
+      modulePostMiddlewares: Middleware[] } {
     class FakeModule {}
     // Reverse the array to apply decorators in the proper order.
     hooks.reverse().forEach(hook => hook(FakeModule));

--- a/packages/core/src/interfaces/controller-and-routes.ts
+++ b/packages/core/src/interfaces/controller-and-routes.ts
@@ -1,13 +1,13 @@
 import { ServiceManager } from '../service-manager';
 import { Context } from './contexts';
-import { Middleware } from './middlewares';
+import { ReducedMiddleware } from './middlewares';
 
 export type HttpMethod = 'POST' | 'GET' | 'PUT' | 'PATCH' | 'DELETE';
 
 export interface LowLevelRoute {
   httpMethod: HttpMethod;
   paths: string[];
-  middlewares: Middleware[];
+  middlewares: ReducedMiddleware[];
   successStatus: number;
 }
 

--- a/packages/core/src/interfaces/controller-and-routes.ts
+++ b/packages/core/src/interfaces/controller-and-routes.ts
@@ -1,10 +1,9 @@
 import { ServiceManager } from '../service-manager';
-import { Context } from './contexts';
 import { ReducedMiddleware } from './middlewares';
 
 export type HttpMethod = 'POST' | 'GET' | 'PUT' | 'PATCH' | 'DELETE';
 
-export interface LowLevelRoute {
+export interface ReducedRoute {
   httpMethod: HttpMethod;
   paths: string[];
   middlewares: ReducedMiddleware[];
@@ -19,4 +18,4 @@ export interface Route {
   successStatus: number;
 }
 
-export type Controller = (services: ServiceManager) => LowLevelRoute[];
+export type Controller = (services: ServiceManager) => ReducedRoute[];

--- a/packages/core/src/interfaces/controller-and-routes.ts
+++ b/packages/core/src/interfaces/controller-and-routes.ts
@@ -12,7 +12,7 @@ export interface LowLevelRoute {
 }
 
 export interface Route {
-  serviceMethodBinder: (context: Context) => Promise<any>|any;
+  middleware: ReducedMiddleware;
   serviceMethodName: string;
   httpMethod: HttpMethod;
   path: string;

--- a/packages/core/src/interfaces/middlewares.ts
+++ b/packages/core/src/interfaces/middlewares.ts
@@ -1,6 +1,5 @@
 import { ServiceManager } from '../service-manager';
 import { Context } from './contexts';
 
-export type Middleware = (ctx: Context) => Promise<any>|any;
-export type PreMiddleware = (ctx: Context, services: ServiceManager) => Promise<any>|any;
-export type PostMiddleware = (ctx: Context, services: ServiceManager) => Promise<any>|any;
+export type ReducedMiddleware = (ctx: Context) => Promise<any>|any;
+export type Middleware = (ctx: Context, services: ServiceManager) => Promise<any>|any;

--- a/packages/core/src/testing/get-post-middleware.spec.ts
+++ b/packages/core/src/testing/get-post-middleware.spec.ts
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 
 import { postHook, preHook } from '../factories';
-import { Hook, PostMiddleware, PreMiddleware } from '../interfaces';
+import { Hook, Middleware } from '../interfaces';
 import { getPostMiddleware } from './get-post-middleware';
 
 describe('getPostMiddleware', () => {
 
   it('should return the post-middleware of the given post-hook.', () => {
-    const middleware: PostMiddleware = ctx => {};
+    const middleware: Middleware = ctx => {};
     const hook: Hook = postHook(middleware);
 
     const actual = getPostMiddleware(hook);
@@ -16,7 +16,7 @@ describe('getPostMiddleware', () => {
   });
 
   it('should throw an Error if the given hook is not a post-hook.', () => {
-    const middleware: PreMiddleware = ctx => {};
+    const middleware: Middleware = ctx => {};
     const hook: Hook = preHook(middleware);
 
     expect(() => getPostMiddleware(hook)).to.throw();

--- a/packages/core/src/testing/get-post-middleware.ts
+++ b/packages/core/src/testing/get-post-middleware.ts
@@ -1,12 +1,12 @@
 import 'reflect-metadata';
 
-import { Hook, PostMiddleware } from '../interfaces';
+import { Hook, Middleware } from '../interfaces';
 
-export function getPostMiddleware(postHook: Hook): PostMiddleware {
+export function getPostMiddleware(postHook: Hook): Middleware {
   @postHook
   class Service {}
 
-  const postMiddlewares = Reflect.getMetadata('post-middlewares', Service) as undefined|PostMiddleware[];
+  const postMiddlewares = Reflect.getMetadata('post-middlewares', Service) as undefined|Middleware[];
 
   if (!postMiddlewares) {
     throw new Error('getPostMiddleware should receive a post-hook.');

--- a/packages/core/src/testing/get-pre-middleware.spec.ts
+++ b/packages/core/src/testing/get-pre-middleware.spec.ts
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 
 import { postHook, preHook } from '../factories';
-import { Hook, PostMiddleware, PreMiddleware } from '../interfaces';
+import { Hook, Middleware } from '../interfaces';
 import { getPreMiddleware } from './get-pre-middleware';
 
 describe('getPreMiddleware', () => {
 
   it('should return the pre-middleware of the given pre-hook.', () => {
-    const middleware: PreMiddleware = ctx => {};
+    const middleware: Middleware = ctx => {};
     const hook: Hook = preHook(middleware);
 
     const actual = getPreMiddleware(hook);
@@ -16,7 +16,7 @@ describe('getPreMiddleware', () => {
   });
 
   it('should throw an Error if the given hook is not a pre-hook.', () => {
-    const middleware: PostMiddleware = ctx => {};
+    const middleware: Middleware = ctx => {};
     const hook: Hook = postHook(middleware);
 
     expect(() => getPreMiddleware(hook)).to.throw();

--- a/packages/core/src/testing/get-pre-middleware.ts
+++ b/packages/core/src/testing/get-pre-middleware.ts
@@ -1,12 +1,12 @@
 import 'reflect-metadata';
 
-import { Hook, PreMiddleware } from '../interfaces';
+import { Hook, Middleware } from '../interfaces';
 
-export function getPreMiddleware(preHook: Hook): PreMiddleware {
+export function getPreMiddleware(preHook: Hook): Middleware {
   @preHook
   class Service {}
 
-  const preMiddlewares = Reflect.getMetadata('pre-middlewares', Service) as undefined|PreMiddleware[];
+  const preMiddlewares = Reflect.getMetadata('pre-middlewares', Service) as undefined|Middleware[];
 
   if (!preMiddlewares) {
     throw new Error('getPreMiddleware should receive a pre-hook.');

--- a/packages/express/src/get-callback.ts
+++ b/packages/express/src/get-callback.ts
@@ -3,11 +3,11 @@ import { Router } from 'express';
 
 import { getExpressMiddleware } from './get-express-middleware';
 
-// Test: should return 404 if no lowLevelRoute exists for the given method and path.
+// Test: should return 404 if no route exists for the given method and path.
 export function getCallback(foal: Foal) {
   const router = Router();
-  for (const lowLevelRoute of foal.lowLevelRoutes) {
-    router.use(getExpressMiddleware(lowLevelRoute));
+  for (const route of foal.routes) {
+    router.use(getExpressMiddleware(route));
   }
   return router;
 }

--- a/packages/express/src/get-express-middleware.spec.ts
+++ b/packages/express/src/get-express-middleware.spec.ts
@@ -3,7 +3,7 @@ import {
   HttpMethod,
   LowLevelRoute,
   MethodNotAllowedError,
-  Middleware
+  ReducedMiddleware
 } from '@foal/core';
 import * as bodyParser from 'body-parser';
 import { expect } from 'chai';
@@ -166,8 +166,8 @@ describe('getExpressMiddleware(lowLevelRoute: LowLevelRoute): ExpressMiddleware'
 
   describe('when it is called with { middlewares: [ ... ] }', () => {
 
-    let middleware1: Middleware;
-    let middleware2: Middleware;
+    let middleware1: ReducedMiddleware;
+    let middleware2: ReducedMiddleware;
 
     it('should return a middleware which inits properly the context.', () => {
       // This test depends on the test 'should return a middleware which responds on GET /foo/12/bar/13'.

--- a/packages/express/src/get-express-middleware.ts
+++ b/packages/express/src/get-express-middleware.ts
@@ -1,4 +1,4 @@
-import { Context, LowLevelRoute } from '@foal/core';
+import { Context, ReducedRoute } from '@foal/core';
 import { Router } from 'express';
 
 import { ExpressMiddleware } from './interfaces';
@@ -16,7 +16,7 @@ function makeContext(req): Context {
   };
 }
 
-export function getExpressMiddleware(route: LowLevelRoute): ExpressMiddleware {
+export function getExpressMiddleware(route: ReducedRoute): ExpressMiddleware {
   async function handler(req, res) {
     const ctx = makeContext(req);
     for (const middleware of route.middlewares) {


### PR DESCRIPTION
# Issue

- `serviceMethodBinder` name in `Route` is not very meaningful compared to `middleware`.
- Having two types `PreMiddleware` and `PostMiddleware` are confusing since they represent the same interface.

# Solution and steps

**Note**: Breaking changes are permitted here since this is an alpha version.

- [x] Rename `Middleware` to `ReducedMiddleware`.
- [x] Rename `PreMiddleware` and `PostMiddleware` to a same type `Middleware`.
- [x] Rename `serviceMethodBinder` to `middleware`.
- [x] Rename `LowLevelRoute` to `ReducedRoute` (consistency with `ReducedMiddleware`).

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.