### PR TITLE
Add `createController` util, fix the LoginController `'get' of undefined` bug and generate with the CLI the tests of empty controllers

### DIFF
--- a/docs/basics/controllers.md
+++ b/docs/basics/controllers.md
@@ -5,14 +5,14 @@ foal generate controller my-controller
 ```
 
 ```typescript
-import { Context, Controller, Get, HttpResponseOk } from '@foal/core';
+import { Context, Controller, Get, HttpResponseOK } from '@foal/core';
 
 @Controller()
 export class MyController {
 
   @Get('/flight')
   getFlights(ctx: Context) {
-    return new HttpResponseOk([]);
+    return new HttpResponseOK([]);
   }
 
 }
@@ -29,7 +29,7 @@ Controllers are the front door of your application. They catch all the incoming 
 Formally a controller is a single class that is instantiated as a singleton. The class itself is surrounded by the `Controller` decorator. The methods that handle the requests take also a decorator: `Get`, `Post`, `Patch`, `Put` or `Delete`. Each method with one of theses decorators is responsible for one route.
 
 ```typescript
-import { Context, Controller, Get, HttpResponseOk } from '@foal/core';
+import { Context, Controller, Get, HttpResponseOK } from '@foal/core';
 
 @Controller()
 export class MyController {
@@ -39,7 +39,7 @@ export class MyController {
 
   @Get('/flight')
   getFlights(ctx: Context) {
-    return new HttpResponseOk(this.flights);
+    return new HttpResponseOK(this.flights);
   }
 
 }

--- a/docs/basics/controllers.md
+++ b/docs/basics/controllers.md
@@ -126,12 +126,14 @@ ok(controller.foo(ctx) instanceof HttpResponseOK);
 ## Inheriting controllers
 
 ```typescript
+@Controller()
 abstract class ParentController {
   @Get('/foo')
   foo() {
     return new HttpResponseOK();
   }
 }
+
 
 @Controller()
 class ChildController extends ParentController {
@@ -141,6 +143,8 @@ class ChildController extends ParentController {
   }
 }
 ```
+
+You can also override `foo`. If you don't add a `Get`, `Post`, `Patch`, `Put` or `Delete` decorator then the parent path and HTTP method are used. If you don't add a hook, then the parent hooks are used. Otherwise they are all discarded.
 
 ## Common controllers
 

--- a/docs/testing/unit-testing.md
+++ b/docs/testing/unit-testing.md
@@ -6,6 +6,27 @@ All tests must be imported in the main `test.ts` file.
 
 ## Controllers
 
+```typescript
+// std
+import { ok } from 'assert';
+
+//3p
+import { Controller, createController, Service } from '@foal/core';
+
+@Service()
+class MyService {
+
+}
+
+@Controller()
+class MyController {
+  constructor(public myService: MyService) {}
+}
+
+const controller = createController(MyController);
+ok(controller.myService instanceof MyService);
+```
+
 ## Hooks
 
 `getHookFunction` util.

--- a/packages/cli/src/generate/generators/controller/create-controller.spec.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.spec.ts
@@ -15,6 +15,7 @@ describe('createController', () => {
 
   afterEach(() => {
     rmfileIfExists('src/app/controllers/test-foo-bar.controller.ts');
+    rmfileIfExists('src/app/controllers/test-foo-bar.controller.spec.ts');
     rmdirIfExists('src/app/controllers');
     rmdirIfExists('src/app');
     // We cannot remove src/ since the generator code lives within. This is bad testing
@@ -22,9 +23,11 @@ describe('createController', () => {
     // rmdirIfExists('src');
 
     rmfileIfExists('controllers/test-foo-bar.controller.ts');
+    rmfileIfExists('controllers/test-foo-bar.controller.spec.ts');
     rmdirIfExists('controllers');
 
     rmfileIfExists('test-foo-bar.controller.ts');
+    rmfileIfExists('test-foo-bar.controller.spec.ts');
   });
 
   describe('should render the empty templates', () => {
@@ -40,6 +43,10 @@ describe('createController', () => {
       const actual = readFileFromRoot('src/app/controllers/test-foo-bar.controller.ts');
       strictEqual(actual, expected);
 
+      const expected2 = readFileFromTemplatesSpec('controller/test-foo-bar.controller.spec.empty.ts');
+      const actual2 = readFileFromRoot('src/app/controllers/test-foo-bar.controller.spec.ts');
+      strictEqual(actual2, expected2);
+
     });
 
     it('in controllers/ if the directory exists.', () => {
@@ -51,6 +58,10 @@ describe('createController', () => {
       const actual = readFileFromRoot('controllers/test-foo-bar.controller.ts');
       strictEqual(actual, expected);
 
+      const expected2 = readFileFromTemplatesSpec('controller/test-foo-bar.controller.spec.empty.ts');
+      const actual2 = readFileFromRoot('controllers/test-foo-bar.controller.spec.ts');
+      strictEqual(actual2, expected2);
+
     });
 
     it('in the current directory otherwise.', () => {
@@ -60,6 +71,10 @@ describe('createController', () => {
       const expected = readFileFromTemplatesSpec('controller/test-foo-bar.controller.empty.ts');
       const actual = readFileFromRoot('test-foo-bar.controller.ts');
       strictEqual(actual, expected);
+
+      const expected2 = readFileFromTemplatesSpec('controller/test-foo-bar.controller.spec.empty.ts');
+      const actual2 = readFileFromRoot('test-foo-bar.controller.spec.ts');
+      strictEqual(actual2, expected2);
 
     });
 

--- a/packages/cli/src/generate/generators/controller/create-controller.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.ts
@@ -10,16 +10,20 @@ export function createController({ name, type }: { name: string, type: Controlle
   const names = getNames(name);
 
   let path = `${names.kebabName}.controller.ts`;
+  let testPath  = `${names.kebabName}.controller.spec.ts`;
 
   if (existsSync('src/app/controllers')) {
     path = `src/app/controllers/${path}`;
+    testPath = `src/app/controllers/${testPath}`;
   } else if (existsSync('controllers')) {
     path = `controllers/${path}`;
+    testPath = `controllers/${testPath}`;
   }
 
   switch (type) {
     case 'Empty':
       renderTemplate('controller/controller.empty.ts', path, names);
+      renderTemplate('controller/controller.spec.empty.ts', testPath, names);
       break;
     case 'REST':
       renderTemplate('controller/controller.rest.ts', path, names);

--- a/packages/cli/src/generate/templates-spec/controller/test-foo-bar.controller.empty.ts
+++ b/packages/cli/src/generate/templates-spec/controller/test-foo-bar.controller.empty.ts
@@ -1,6 +1,11 @@
-import { Controller } from '@foal/core';
+import { Context, Controller, Get, HttpResponseOK } from '@foal/core';
 
 @Controller()
 export class TestFooBarController {
+
+  @Get('/')
+  foo(ctx: Context) {
+    return new HttpResponseOK();
+  }
 
 }

--- a/packages/cli/src/generate/templates-spec/controller/test-foo-bar.controller.spec.empty.ts
+++ b/packages/cli/src/generate/templates-spec/controller/test-foo-bar.controller.spec.empty.ts
@@ -1,0 +1,29 @@
+// std
+import { ok, strictEqual } from 'assert';
+
+// 3p
+import { createController, getHttpMethod, getPath, isHttpResponseOK } from '@foal/core';
+
+// App
+import { TestFooBarController } from './test-foo-bar.controller';
+
+describe('TestFooBarController', () => {
+
+  let controller: TestFooBarController;
+
+  beforeEach(() => controller = createController(TestFooBarController));
+
+  describe('has a "foo" method that', () => {
+
+    it('should handle requests at GET /.', () => {
+      strictEqual(getHttpMethod(TestFooBarController, 'foo'), 'GET');
+      strictEqual(getPath(TestFooBarController, 'foo'), '/');
+    });
+
+    it('should return an HttpResponseOK.', () => {
+      ok(isHttpResponseOK(controller.foo()));
+    });
+
+  });
+
+});

--- a/packages/cli/src/generate/templates/controller/controller.empty.ts
+++ b/packages/cli/src/generate/templates/controller/controller.empty.ts
@@ -1,6 +1,11 @@
-import { Controller } from '@foal/core';
+import { Context, Controller, Get, HttpResponseOK } from '@foal/core';
 
 @Controller()
 export class /* upperFirstCamelName */Controller {
+
+  @Get('/')
+  foo(ctx: Context) {
+    return new HttpResponseOK();
+  }
 
 }

--- a/packages/cli/src/generate/templates/controller/controller.spec.empty.ts
+++ b/packages/cli/src/generate/templates/controller/controller.spec.empty.ts
@@ -1,0 +1,29 @@
+// std
+import { ok, strictEqual } from 'assert';
+
+// 3p
+import { createController, getHttpMethod, getPath, isHttpResponseOK } from '@foal/core';
+
+// App
+import { /* upperFirstCamelName */Controller } from './/* kebabName */.controller';
+
+describe('/* upperFirstCamelName */Controller', () => {
+
+  let controller: /* upperFirstCamelName */Controller;
+
+  beforeEach(() => controller = createController(/* upperFirstCamelName */Controller));
+
+  describe('has a "foo" method that', () => {
+
+    it('should handle requests at GET /.', () => {
+      strictEqual(getHttpMethod(/* upperFirstCamelName */Controller, 'foo'), 'GET');
+      strictEqual(getPath(/* upperFirstCamelName */Controller, 'foo'), '/');
+    });
+
+    it('should return an HttpResponseOK.', () => {
+      ok(isHttpResponseOK(controller.foo()));
+    });
+
+  });
+
+});

--- a/packages/core/src/auth/authentication/login.controller.spec.ts
+++ b/packages/core/src/auth/authentication/login.controller.spec.ts
@@ -5,6 +5,7 @@ import { deepStrictEqual, ok, strictEqual } from 'assert';
 import {
   Context,
   Controller,
+  createController,
   getHttpMethod,
   getPath,
   HttpResponseBadRequest,
@@ -61,7 +62,7 @@ describe('LoginController', () => {
         }
       };
 
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       await controller.logout(ctx);
 
       deepStrictEqual(ctx.request.session, {});
@@ -71,7 +72,7 @@ describe('LoginController', () => {
       const ctx = new Context({});
       ctx.request.session = {};
 
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       await controller.logout(ctx);
     });
 
@@ -79,7 +80,7 @@ describe('LoginController', () => {
       const ctx = new Context({});
       ctx.request.session = {};
 
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       const response = await controller.logout(ctx);
 
       ok(response instanceof HttpResponseNoContent);
@@ -97,7 +98,7 @@ describe('LoginController', () => {
         };
       }
 
-      const controller = new ConcreteController2(new ServiceManager());
+      const controller = createController(ConcreteController2);
       const response = await controller.logout(ctx);
 
       ok(response instanceof HttpResponseRedirect);
@@ -143,7 +144,7 @@ describe('LoginController', () => {
         }
       });
 
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       const response = await controller.login(ctx);
 
       ok(response instanceof HttpResponseNotFound);
@@ -160,7 +161,7 @@ describe('LoginController', () => {
         },
       });
 
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       const response = await controller.login(ctx);
 
       ok(response instanceof HttpResponseBadRequest);
@@ -200,7 +201,7 @@ describe('LoginController', () => {
         },
       });
 
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       controller.login(ctx)
         .then(response => {
           if (response instanceof HttpResponseBadRequest) {
@@ -227,7 +228,7 @@ describe('LoginController', () => {
       }));
 
       it('should return an HttpResponseNoContent if redirect.success is undefined.', async () => {
-        const controller = new ConcreteController(new ServiceManager());
+        const controller = createController(ConcreteController);
         const response = await controller.login(ctx);
 
         ok(response instanceof HttpResponseNoContent);
@@ -244,7 +245,7 @@ describe('LoginController', () => {
           ];
         }
 
-        const controller = new ConcreteController2(new ServiceManager());
+        const controller = createController(ConcreteController2);
         const response = await controller.login(ctx);
 
         ok(response instanceof HttpResponseRedirect);
@@ -252,7 +253,7 @@ describe('LoginController', () => {
       });
 
       it('should create or update ctx.session.authentication to include the userId.', async () => {
-        const controller = new ConcreteController(new ServiceManager());
+        const controller = createController(ConcreteController);
         await controller.login(ctx);
 
         deepStrictEqual(ctx.request.session.authentication, {
@@ -284,7 +285,7 @@ describe('LoginController', () => {
       }));
 
       it('should return an HttpResponseUnauthorized if redirect.failure is undefined.', async () => {
-        const controller = new ConcreteController(new ServiceManager());
+        const controller = createController(ConcreteController);
         const response = await controller.login(ctx);
 
         ok(response instanceof HttpResponseUnauthorized);

--- a/packages/core/src/auth/authentication/login.controller.ts
+++ b/packages/core/src/auth/authentication/login.controller.ts
@@ -5,6 +5,7 @@ import * as Ajv from 'ajv';
 import {
   Class,
   Context,
+  Controller,
   Get,
   HttpResponseBadRequest,
   HttpResponseNoContent,
@@ -30,6 +31,7 @@ export function strategy(name: Strategy['name'],
   return { name, authenticatorClass, schema };
 }
 
+@Controller()
 export abstract class LoginController {
   redirect: { logout?: string, success?: string, failure?: string } | undefined;
   abstract strategies: Strategy[];

--- a/packages/core/src/common/controllers/rest.controller.spec.ts
+++ b/packages/core/src/common/controllers/rest.controller.spec.ts
@@ -5,6 +5,7 @@ import { deepStrictEqual, fail, ok, strictEqual } from 'assert';
 import {
   Context,
   Controller,
+  createController,
   getHttpMethod,
   getPath,
   HttpResponseCreated,
@@ -27,7 +28,7 @@ describe('RestController', () => {
   }
 
   it('has a getQuery method that should return an empty object', () => {
-    const controller = new ConcreteController(new ServiceManager());
+    const controller = createController(ConcreteController);
     deepStrictEqual(controller.getQuery(new Context({})), {});
   });
 
@@ -39,7 +40,7 @@ describe('RestController', () => {
     });
 
     it('should return a HttpResponseMethodNotAllowed.', () => {
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       ok(controller.delete() instanceof HttpResponseMethodNotAllowed);
     });
 
@@ -67,7 +68,7 @@ describe('RestController', () => {
         serializerClass = Serializer;
       }
 
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       ok(await controller.deleteById(new Context({})) instanceof HttpResponseNotImplemented);
     });
 
@@ -190,7 +191,7 @@ describe('RestController', () => {
         serializerClass = Serializer;
       }
 
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       ok(await controller.get(new Context({})) instanceof HttpResponseNotImplemented);
     });
 
@@ -257,7 +258,7 @@ describe('RestController', () => {
         serializerClass = Serializer;
       }
 
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       ok(await controller.getById(new Context({})) instanceof HttpResponseNotImplemented);
     });
 
@@ -366,7 +367,7 @@ describe('RestController', () => {
     });
 
     it('should return a HttpResponseMethodNotAllowed.', () => {
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       ok(controller.patch() instanceof HttpResponseMethodNotAllowed);
     });
 
@@ -394,7 +395,7 @@ describe('RestController', () => {
         serializerClass = Serializer;
       }
 
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       ok(await controller.patchById(new Context({})) instanceof HttpResponseNotImplemented);
     });
 
@@ -526,7 +527,7 @@ describe('RestController', () => {
         serializerClass = Serializer;
       }
 
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       ok(await controller.post(new Context({})) instanceof HttpResponseNotImplemented);
     });
 
@@ -570,7 +571,7 @@ describe('RestController', () => {
     });
 
     it('should return a HttpResponseMethodNotAllowed.', () => {
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       ok(controller.postById() instanceof HttpResponseMethodNotAllowed);
     });
 
@@ -584,7 +585,7 @@ describe('RestController', () => {
     });
 
     it('should return a HttpResponseMethodNotAllowed.', () => {
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       ok(controller.put() instanceof HttpResponseMethodNotAllowed);
     });
 
@@ -612,7 +613,7 @@ describe('RestController', () => {
         serializerClass = Serializer;
       }
 
-      const controller = new ConcreteController(new ServiceManager());
+      const controller = createController(ConcreteController);
       ok(await controller.putById(new Context({})) instanceof HttpResponseNotImplemented);
     });
 

--- a/packages/core/src/core/controllers.spec.ts
+++ b/packages/core/src/core/controllers.spec.ts
@@ -1,11 +1,12 @@
 // std
-import { strictEqual } from 'assert';
+import { ok, strictEqual } from 'assert';
 
 // 3p
 import 'reflect-metadata';
 
 // FoalTS
-import { Controller } from './controllers';
+import { Controller, createController } from './controllers';
+import { Service } from './service-manager';
 
 describe('Controller', () => {
 
@@ -15,6 +16,49 @@ describe('Controller', () => {
 
     const actual = Reflect.getOwnMetadata('path', Foobar);
     strictEqual(actual, '/foo');
+  });
+
+});
+
+describe('createController', () => {
+
+  it('should instantiate a controller (no dependencies).', () => {
+    @Controller()
+    class MyController {
+
+    }
+    const controller = createController(MyController);
+    ok(controller instanceof MyController);
+  });
+
+  it('should instantiate a controller with its dependencies.', () => {
+    @Service()
+    class MyService {}
+
+    @Controller()
+    class MyController {
+      constructor(public myService: MyService) {}
+    }
+    const controller = createController(MyController);
+    ok(controller instanceof MyController);
+    ok(controller.myService instanceof MyService);
+  });
+
+  it('should instantiate an inherited controller with its dependencies.', () => {
+    @Service()
+    class MyService {}
+
+    @Controller()
+    class MyController {
+      constructor(public myService: MyService) {}
+    }
+
+    @Controller()
+    class ChildController extends MyController {}
+
+    const controller = createController(ChildController);
+    ok(controller instanceof ChildController);
+    ok(controller.myService instanceof MyService);
   });
 
 });

--- a/packages/core/src/core/controllers.spec.ts
+++ b/packages/core/src/core/controllers.spec.ts
@@ -6,7 +6,7 @@ import 'reflect-metadata';
 
 // FoalTS
 import { Controller, createController } from './controllers';
-import { Service } from './service-manager';
+import { Service, ServiceManager } from './service-manager';
 
 describe('Controller', () => {
 
@@ -59,6 +59,22 @@ describe('createController', () => {
     const controller = createController(ChildController);
     ok(controller instanceof ChildController);
     ok(controller.myService instanceof MyService);
+  });
+
+  it('should instantiate a controller with its dependencies from the given ServiceManager.', () => {
+    @Service()
+    class MyService {}
+
+    @Controller()
+    class MyController {
+      constructor(public myService: MyService) {}
+    }
+    const services = new ServiceManager();
+    const service = services.get(MyService);
+
+    const controller = createController(MyController, services);
+    ok(controller instanceof MyController);
+    strictEqual(controller.myService, service);
   });
 
 });

--- a/packages/core/src/core/controllers.ts
+++ b/packages/core/src/core/controllers.ts
@@ -1,6 +1,19 @@
 // 3p
 import 'reflect-metadata';
 
+// FoalTS
+import { Class } from './class.interface';
+import { getMetadata } from './routes/utils';
+import { ServiceManager } from './service-manager';
+
 export function Controller(path?: string) {
   return Reflect.metadata('path', path);
+}
+
+export function createController<T>(controllerClass: Class<T>): T {
+  const controllerDependencies = getMetadata('design:paramtypes', controllerClass) as Class[] || [];
+  const services = new ServiceManager();
+  return new controllerClass(
+    ...controllerDependencies.map(serviceClass => services.get(serviceClass))
+  );
 }

--- a/packages/core/src/core/controllers.ts
+++ b/packages/core/src/core/controllers.ts
@@ -10,10 +10,12 @@ export function Controller(path?: string) {
   return Reflect.metadata('path', path);
 }
 
-export function createController<T>(controllerClass: Class<T>): T {
+export function createController<T>(controllerClass: Class<T>, services?: ServiceManager): T {
   const controllerDependencies = getMetadata('design:paramtypes', controllerClass) as Class[] || [];
-  const services = new ServiceManager();
+  if (!services) {
+    services = new ServiceManager();
+  }
   return new controllerClass(
-    ...controllerDependencies.map(serviceClass => services.get(serviceClass))
+    ...controllerDependencies.map(serviceClass => (services as ServiceManager).get(serviceClass))
   );
 }

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -1,5 +1,5 @@
 export * from './class.interface';
-export { Controller } from './controllers';
+export { createController, Controller } from './controllers';
 export * from './http';
 export * from './hooks';
 export * from './routes';

--- a/packages/core/src/core/routes/make-controller-routes.ts
+++ b/packages/core/src/core/routes/make-controller-routes.ts
@@ -1,5 +1,6 @@
 // FoalTS
 import { Class } from '../class.interface';
+import { createController } from '../controllers';
 import { HookFunction } from '../hooks';
 import { ServiceManager } from '../service-manager';
 import { Route } from './route.interface';
@@ -17,10 +18,7 @@ export function makeControllerRoutes(parentPath: string, parentHooks: HookFuncti
   const controllerHooks = getMetadata('hooks', controllerClass) as HookFunction[] || [];
   const controllerPath = getMetadata('path', controllerClass) as string|undefined;
 
-  const controllerDependencies = getMetadata('design:paramtypes', controllerClass) as Class[] || [];
-  const controller = new controllerClass(
-    ...controllerDependencies.map(serviceClass => services.get(serviceClass))
-  );
+  const controller = createController(controllerClass, services);
 
   getMethods(controllerClass.prototype).forEach(propertyKey => {
     if (propertyKey === 'constructor') { return; }


### PR DESCRIPTION
# Issue

Bug: controllers inheriting `LoginController` are not instantiated with their dependencies (the `ServiceManager`). This is because the `LoginController` does not have the `Controller` decorator.

This was not caught in the unit tests because the way the "testing child controller" is instantiated is different.

# Solution and steps

Create a `createController` util to handle the controller instantiation in the unit tests as well as in the FoalTS core.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.