### PR TITLE
Do not modify/set the value of process.env.NODE_ENV when building.

### DIFF
--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -31,6 +31,9 @@ const commonConfig = {
       }
     ]
   },
+  optimization: {
+    nodeEnv: false
+  },
   output: {
     filename: 'server.js',
     path: path.resolve(process.cwd(), 'lib'),


### PR DESCRIPTION
# Issue

Webpack modes modify/set the value of `process.env.NODE_ENV` when building. This is bad in our case:
- the tests are executed with `process.env.NODE_ENV === 'development'`,
- 3p libraries (ex: express) do not have their `process.env.NODE_ENV` converted which may lead to unexpected behaviors.

# Solution and steps

Keep using the webpack modes but disable this feature.

# Checklist

- [x] Add/update/check docs.
- [ ] ~~Add/update/check tests~~.
- [x] Update/check the cli generators.