### PR TITLE
Change `SequelizeConnectionService` constructor params.

### DIFF
--- a/docs/cookbook/authentication.md
+++ b/docs/cookbook/authentication.md
@@ -24,7 +24,7 @@ import { SequelizeConnectionService } from '@foal/sequelize';
 @Service()
 export class ConnectionService extends SequelizeConnectionService {
   constructor() {
-    super('postgres://postgres:password@localhost:5432/foal_examples');
+    super('foal_examples', 'postgres', 'password', { dialect: 'postgres' });
   }
 }
 ```

--- a/docs/packages/sequelize.md
+++ b/docs/packages/sequelize.md
@@ -21,7 +21,7 @@ import { SequelizeConnectionService } from '@foal/sequelize';
 @Service()
 export class Connection extends SequelizeConnectionService {
   constructor() {
-    super('postgres://user:pass@example.com:5432/dbname');
+    super('dbname', 'user', 'password', { dialect: 'postgres' });
   }
 }
 ```

--- a/packages/examples/src/app/services/connection.service.ts
+++ b/packages/examples/src/app/services/connection.service.ts
@@ -6,6 +6,6 @@ import { config } from '../../config';
 @Service()
 export class ConnectionService extends SequelizeConnectionService {
   constructor() {
-    super(config.db.uri);
+    super(config.db.dbName, config.db.user, config.db.password, config.db.options);
   }
 }

--- a/packages/examples/src/config/index.ts
+++ b/packages/examples/src/config/index.ts
@@ -2,7 +2,12 @@ import { logOptions } from '@foal/express';
 
 export const config = {
   db: {
-    uri: 'postgres://postgres:password@localhost:5432/foal_examples'
+    dbName: 'foal_examples',
+    options: {
+      dialect: 'postgres'
+    },
+    password: 'password',
+    user: 'postgres',
   },
   errors: {
     logs: 'all' as logOptions,

--- a/packages/sequelize/src/sequelize-connection.service.ts
+++ b/packages/sequelize/src/sequelize-connection.service.ts
@@ -8,7 +8,7 @@ const DEFAULT_OPTIONS = {
 export abstract class SequelizeConnectionService {
   public sequelize: Sequelize;
 
-  constructor(dbName: string, username: string, password: string, options: ObjectType) {
+  constructor(dbName: string, username: string|null, password: string|null, options: ObjectType) {
     this.sequelize = new Sequelize(dbName, username, password, Object.assign({}, DEFAULT_OPTIONS, options));
   }
 }

--- a/packages/sequelize/src/sequelize-connection.service.ts
+++ b/packages/sequelize/src/sequelize-connection.service.ts
@@ -1,13 +1,14 @@
 import { ObjectType } from '@foal/core';
 import * as Sequelize from 'sequelize';
 
+const DEFAULT_OPTIONS = {
+  logging: false
+};
+
 export abstract class SequelizeConnectionService {
   public sequelize: Sequelize;
 
-  // Add params in the future.
-  constructor(uri: string, options: ObjectType = {}) {
-    this.sequelize = new Sequelize(uri, Object.assign({
-      logging: false
-    }, options));
+  constructor(dbName: string, username: string, password: string, options: ObjectType) {
+    this.sequelize = new Sequelize(dbName, username, password, Object.assign({}, DEFAULT_OPTIONS, options));
   }
 }

--- a/packages/sequelize/src/sequelize.service.spec.ts
+++ b/packages/sequelize/src/sequelize.service.spec.ts
@@ -11,9 +11,9 @@ interface User {
   lastName: string;
 }
 
-function testSuite(dbName: string, uri: string) {
+function testSuite(dialect: string, dbName: string, username: string, password: string) {
 
-  describe(`with ${dbName}`, () => {
+  describe(`with ${dialect}`, () => {
 
     let service: SequelizeService<User>;
     let model: any;
@@ -23,7 +23,10 @@ function testSuite(dbName: string, uri: string) {
     before(() => {
       class ConcreteSequelizeConnectionService extends SequelizeConnectionService {
         constructor() {
-          super(uri, { define: { timestamps: false } });
+          super(dbName, username, password, {
+            define: { timestamps: false },
+            dialect,
+          });
         }
       }
 
@@ -219,13 +222,13 @@ function testSuite(dbName: string, uri: string) {
 describe('SequelizeService<User>', () => {
 
   // Postgres
-  let user = process.env.postgres_user !== undefined ?  process.env.postgres_user :  'postgres';
-  let password = process.env.postgres_password !== undefined ? process.env.postgres_password : 'password';
-  testSuite('PostgreSQL', `postgres://${user}:${password}@localhost:5432/foal_sequelize_test`);
+  let user = process.env.postgres_user !== undefined ?  process.env.postgres_user as string :  'postgres';
+  let password = process.env.postgres_password !== undefined ? process.env.postgres_password as string : 'password';
+  testSuite('postgres', 'foal_sequelize_test', user, password);
 
   // MySQL
-  user = process.env.mysql_user !== undefined ? process.env.mysql_user : 'root';
-  password = process.env.mysql_password !== undefined ? process.env.mysql_password : 'password';
-  testSuite('MySQL', `mysql://${user}:${password}@localhost:3306/foal_sequelize_test`);
+  user = process.env.mysql_user !== undefined ? process.env.mysql_user as string : 'root';
+  password = process.env.mysql_password !== undefined ? process.env.mysql_password as string : 'password';
+  testSuite('mysql', 'foal_sequelize_test', user, password);
 
 });


### PR DESCRIPTION
# Issue

- Generally db docs don't use the database `uri` but params instead (especially public cloud docs).
- Using `uri` requires to remember everytime which default port is used by MySQL or PostgreSQL.

# Solution and steps

- [x] `SequelizeConnectionService` now takes several params instead of a single URI.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check foal generator repo (https://github.com/FoalTS/generator-foal/pull/37).