### PR TITLE
parsePassword(object) -> parsePassword(string).

### DIFF
--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -26,9 +26,7 @@ export class Flight {
   password: string;
 
   setPassword(password: string) {
-    const o = { password };
-    parsePassword(o);
-    this.password = o.password;
+    this.password = parsePassword(password);
   }
 
 }

--- a/packages/core/src/auth/authentication/strategies/email/parse-password.parser.spec.ts
+++ b/packages/core/src/auth/authentication/strategies/email/parse-password.parser.spec.ts
@@ -6,20 +6,10 @@ import { parsePassword } from './parse-password.parser';
 
 describe('parsePassword', () => {
 
-  it('should not throw an exception or add a password property to the data if it originally'
-      + 'does not exist.', async () => {
-    const user = {};
-    await parsePassword(user);
-    expect(user.hasOwnProperty('password')).to.equal(false);
-  });
-
   it('should hash and salt the plain password if it exists.', async () => {
-    const user = {
-      password: 'my_strong_password'
-    };
-    await parsePassword(user);
-    expect(user.password).to.be.an('string');
-    const arr = user.password.split('$');
+    const actual = await parsePassword('my_strong_password');
+    expect(actual).to.be.an('string');
+    const arr = actual.split('$');
     expect(arr).to.have.lengthOf(4);
     const password = {
       algorithm: arr[0],

--- a/packages/core/src/auth/authentication/strategies/email/parse-password.parser.ts
+++ b/packages/core/src/auth/authentication/strategies/email/parse-password.parser.ts
@@ -1,14 +1,11 @@
 import { pbkdf2, randomBytes } from 'crypto';
 import { promisify } from 'util';
 
-export async function parsePassword(data: { password?: string }): Promise<void> {
-  if (!data.password) {
-    return;
-  }
+export async function parsePassword(password: string): Promise<string> {
   const salt = (await promisify(randomBytes)(16)).toString('hex');
   const iterations = 100000;
   const keylen = 64;
   const digest = 'sha256';
-  const derivedKey = await promisify(pbkdf2)(data.password, salt, iterations, keylen, digest);
-  data.password = `pbkdf2_${digest}$${iterations}$${salt}$${derivedKey.toString('hex')}`;
+  const derivedKey = await promisify(pbkdf2)(password, salt, iterations, keylen, digest);
+  return `pbkdf2_${digest}$${iterations}$${salt}$${derivedKey.toString('hex')}`;
 }

--- a/packages/examples/src/app/entities/user.entity.ts
+++ b/packages/examples/src/app/entities/user.entity.ts
@@ -14,9 +14,7 @@ export class User extends AbstractUser {
   password: string;
 
   setPassword(password: string) {
-    const o = { password };
-    parsePassword(o);
-    this.password = o.password;
+    this.password = parsePassword(password);
   }
 
 }


### PR DESCRIPTION
# Issue

Passing an object to `parsePassword` adds complexity.

# Solution and steps

Change the `parsePassword` param: `data: { password?: string }` -> `password: string`

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.