### PR TITLE
Add `stateDef` to `getCallback`.

### DIFF
--- a/docs/packages/express.md
+++ b/docs/packages/express.md
@@ -2,9 +2,11 @@
 
 Foal package to run the app with express.
 
-## `getCallback(foal: Foal)`
+## `getCallback(foal: Foal, stateDef: { req: string, ctx: string }[] = [])`
 
 Returns an express middleware from the foal application. It's an adapter to make foal work with express.
+
+**stateDef:** Optional array to forward data from the express `req` object to the foal `state` `context`.
 
 **Note:** Errors are not processed by this middleware. This means that any errors thrown or rejected in the foal app will have to be handled then by an express error-handling middleware. Express already integrates a default one but you can also use `handleErrors` for a higher flexibility.
 

--- a/packages/express/src/get-callback.ts
+++ b/packages/express/src/get-callback.ts
@@ -3,11 +3,10 @@ import { Router } from 'express';
 
 import { getExpressMiddleware } from './get-express-middleware';
 
-// Test: should return 404 if no route exists for the given method and path.
-export function getCallback(foal: Foal) {
+export function getCallback(foal: Foal, stateDef: { req: string, ctx: string }[] = []) {
   const router = Router();
   for (const route of foal.routes) {
-    router.use(getExpressMiddleware(route));
+    router.use(getExpressMiddleware(route, stateDef));
   }
   return router;
 }

--- a/packages/express/src/get-express-middleware.spec.ts
+++ b/packages/express/src/get-express-middleware.spec.ts
@@ -15,7 +15,8 @@ import { getExpressMiddleware } from './get-express-middleware';
 // HACK
 console.error = () => {};
 
-describe('getExpressMiddleware(route: ReducedRoute): ExpressMiddleware', () => {
+describe(`getExpressMiddleware(route: ReducedRoute,
+          stateDef: { req: string, ctx: string }[] = []): ExpressMiddleware`, () => {
 
   let route: ReducedRoute;
   let app: any;
@@ -181,17 +182,25 @@ describe('getExpressMiddleware(route: ReducedRoute): ExpressMiddleware', () => {
       app.use((req, res, next) => {
         req.session = session;
         req.user = user;
+        req.csrf = 'foobar';
         next();
       });
       route = { httpMethod: 'POST', paths: ['/:id'], middlewares: [ middleware1 ], successStatus: 200 };
-      app.use(getExpressMiddleware(route));
+      app.use(getExpressMiddleware(route, [
+        {
+          ctx: 'csrfToken',
+          req: 'csrf'
+        }
+      ]));
 
       const expected = {
         body: { text: 'Hello world' },
         params: { id: '1' },
         query: { a: 'b' },
         session,
-        state: {},
+        state: {
+          csrfToken: 'foobar'
+        },
         user,
       };
       return request(app)

--- a/packages/express/src/get-express-middleware.ts
+++ b/packages/express/src/get-express-middleware.ts
@@ -16,9 +16,11 @@ function makeContext(req): Context {
   };
 }
 
-export function getExpressMiddleware(route: ReducedRoute): ExpressMiddleware {
+export function getExpressMiddleware(route: ReducedRoute,
+                                     stateDef: { req: string, ctx: string }[] = []): ExpressMiddleware {
   async function handler(req, res) {
     const ctx = makeContext(req);
+    stateDef.forEach(e => ctx.state[e.ctx] = req[e.req]);
     for (const middleware of route.middlewares) {
       await middleware(ctx);
     }


### PR DESCRIPTION
# Issue

It is a pain (and not really useful) to convert some express middlewares such as `csurf` to pre-hooks. It would be nice to keep applying these middlewares to the express app and to forward some of their generated data to `context.state`.

# Solution and steps

- [x] Add an optional parameter to `getCallback` to forward `req` attributes to `ctx.state`.

*Note*: For example we can use this feature to forward a `csrf` token and use it in templates (`ctx.state` is used by default to render ejs templates).

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.