### PR TITLE
[Docs] Fix csrf issue in the guide.

### DIFF
--- a/docs/guide/1-introduction.md
+++ b/docs/guide/1-introduction.md
@@ -6,7 +6,7 @@ As most of nowdays apps use rich-client interface, you'll use a precompiled fron
 
 First create a new project by following [these instructions](../README.md).
 
-Then [download the frontend app](https://foalts.org/guide-frontend.zip), unzip the bundle and copy paste its content in the `public` directory of your project.
+Then [download the frontend app](https://foalts.org/guide-frontend.zip), unzip the bundle and replace the `public/` directory and the `src/app/templates/index.html` file with its content.
 
 If you refresh the page at `http://localhost:3000` you should now see this.
 


### PR DESCRIPTION
# Issue

The `get-started` guide is not working because of a `csrf bad token`.

# Solution and steps

This PR fixes this with the new `guide-frontend.zip`