### PR TITLE
Make the app return 403 'Bad csrf token' when the csrf token is incorrect or missing.

### DIFF
--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -1,13 +1,38 @@
+// 3p
+import * as request from 'supertest';
+
+// FoalTS
 import { createApp } from './create-app';
 
 describe('createApp', () => {
-  it('should be tested.', () => {
-    // TODO: Add tests.
-    createApp(class {});
-  });
-});
 
-// TODO: Add tests
+  it('should return a 403 "Bad csrf token" on POST/PATCH/PUT/DELETE requests with bad'
+      + ' csrf token.', () => {
+    process.env.SETTINGS_CSRF = 'true';
+    const app = createApp(class {});
+    const promise = Promise.all([
+      request(app).post('/').expect(403).expect('Bad csrf token.'),
+      request(app).patch('/').expect(403).expect('Bad csrf token.'),
+      request(app).put('/').expect(403).expect('Bad csrf token.'),
+      request(app).delete('/').expect(403).expect('Bad csrf token.'),
+    ]);
+    process.env.SETTINGS_CSRF = 'false'; // Not great: assumption about the default param here.
+    return promise;
+  });
+
+  it('should return 404 "Not Found" on requests that have no handlers.', () => {
+    const app = createApp(class {});
+    return Promise.all([
+      request(app).get('/foo').expect(404),
+      request(app).post('/foo').expect(404),
+      request(app).patch('/foo').expect(404),
+      request(app).put('/foo').expect(404),
+      request(app).delete('/foo').expect(404),
+    ]);
+  });
+
+  // TODO: Add tests.
+});
 
 // import * as express from 'express';
 // import * as request from 'supertest';

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -9,7 +9,6 @@ import * as logger from 'morgan';
 import {
   Class,
   Config,
-  HttpResponseForbidden,
   IModule,
   makeModuleRoutes,
   ServiceManager
@@ -36,7 +35,7 @@ export function createApp(rootModuleClass: Class<IModule>) {
     name: Config.get('settings', 'sessionName'),
     resave: Config.get('settings', 'sessionResave', false),
     saveUninitialized: Config.get('settings', 'sessionSaveUninitialized', true),
-    secret: Config.get('settings', 'sessionSecret', ''),
+    secret: Config.get('settings', 'sessionSecret', 'default_secret'),
   }));
 
   if (Config.get('settings', 'csrf', false) as boolean) {
@@ -44,7 +43,8 @@ export function createApp(rootModuleClass: Class<IModule>) {
   }
   app.use((err, req, res, next) => {
     if (err.code === 'EBADCSRFTOKEN') {
-      err = new HttpResponseForbidden('Bad csrf token.');
+      res.status(403).send('Bad csrf token.');
+      return;
     }
     next(err);
   });


### PR DESCRIPTION
# Issue

A bad csrf token returns a 500 "Internal Server Error".

# Solution and steps

Make the return app return a 403 'Bad csrf token.'

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.