### PR TITLE
[Doc] Add path note in ejs package.

### DIFF
--- a/docs/packages/ejs.md
+++ b/docs/packages/ejs.md
@@ -18,6 +18,8 @@ export class IndexViewService extends EjsTemplateService {
 }
 ```
 
+> Note that the path `./templates/index.html` is relative to the directory from where you launch your node process. If you want it to be relative to the directory of `index-view.service.ts`, you must import the `path` package and write instead `path.join(__dirname, 'templates/index.html')`.
+
 `templates/index.html`
 ```html
 <!DOCTYPE html>


### PR DESCRIPTION
Add a small note on template paths in `@foal/ejs` services.