### PR TITLE
Add HTML escaping in `@foal/common`

### DIFF
--- a/docs/packages/common.md
+++ b/docs/packages/common.md
@@ -74,3 +74,21 @@ Returns a 401 status if the user is not authenticated.
 ### `restrictAccessToAdmin()`
 
 Returns a 401 status if the user is not authenticated and a 403 if `ctx.user.isAdmin` is not truthy.
+
+## Utils
+
+### `escape(str: string): string`
+
+Escapes HTML and returns a new string.
+
+### `escapeHTML(object: ObjectType, propName: string): void`
+
+Escapes HTML for the given property.
+
+```typescript
+escapeHTML(myObject, 'foobar')
+```
+is equivalent to
+```typescript
+myObject.foobar = escape(myObject.foobar)
+```

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -2,3 +2,4 @@ export * from './controller-factories';
 export * from './post-hooks';
 export * from './pre-hooks';
 export * from './services';
+export * from './utils';

--- a/packages/common/src/utils/escape-html.spec.ts
+++ b/packages/common/src/utils/escape-html.spec.ts
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+
+import { escapeHTML } from './escape-html';
+
+describe('escapeHTML(object: ObjectType, propName: string)', () => {
+
+  it('should escape the property of the given object if it is a string.', () => {
+    const o = {
+      foobar: '<script>alert(\'XSS\')</script>'
+    };
+    escapeHTML(o, 'foobar');
+    expect(o.foobar).to.equal('&lt;script&gt;alert(&#x27;XSS&#x27;)&lt;&#x2F;script&gt;');
+  });
+
+  it('should throw an error if the property is not a string (potentially undefined).', () => {
+    const o = {};
+    expect(() => escapeHTML(o, 'foobar')).to.throw(TypeError, 'foobar should be a string (got undefined).');
+  });
+
+});

--- a/packages/common/src/utils/escape-html.ts
+++ b/packages/common/src/utils/escape-html.ts
@@ -1,0 +1,11 @@
+import { ObjectType } from '@foal/core';
+
+import { escape } from './escape';
+
+export function escapeHTML(object: ObjectType, propName: string): void {
+  const type = typeof object[propName];
+  if (type !== 'string') {
+    throw new TypeError(`${propName} should be a string (got ${type}).`);
+  }
+  object[propName] = escape(object[propName]);
+}

--- a/packages/common/src/utils/escape.spec.ts
+++ b/packages/common/src/utils/escape.spec.ts
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+
+import { escape } from './escape';
+
+describe('escape(str: string): string', () => {
+
+  it('should escape &.', () => {
+    const actual = escape('foo& &');
+    const expected = 'foo&amp; &amp;';
+
+    expect(actual).to.equal(expected);
+  });
+
+  it('should escape <.', () => {
+    const actual = escape('foo< <');
+    const expected = 'foo&lt; &lt;';
+
+    expect(actual).to.equal(expected);
+  });
+
+  it('should escape >.', () => {
+    const actual = escape('foo> >');
+    const expected = 'foo&gt; &gt;';
+
+    expect(actual).to.equal(expected);
+  });
+
+  it('should escape ".', () => {
+    const actual = escape('foo" "');
+    const expected = 'foo&quot; &quot;';
+
+    expect(actual).to.equal(expected);
+  });
+
+  it('should escape \'.', () => {
+    const actual = escape('foo\' \'');
+    const expected = 'foo&#x27; &#x27;';
+
+    expect(actual).to.equal(expected);
+  });
+
+  it('should escape /.', () => {
+    const actual = escape('foo/ /');
+    const expected = 'foo&#x2F; &#x2F;';
+
+    expect(actual).to.equal(expected);
+  });
+
+});

--- a/packages/common/src/utils/escape.ts
+++ b/packages/common/src/utils/escape.ts
@@ -1,0 +1,12 @@
+const escapeMap = {
+  '"': '&quot;',
+  '&': '&amp;',
+  '\'': '&#x27;',
+  '/': '&#x2F;',
+  '<': '&lt;',
+  '>': '&gt;',
+};
+
+export function escape(str: string): string {
+  return str.replace(/[&<>"'\/]/g, match => escapeMap[match]);
+}

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { escape } from './escape';

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { escape } from './escape';
+export { escapeHTML } from './escape-html';

--- a/packages/core/src/foal.spec.ts
+++ b/packages/core/src/foal.spec.ts
@@ -34,7 +34,7 @@ describe('Foal', () => {
 
     it('should instantiate the services given in the services array.', () => {
       // When calling `services.get` the services are instantiated if
-      // they do not already exist. The only way to test if there are created
+      // they do not already exist. The only way to test if they are created
       // before is using the prototype schema of the ServiceManager.
       const foal1 = new Foal(foalModule1);
       const foal2 = new Foal(foalModule2, foal1);


### PR DESCRIPTION
# Issue

FoalTS needs utils to escape HTML.

# Solution and steps

- [x] Add `escape`.
- [x] Add `escapeHTML`.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
  