### PR TITLE
Fix `validateEmailCredentialsFormat` naming.

### DIFF
--- a/docs/packages/authentication.md
+++ b/docs/packages/authentication.md
@@ -56,7 +56,7 @@ When the authentication fails it returns an `HttpResponseUnauthorized` if `failu
 
 ```typescript
 import { Module } from '@foal/core';
-import { authentication, validateEmailCredentialsFormat } from '@foal/authentication';
+import { authentication, validateEmailAndPasswordCredentialsFormat } from '@foal/authentication';
 
 import { AuthenticatorService } from './authenticator.service';
 
@@ -67,7 +67,7 @@ export const AuthModule: Module = {
         failureRedirect: '/login?invalid_credentials=true',
         successRedirect: '/home'
       })
-      .withPreHook(validateEmailCredentialsFormat())
+      .withPreHook(validateEmailAndPasswordCredentialsFormat())
   ]
 }
 ```
@@ -216,7 +216,7 @@ export const AppModule: Module = {
 
 ```typescript
 // auth.module.ts
-import { authentication, validateEmailCredentialsFormat } from '@foal/authentication';
+import { authentication, validateEmailAndPasswordCredentialsFormat } from '@foal/authentication';
 import { basic, HttpResponseOK, Module } from '@foal/core';
 
 import { AuthService } from './auth.service';
@@ -225,7 +225,7 @@ export const AuthModule: Module = {
   controllers: [
     authentication
       .attachService('/login', AuthService)
-      .withPreHook(validateEmailCredentialsFormat()),
+      .withPreHook(validateEmailAndPasswordCredentialsFormat()),
     // In practice we would use below the view controller
     // factory with a template.
     basic

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.4.0-beta.3"
+  "version": "0.4.0-beta.4"
 }

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foal/authentication",
-  "version": "0.4.0-beta.3",
+  "version": "0.4.0-beta.4",
   "description": "Foal components for authentication and authorization",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/authentication/src/email-and-password/index.ts
+++ b/packages/authentication/src/email-and-password/index.ts
@@ -1,4 +1,4 @@
 export { EmailAndPasswordAuthenticatorService } from './email-and-password-authenticator.service';
-export { validateEmailCredentialsFormat } from './validate-email-credentials-format.pre-hook';
+export { validateEmailAndPasswordCredentialsFormat } from './validate-email-and-password-credentials-format.pre-hook';
 export { emailAndPasswordSchema, EmailAndPassword } from './email-and-password.schema';
 export { parsePassword } from './parse-password.parser';

--- a/packages/authentication/src/email-and-password/validate-email-and-password-credentials-format.pre-hook.spec.ts
+++ b/packages/authentication/src/email-and-password/validate-email-and-password-credentials-format.pre-hook.spec.ts
@@ -1,12 +1,12 @@
 import { createEmptyContext, HttpResponseBadRequest, ServiceManager } from '@foal/core';
 import { expect } from 'chai';
 
-import { validateEmailCredentialsFormat } from './validate-email-credentials-format.pre-hook';
+import { validateEmailAndPasswordCredentialsFormat } from './validate-email-and-password-credentials-format.pre-hook';
 
-describe('validateEmailCredentialsFormat', () => {
+describe('validateEmailAndPasswordCredentialsFormat', () => {
 
   it('should return an HttpResponseBadRequest if the email property is missing.', () => {
-    const preHook = validateEmailCredentialsFormat();
+    const preHook = validateEmailAndPasswordCredentialsFormat();
     const ctx = createEmptyContext();
     ctx.body = {
       password: 'myPassword',
@@ -27,7 +27,7 @@ describe('validateEmailCredentialsFormat', () => {
   });
 
   it('should return an HttpResponseBadRequest if the password property is missing.', () => {
-    const preHook = validateEmailCredentialsFormat();
+    const preHook = validateEmailAndPasswordCredentialsFormat();
     const ctx = createEmptyContext();
     ctx.body = {
       email: 'john@jack.com',
@@ -48,7 +48,7 @@ describe('validateEmailCredentialsFormat', () => {
   });
 
   it('should return an HttpResponseBadRequest if the email property is not a string.', () => {
-    const preHook = validateEmailCredentialsFormat();
+    const preHook = validateEmailAndPasswordCredentialsFormat();
     const ctx = createEmptyContext();
     ctx.body = {
       email: 1,
@@ -70,7 +70,7 @@ describe('validateEmailCredentialsFormat', () => {
   });
 
   it('should return an HttpResponseBadRequest if the password property is not a string.', () => {
-    const preHook = validateEmailCredentialsFormat();
+    const preHook = validateEmailAndPasswordCredentialsFormat();
     const ctx = createEmptyContext();
     ctx.body = {
       email: 'john@jack.com',
@@ -92,7 +92,7 @@ describe('validateEmailCredentialsFormat', () => {
   });
 
   it('should return an HttpResponseBadRequest if the email property does not contain a valid email.', () => {
-    const preHook = validateEmailCredentialsFormat();
+    const preHook = validateEmailAndPasswordCredentialsFormat();
     const ctx = createEmptyContext();
     ctx.body = {
       email: 'johnjack.com',
@@ -114,7 +114,7 @@ describe('validateEmailCredentialsFormat', () => {
   });
 
   it('should return an HttpResponseBadRequest if there are additional properties.', () => {
-    const preHook = validateEmailCredentialsFormat();
+    const preHook = validateEmailAndPasswordCredentialsFormat();
     const ctx = createEmptyContext();
     ctx.body = {
       email: 'john@jack.com',
@@ -137,7 +137,7 @@ describe('validateEmailCredentialsFormat', () => {
   });
 
   it('should not return anything if the input is correct.', () => {
-    const preHook = validateEmailCredentialsFormat();
+    const preHook = validateEmailAndPasswordCredentialsFormat();
     const ctx = createEmptyContext();
     ctx.body = {
       email: 'john@jack.com',

--- a/packages/authentication/src/email-and-password/validate-email-and-password-credentials-format.pre-hook.ts
+++ b/packages/authentication/src/email-and-password/validate-email-and-password-credentials-format.pre-hook.ts
@@ -1,7 +1,7 @@
 import { validate } from '@foal/ajv';
 import { PreHook } from '@foal/core';
 
-export function validateEmailCredentialsFormat(): PreHook {
+export function validateEmailAndPasswordCredentialsFormat(): PreHook {
   return validate({
     additionalProperties: false,
     properties: {

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foal/examples",
-  "version": "0.4.0-beta.3",
+  "version": "0.4.0-beta.4",
   "description": "FoalTs examples",
   "scripts": {
     "shell": "node --require ts-node/register",
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@foal/ajv": "^0.4.0-beta.3",
-    "@foal/authentication": "^0.4.0-beta.3",
+    "@foal/authentication": "^0.4.0-beta.4",
     "@foal/common": "^0.4.0-beta.3",
     "@foal/core": "^0.4.0-beta.3",
     "@foal/ejs": "^0.4.0-beta.3",

--- a/packages/examples/src/app/authentication/auth.module.ts
+++ b/packages/examples/src/app/authentication/auth.module.ts
@@ -1,4 +1,4 @@
-import { authentication, validateEmailCredentialsFormat } from '@foal/authentication';
+import { authentication, validateEmailAndPasswordCredentialsFormat } from '@foal/authentication';
 import { Module } from '@foal/core';
 
 import { view } from '@foal/common';
@@ -12,7 +12,7 @@ export const AuthModule: Module = {
         failureRedirect: '/auth?invalid_credentials=true',
         successRedirect: '/home',
       })
-      .withPreHook(validateEmailCredentialsFormat()),
+      .withPreHook(validateEmailAndPasswordCredentialsFormat()),
     authentication
       .attachLogout('/logout', {
         httpMethod: 'POST',


### PR DESCRIPTION
Reasons:
- Name consistency.
- The generator is currently broken on prod: it does not find the searched pre-hook.