### PR TITLE
Allow null `Route.serviceMethodName`.

### DIFF
--- a/docs/advanced/controller-factories.md
+++ b/docs/advanced/controller-factories.md
@@ -13,6 +13,7 @@ interface MyService {
 Then create your controller factory from the `ControllerFactory` abstract class.
 
 ```typescript
+import { MethodNotAllowedError } from '@foal/common';
 import {
   Context,
   ControllerFactory,
@@ -31,6 +32,13 @@ export class MyControllerFactory extends ControllerFactory<MyService> {
         },
         path: '/',
         serviceMethodName: 'giveMeANumber',
+        successStatus: 200,
+      },
+      {
+        httpMethod: 'POST',
+        middleware: (context: Context) => { throw new MethodNotAllowedError(); },
+        path: '/',
+        serviceMethodName: null,
         successStatus: 200,
       }
     ];

--- a/docs/packages/sequelize.md
+++ b/docs/packages/sequelize.md
@@ -72,7 +72,7 @@ app.listen(3000, () => console.log('Listening...'));
 Let's say that we want to forbid to use the method `delete` when using the service as a controller.
 
 ```typescript
-import { MethodNotAllowed } from '@foal/common';
+import { methodNotAllowed } from '@foal/common';
 import { Service, ObjectType } from '@foal/core';
 import { Sequelize, SequelizeService } from '@foal/sequelize';
 
@@ -86,7 +86,7 @@ export class User extends SequelizeService {
     }, connection);
   }
 
-  @MethodNotAllowed()
+  @methodNotAllowed()
   public delete(id: any, query: ObjectType): Promise<any> {
     return super.delete(id, query);
   }

--- a/packages/core/src/factories/controller-factory.spec.ts
+++ b/packages/core/src/factories/controller-factory.spec.ts
@@ -9,30 +9,14 @@ import { ControllerFactory } from './controller-factory';
 describe('ControllerFactory<T>', () => {
 
   interface ServiceInterface { foobar: () => Promise<any>; }
-  const classPreMiddleware1: Middleware = (ctx: Context, services: ServiceManager) => {
-    ctx.state.preClass1 = { services };
-  };
-  const classPreMiddleware2: Middleware = (ctx: Context, services: ServiceManager) => {
-    ctx.state.preClass2 = { services };
-  };
-  const methodPreMiddleware1: Middleware = (ctx: Context, services: ServiceManager) => {
-    ctx.state.preMethod1 = { services };
-  };
-  const methodPreMiddleware2: Middleware = (ctx: Context, services: ServiceManager) => {
-    ctx.state.preMethod2 = { services };
-  };
-  const classPostMiddleware1: Middleware = (ctx: Context, services: ServiceManager) => {
-    ctx.state.postClass1 = { services };
-  };
-  const classPostMiddleware2: Middleware = (ctx: Context, services: ServiceManager) => {
-    ctx.state.postClass2 = { services };
-  };
-  const methodPostMiddleware1: Middleware = (ctx: Context, services: ServiceManager) => {
-    ctx.state.postMethod1 = { services };
-  };
-  const methodPostMiddleware2: Middleware = (ctx: Context, services: ServiceManager) => {
-    ctx.state.postMethod2 = { services };
-  };
+  const classPreMiddleware1: Middleware = (ctx, services) => ctx.state.preClass1 = { services };
+  const classPreMiddleware2: Middleware = (ctx, services) => ctx.state.preClass2 = { services };
+  const methodPreMiddleware1: Middleware = (ctx, services) => ctx.state.preMethod1 = { services };
+  const methodPreMiddleware2: Middleware = (ctx, services) => ctx.state.preMethod2 = { services };
+  const classPostMiddleware1: Middleware = (ctx, services) => ctx.state.postClass1 = { services };
+  const classPostMiddleware2: Middleware = (ctx, services) => ctx.state.postClass2 = { services };
+  const methodPostMiddleware1: Middleware = (ctx, services) => ctx.state.postMethod1 = { services };
+  const methodPostMiddleware2: Middleware = (ctx, services) => ctx.state.postMethod2 = { services };
 
   @Service()
   @preHook(classPreMiddleware1)
@@ -58,6 +42,13 @@ describe('ControllerFactory<T>', () => {
           path: '/foobar',
           serviceMethodName: 'foobar',
           successStatus: 10000
+        },
+        {
+          httpMethod: 'GET',
+          middleware: async (context: Context) => service.foobar(),
+          path: '/foobar',
+          serviceMethodName: null,
+          successStatus: 10000
         }
       ];
     }
@@ -72,49 +63,48 @@ describe('ControllerFactory<T>', () => {
 
   describe('when attachService(path: string, ServiceClass: Type<T>) is called', () => {
 
-    describe('with good parameters', () => {
+    it('should return a ReducedRoute array from the Route array of the getRoutes method.', async () => {
+      const controller = controllerFactory.attachService('/my_path', ServiceClass);
+      const routes = controller(services);
 
-      it('should return a ReducedRoute array from the Route array of the getRoutes method.', async () => {
-        const controller = controllerFactory.attachService('/my_path', ServiceClass);
-        const routes = controller(services);
+      expect(routes).to.be.an('array').and.to.have.lengthOf(2);
 
-        expect(routes).to.be.an('array').and.to.have.lengthOf(1);
+      const actual = routes[0];
 
-        const actual = routes[0];
+      expect(actual.httpMethod).to.equal('GET');
+      expect(actual.paths).to.deep.equal(['/my_path', '/foobar']);
+      expect(actual.successStatus).to.equal(10000);
 
-        expect(actual.httpMethod).to.equal('GET');
-        expect(actual.paths).to.deep.equal(['/my_path', '/foobar']);
-        expect(actual.successStatus).to.equal(10000);
+      expect(actual.middlewares).to.be.an('array').and.to.have.lengthOf(4 + 1 + 4);
+      const ctx = createEmptyContext();
 
-        expect(actual.middlewares).to.be.an('array').and.to.have.lengthOf(4 + 1 + 4);
-        const ctx = createEmptyContext();
+      // Pre-hooks
+      actual.middlewares[0](ctx);
+      expect(ctx.state.preClass1).to.deep.equal({ services });
+      actual.middlewares[1](ctx);
+      expect(ctx.state.preClass2).to.deep.equal({ services });
+      actual.middlewares[2](ctx);
+      expect(ctx.state.preMethod1).to.deep.equal({ services });
+      actual.middlewares[3](ctx);
+      expect(ctx.state.preMethod2).to.deep.equal({ services });
 
-        // Pre-hooks
-        actual.middlewares[0](ctx);
-        expect(ctx.state.preClass1).to.deep.equal({ services });
-        actual.middlewares[1](ctx);
-        expect(ctx.state.preClass2).to.deep.equal({ services });
-        actual.middlewares[2](ctx);
-        expect(ctx.state.preMethod1).to.deep.equal({ services });
-        actual.middlewares[3](ctx);
-        expect(ctx.state.preMethod2).to.deep.equal({ services });
+      // Service method
+      await actual.middlewares[4](ctx);
+      expect(ctx.result).to.equal('Hello world');
 
-        // Service method
-        await actual.middlewares[4](ctx);
-        expect(ctx.result).to.equal('Hello world');
+      // Post-hooks
+      // Method post-hooks should be executed before class post-hooks.
+      actual.middlewares[5](ctx);
+      expect(ctx.state.postMethod1).to.deep.equal({ services });
+      actual.middlewares[6](ctx);
+      expect(ctx.state.postMethod2).to.deep.equal({ services });
+      actual.middlewares[7](ctx);
+      expect(ctx.state.postClass1).to.deep.equal({ services });
+      actual.middlewares[8](ctx);
+      expect(ctx.state.postClass2).to.deep.equal({ services });
 
-        // Post-hooks
-        // Method post-hooks should be executed before class post-hooks.
-        actual.middlewares[5](ctx);
-        expect(ctx.state.postMethod1).to.deep.equal({ services });
-        actual.middlewares[6](ctx);
-        expect(ctx.state.postMethod2).to.deep.equal({ services });
-        actual.middlewares[7](ctx);
-        expect(ctx.state.postClass1).to.deep.equal({ services });
-        actual.middlewares[8](ctx);
-        expect(ctx.state.postClass2).to.deep.equal({ services });
-      });
-
+      const actual2 = routes[1];
+      expect(actual2.middlewares).to.be.an('array').and.to.have.lengthOf(4 + 1 + 0);
     });
 
   });

--- a/packages/core/src/factories/controller-factory.ts
+++ b/packages/core/src/factories/controller-factory.ts
@@ -36,15 +36,25 @@ export abstract class ControllerFactory<T> {
 
   protected abstract getRoutes(service: T): Route[];
 
-  private getPreMiddlewares(ServiceClass: Type<T>, methodName: string): Middleware[] {
+  private getPreMiddlewares(ServiceClass: Type<T>, methodName: string|null): Middleware[] {
     const classPreMiddlewares: Middleware[] = Reflect.getMetadata('pre-middlewares', ServiceClass) || [];
+
+    if (methodName === null) {
+      return classPreMiddlewares;
+    }
+
     const methodPreMiddlewares: Middleware[] = Reflect.getMetadata('pre-middlewares', ServiceClass.prototype,
       methodName) || [];
     return classPreMiddlewares.concat(methodPreMiddlewares);
   }
 
-  private getPostMiddlewares(ServiceClass: Type<T>, methodName: string): Middleware[] {
+  private getPostMiddlewares(ServiceClass: Type<T>, methodName: string|null): Middleware[] {
     const classPostMiddlewares: Middleware[] = Reflect.getMetadata('post-middlewares', ServiceClass) || [];
+
+    if (methodName === null) {
+      return classPostMiddlewares;
+    }
+
     const methodPostMiddlewares: Middleware[] = Reflect.getMetadata('post-middlewares', ServiceClass.prototype,
       methodName) || [];
     return methodPostMiddlewares.concat(classPostMiddlewares);

--- a/packages/core/src/interfaces/controller-and-routes.ts
+++ b/packages/core/src/interfaces/controller-and-routes.ts
@@ -12,7 +12,7 @@ export interface ReducedRoute {
 
 export interface Route {
   middleware: ReducedMiddleware;
-  serviceMethodName: string;
+  serviceMethodName: string|null;
   httpMethod: HttpMethod;
   path: string;
   successStatus: number;


### PR DESCRIPTION
# Issue

Sometimes controller factories may create routes not from a particular service method.

# Solution and steps

Allow `null` value for `Route.serviceMethodName`.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
  