### PR TITLE
Add validateLocalCredentialsFormat

### DIFF
--- a/docs/packages/authentication.md
+++ b/docs/packages/authentication.md
@@ -56,7 +56,7 @@ When the authentication fails it returns an `HttpResponseUnauthorized` if `failu
 
 ```typescript
 import { Module } from '@foal/core';
-import { authentication } from '@foal/authentication';
+import { authentication, validateLocalCredentialsFormat } from '@foal/authentication';
 
 import { MyAuthenticatorService } from './my-authenticator.service';
 
@@ -67,7 +67,7 @@ export const AuthModule: Module = {
         failureRedirect: '/login?invalid_credentials=true',
         successRedirect: '/home'
       })
-      .withPreHook(/* You must add here a pre-hook to validate the input data. You may use the `validate` pre-hook from @foal/ajv.*/)
+      .withPreHook(validateLocalCredentialsFormat())
   ]
 }
 ```
@@ -212,8 +212,7 @@ export const AppModule: Module = {
 
 ```typescript
 // auth.module.ts
-import { validate } from '@foal/ajv';
-import { authentication } from '@foal/authentication';
+import { authentication, validateLocalCredentialsFormat } from '@foal/authentication';
 import { basic, HttpResponseOK, Module } from '@foal/core';
 
 import { AuthService } from './auth.service';
@@ -222,15 +221,7 @@ export const AuthModule: Module = {
   controllers: [
     authentication
       .attachService('/login', AuthService)
-      .withPreHook(validate({
-        additionalProperties: false,
-        properties: [
-          email: { type: 'string', format: 'email' },
-          password: { type: 'string' }
-        ],
-        required: [ 'email', 'password' ],
-        type: 'object'
-      })),
+      .withPreHook(validateLocalCredentialsFormat()),
     // In practice we would use below the view controller
     // factory with a template.
     basic

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -41,6 +41,7 @@
     "dist/"
   ],
   "dependencies": {
+    "@foal/ajv": "^0.4.0-beta.1",
     "@foal/common": "^0.4.0-beta.2",
     "@foal/core": "^0.4.0-beta.1"
   },

--- a/packages/authentication/src/index.ts
+++ b/packages/authentication/src/index.ts
@@ -1,5 +1,6 @@
 export * from './authenticators';
 export * from './authorization';
+export * from './pre-hooks';
 export * from './authenticate.pre-hook';
 export * from './authentication.controller-factory';
 export * from './authenticator.interface';

--- a/packages/authentication/src/pre-hooks/index.ts
+++ b/packages/authentication/src/pre-hooks/index.ts
@@ -1,0 +1,1 @@
+export { validateLocalCredentialsFormat } from './validate-local-credentials-format.pre-hook';

--- a/packages/authentication/src/pre-hooks/validate-local-credentials-format.pre-hook.spec.ts
+++ b/packages/authentication/src/pre-hooks/validate-local-credentials-format.pre-hook.spec.ts
@@ -1,0 +1,151 @@
+import { createEmptyContext, HttpResponseBadRequest, ServiceManager } from '@foal/core';
+import { expect } from 'chai';
+
+import { validateLocalCredentialsFormat } from './validate-local-credentials-format.pre-hook';
+
+describe('validateLocalCredentialsFormat', () => {
+
+  it('should return an HttpResponseBadRequest if the email property is missing.', () => {
+    const preHook = validateLocalCredentialsFormat();
+    const ctx = createEmptyContext();
+    ctx.body = {
+      password: 'myPassword',
+    };
+
+    const result = preHook(ctx, new ServiceManager());
+    expect(result).to.be.instanceOf(HttpResponseBadRequest);
+    expect((result as HttpResponseBadRequest).content).to.be.an('array').and.to.have.lengthOf(1);
+    expect((result as HttpResponseBadRequest).content[0]).to.deep.equal({
+      dataPath: '',
+      keyword: 'required',
+      message: 'should have required property \'email\'',
+      params: {
+        missingProperty: 'email',
+      },
+      schemaPath: '#/required',
+    });
+  });
+
+  it('should return an HttpResponseBadRequest if the password property is missing.', () => {
+    const preHook = validateLocalCredentialsFormat();
+    const ctx = createEmptyContext();
+    ctx.body = {
+      email: 'john@jack.com',
+    };
+
+    const result = preHook(ctx, new ServiceManager());
+    expect(result).to.be.instanceOf(HttpResponseBadRequest);
+    expect((result as HttpResponseBadRequest).content).to.be.an('array').and.to.have.lengthOf(1);
+    expect((result as HttpResponseBadRequest).content[0]).to.deep.equal({
+      dataPath: '',
+      keyword: 'required',
+      message: 'should have required property \'password\'',
+      params: {
+        missingProperty: 'password',
+      },
+      schemaPath: '#/required',
+    });
+  });
+
+  it('should return an HttpResponseBadRequest if the email property is not a string.', () => {
+    const preHook = validateLocalCredentialsFormat();
+    const ctx = createEmptyContext();
+    ctx.body = {
+      email: 1,
+      password: 'myPassword',
+    };
+
+    const result = preHook(ctx, new ServiceManager());
+    expect(result).to.be.instanceOf(HttpResponseBadRequest);
+    expect((result as HttpResponseBadRequest).content).to.be.an('array').and.to.have.lengthOf(1);
+    expect((result as HttpResponseBadRequest).content[0]).to.deep.equal({
+      dataPath: '.email',
+      keyword: 'type',
+      message: 'should be string',
+      params: {
+        type: 'string',
+      },
+      schemaPath: '#/properties/email/type',
+    });
+  });
+
+  it('should return an HttpResponseBadRequest if the password property is not a string.', () => {
+    const preHook = validateLocalCredentialsFormat();
+    const ctx = createEmptyContext();
+    ctx.body = {
+      email: 'john@jack.com',
+      password: 1,
+    };
+
+    const result = preHook(ctx, new ServiceManager());
+    expect(result).to.be.instanceOf(HttpResponseBadRequest);
+    expect((result as HttpResponseBadRequest).content).to.be.an('array').and.to.have.lengthOf(1);
+    expect((result as HttpResponseBadRequest).content[0]).to.deep.equal({
+      dataPath: '.password',
+      keyword: 'type',
+      message: 'should be string',
+      params: {
+        type: 'string',
+      },
+      schemaPath: '#/properties/password/type',
+    });
+  });
+
+  it('should return an HttpResponseBadRequest if the email property does not contain a valid email.', () => {
+    const preHook = validateLocalCredentialsFormat();
+    const ctx = createEmptyContext();
+    ctx.body = {
+      email: 'johnjack.com',
+      password: 'myPassword',
+    };
+
+    const result = preHook(ctx, new ServiceManager());
+    expect(result).to.be.instanceOf(HttpResponseBadRequest);
+    expect((result as HttpResponseBadRequest).content).to.be.an('array').and.to.have.lengthOf(1);
+    expect((result as HttpResponseBadRequest).content[0]).to.deep.equal({
+      dataPath: '.email',
+      keyword: 'format',
+      message: 'should match format "email"',
+      params: {
+        format: 'email',
+      },
+      schemaPath: '#/properties/email/format',
+    });
+  });
+
+  it('should return an HttpResponseBadRequest if there are additional properties.', () => {
+    const preHook = validateLocalCredentialsFormat();
+    const ctx = createEmptyContext();
+    ctx.body = {
+      email: 'john@jack.com',
+      foo: 'bar',
+      password: 'myPassword',
+    };
+
+    const result = preHook(ctx, new ServiceManager());
+    expect(result).to.be.instanceOf(HttpResponseBadRequest);
+    expect((result as HttpResponseBadRequest).content).to.be.an('array').and.to.have.lengthOf(1);
+    expect((result as HttpResponseBadRequest).content[0]).to.deep.equal({
+      dataPath: '',
+      keyword: 'additionalProperties',
+      message: 'should NOT have additional properties',
+      params: {
+        additionalProperty: 'foo',
+      },
+      schemaPath: '#/additionalProperties',
+    });
+  });
+
+  it('should not return anything if the input is correct.', () => {
+    const preHook = validateLocalCredentialsFormat();
+    const ctx = createEmptyContext();
+    ctx.body = {
+      email: 'john@jack.com',
+      password: 'myPassword',
+    };
+
+    const result = preHook(ctx, new ServiceManager());
+    expect(result).to.equal(undefined);
+  });
+
+});

--- a/packages/authentication/src/pre-hooks/validate-local-credentials-format.pre-hook.ts
+++ b/packages/authentication/src/pre-hooks/validate-local-credentials-format.pre-hook.ts
@@ -1,0 +1,14 @@
+import { validate } from '@foal/ajv';
+import { PreHook } from '@foal/core';
+
+export function validateLocalCredentialsFormat(): PreHook {
+  return validate({
+    additionalProperties: false,
+    properties: {
+      email: { type: 'string', format: 'email' },
+      password: { type: 'string' }
+    },
+    required: [ 'email', 'password' ],
+    type: 'object',
+  });
+}


### PR DESCRIPTION
# Issue

Local authentication needs an easy way to check input data.

# Solution and steps

Create a `validateLocalCredentialsFormat` pre-hook.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check foal generator repo (https://github.com/FoalTS/generator-foal/pull/62).