### PR TITLE
Add ValidateQuery hook

### DIFF
--- a/docs/cookbook/validation.md
+++ b/docs/cookbook/validation.md
@@ -1,6 +1,6 @@
 # Validation
 
-`ValidateBody` is a hook to control the data received by the server. [Ajv](https://github.com/epoberezkin/ajv), a fast JSON Schema Validator, validates the `context.request.body` with the given schema. If the validation fails then an `HttpResponseBadRequest` is returned with the validation errors as `content`.
+`ValidateBody` and `ValidateQuery` are hooks to control the body and the query of the requests received by the server. [Ajv](https://github.com/epoberezkin/ajv), a fast JSON Schema Validator, validates the `context.request.body` with the given schema. If the validation fails then an `HttpResponseBadRequest` is returned with the validation errors as `content`.
 
 You can provide your own instance of Ajv.
 

--- a/packages/core/src/common/hooks/index.ts
+++ b/packages/core/src/common/hooks/index.ts
@@ -1,3 +1,4 @@
 export { InitDB } from './init-db.hook';
 export { Log } from './log.hook';
 export { ValidateBody } from './validate-body.hook';
+export { ValidateQuery } from './validate-query.hook';

--- a/packages/core/src/common/hooks/validate-query.hook.spec.ts
+++ b/packages/core/src/common/hooks/validate-query.hook.spec.ts
@@ -1,0 +1,93 @@
+// std
+import { notStrictEqual, ok, strictEqual } from 'assert';
+
+// 3p
+import * as Ajv from 'ajv';
+
+// FoalTS
+import { Context, getHookFunction, HttpResponseBadRequest, ServiceManager } from '../../core';
+import { ValidateQuery } from './validate-query.hook';
+
+describe('ValidateQuery', () => {
+
+  it('should not return an HttpResponseBadRequest if ctx.request.query is validated '
+      + ' by ajv for the given schema.', () => {
+    const schema = {
+      properties: {
+        foo: { type: 'integer' }
+      },
+      type: 'object',
+    };
+    const hook = getHookFunction(ValidateQuery(schema));
+    const ctx = new Context({});
+    ctx.request.query = {
+      foo: 3
+    };
+
+    const actual = hook(ctx, new ServiceManager());
+    strictEqual(actual instanceof HttpResponseBadRequest, false);
+  });
+
+  it('should return an HttpResponseBadRequest if ctx.request.query is not validated by '
+      + ' ajv for the given schema.', () => {
+    const schema = {
+      properties: {
+        foo: { type: 'integer' }
+      },
+      type: 'object',
+    };
+    const hook = getHookFunction(ValidateQuery(schema));
+
+    function context(query) {
+      const ctx = new Context({});
+      ctx.request.query = query;
+      return ctx;
+    }
+
+    ok(hook(context(null), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context(undefined), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context('foo'), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context(3), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context(true), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context({ foo: '3' }), new ServiceManager()) instanceof HttpResponseBadRequest);
+  });
+
+  it('should return an HttpResponseBadRequest with a defined `content` property if '
+      + 'ctx.request.query is not validated by ajv.', () => {
+    const schema = {
+      properties: {
+        foo: { type: 'integer' }
+      },
+      type: 'object',
+    };
+    const hook = getHookFunction(ValidateQuery(schema));
+    const ctx = new Context({});
+
+    const actual = hook(ctx, new ServiceManager());
+    ok(actual instanceof HttpResponseBadRequest);
+    notStrictEqual((actual as HttpResponseBadRequest).content, undefined);
+  });
+
+  it('should use the given ajv instance if it exists.', () => {
+    const schema = {
+      properties: {
+        bar: { type: 'integer', default: 4 },
+        foo: { type: 'integer' },
+      },
+      type: 'object',
+    };
+    const ctx = new Context({});
+    ctx.request.query = {
+      foo: 3,
+    };
+
+    let hook = getHookFunction(ValidateQuery(schema));
+    hook(ctx, new ServiceManager());
+    strictEqual(ctx.request.query.bar, undefined);
+
+    hook = getHookFunction(ValidateQuery(schema, new Ajv({ useDefaults: true })));
+    hook(ctx, new ServiceManager());
+    strictEqual(ctx.request.query.bar, 4);
+  });
+
+});

--- a/packages/core/src/common/hooks/validate-query.hook.ts
+++ b/packages/core/src/common/hooks/validate-query.hook.ts
@@ -1,0 +1,14 @@
+import * as Ajv from 'ajv';
+
+import { Hook, HookDecorator, HttpResponseBadRequest } from '../../core';
+
+const defaultInstance = new Ajv();
+
+export function ValidateQuery(schema: object, ajv = defaultInstance): HookDecorator {
+  const isValid = ajv.compile(schema);
+  return Hook(ctx => {
+    if (!isValid(ctx.request.query)) {
+      return new HttpResponseBadRequest(isValid.errors as Ajv.ErrorObject[]);
+    }
+  });
+}


### PR DESCRIPTION
# Issue

Having an easy way to validate the query (`/foo?queryParam1=3&queryParam2=3`) of a request.

# Solution and steps

Create `ValidateQuery` with the same model as `ValidateBody`.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.