### PR TITLE
Fix commands `npm run migration:generate` and `npm run migration:run`

### DIFF
--- a/packages/cli/src/generate/templates-spec/app/ormconfig.1.json
+++ b/packages/cli/src/generate/templates-spec/app/ormconfig.1.json
@@ -2,7 +2,7 @@
   "type": "sqlite",
   "database": "./db.sqlite3",
   "entities": ["src/app/**/*.entity.ts"],
-  "migrations": ["migration/*.js"],
+  "migrations": ["migrations/*.ts"],
   "cli": {
     "migrationsDir": "migrations"
   },

--- a/packages/cli/src/generate/templates-spec/app/src/app/entities/user.entity.1.ts
+++ b/packages/cli/src/generate/templates-spec/app/src/app/entities/user.entity.1.ts
@@ -5,3 +5,5 @@ import { Entity } from 'typeorm';
 export class User extends AbstractUser {
 
 }
+
+export { Group, Permission } from '@foal/core';

--- a/packages/cli/src/generate/templates/app/ormconfig.json
+++ b/packages/cli/src/generate/templates/app/ormconfig.json
@@ -2,7 +2,7 @@
   "type": "sqlite",
   "database": "./db.sqlite3",
   "entities": ["src/app/**/*.entity.ts"],
-  "migrations": ["migration/*.js"],
+  "migrations": ["migrations/*.ts"],
   "cli": {
     "migrationsDir": "migrations"
   },

--- a/packages/cli/src/generate/templates/app/src/app/entities/user.entity.ts
+++ b/packages/cli/src/generate/templates/app/src/app/entities/user.entity.ts
@@ -5,3 +5,5 @@ import { Entity } from 'typeorm';
 export class User extends AbstractUser {
 
 }
+
+export { Group, Permission } from '@foal/core';


### PR DESCRIPTION
# Issue

- Creating migrations fails because `Group` and `Permission` are not found.
- Running the migrations fails because the given path is incorrect.

# Solution and steps

- Export the entities `Group` and `Permission`.
- Fix the migrations path in `ormconfig.json`

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.