### PR TITLE
By default auto create database schema on every application launch 

### DIFF
--- a/docs/production/deployment-prod.md
+++ b/docs/production/deployment-prod.md
@@ -4,3 +4,4 @@ When deploying an application to production you need to:
 - use https (or set `sessionCookieSecure` to `false` in `config/settings.production.json`),
 - set the `NODE_ENV` environment variable to `production`,
 - specify the name of your domain in `config/settings.production.json` with the property `sessionCookieDomain` (or use the env variable `SETTINGS_SESSION_COOKIE_DOMAIN` for that).
+- use database migrations instead of the TypeORM `synchronize` feature (it auto creates database schema on every application launch). You can disable this feature by setting the env variable `TYPEORM_SYNCHRONIZE` to false.

--- a/packages/cli/src/generate/templates-spec/app/ormconfig.1.json
+++ b/packages/cli/src/generate/templates-spec/app/ormconfig.1.json
@@ -5,5 +5,6 @@
   "migrations": ["migration/*.js"],
   "cli": {
     "migrationsDir": "migrations"
-  }
+  },
+  "synchronize": true
 }

--- a/packages/cli/src/generate/templates/app/ormconfig.json
+++ b/packages/cli/src/generate/templates/app/ormconfig.json
@@ -5,5 +5,6 @@
   "migrations": ["migration/*.js"],
   "cli": {
     "migrationsDir": "migrations"
-  }
+  },
+  "synchronize": true
 }


### PR DESCRIPTION
# Issue

Creating and running migrations in development is tedious.

# Solution and steps

Add `synchronize: true` in the generated `ormconfig.json`

# Checklist

- [x] Add/update/check docs.
- [ ] ~~Add/update/check tests.~~
- [x] Update/check the cli generators.