### PR TITLE
 Support custom session store in create-app

### DIFF
--- a/docs/production/deployment-prod.md
+++ b/docs/production/deployment-prod.md
@@ -5,3 +5,5 @@ When deploying an application to production you need to:
 - set the `NODE_ENV` environment variable to `production`,
 - specify the name of your domain in `config/settings.production.json` with the property `sessionCookieDomain` (or use the env variable `SETTINGS_SESSION_COOKIE_DOMAIN` for that).
 - use database migrations instead of the TypeORM `synchronize` feature (it auto creates database schema on every application launch). You can disable this feature by setting the env variable `TYPEORM_SYNCHRONIZE` to false.
+
+If you want to use a redis or another DB to store your sessions, you can specify the express session store of your choice in `src/app/index.ts`. By default sessions are stored in the default sqlite database.

--- a/packages/cli/src/generate/templates-spec/app/package.1.json
+++ b/packages/cli/src/generate/templates-spec/app/package.1.json
@@ -27,6 +27,7 @@
     "@foal/ejs": "^0.6.0-alpha.3",
     "source-map-support": "^0.5.1",
     "sqlite3": "^4.0.0",
+    "connect-sqlite3": "^0.9.11",
     "typeorm": "^0.2.6"
   },
   "devDependencies": {

--- a/packages/cli/src/generate/templates-spec/app/src/index.1.ts
+++ b/packages/cli/src/generate/templates-spec/app/src/index.1.ts
@@ -3,10 +3,13 @@ import 'source-map-support/register';
 import * as http from 'http';
 
 import { Config, createApp } from '@foal/core';
+import * as sqliteStoreFactory from 'connect-sqlite3';
 
 import { AppModule } from './app/app.module';
 
-const app = createApp(AppModule);
+const app = createApp(AppModule, {
+  store: session => new sqliteStoreFactory(session)({ db: 'db.sqlite3' })
+});
 
 const httpServer = http.createServer(app);
 const port = Config.get('settings', 'port', 3000);

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -27,6 +27,7 @@
     "@foal/ejs": "^0.6.0-alpha.3",
     "source-map-support": "^0.5.1",
     "sqlite3": "^4.0.0",
+    "connect-sqlite3": "^0.9.11",
     "typeorm": "^0.2.6"
   },
   "devDependencies": {

--- a/packages/cli/src/generate/templates/app/src/index.ts
+++ b/packages/cli/src/generate/templates/app/src/index.ts
@@ -3,10 +3,13 @@ import 'source-map-support/register';
 import * as http from 'http';
 
 import { Config, createApp } from '@foal/core';
+import * as sqliteStoreFactory from 'connect-sqlite3';
 
 import { AppModule } from './app/app.module';
 
-const app = createApp(AppModule);
+const app = createApp(AppModule, {
+  store: session => new sqliteStoreFactory(session)({ db: 'db.sqlite3' })
+});
 
 const httpServer = http.createServer(app);
 const port = Config.get('settings', 'port', 3000);

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -1,4 +1,9 @@
+// std
+import { strictEqual } from 'assert';
+import { promisify } from 'util';
+
 // 3p
+import { MemoryStore } from 'express-session';
 import * as request from 'supertest';
 
 // FoalTS
@@ -79,21 +84,24 @@ describe('createApp', () => {
       .expect({ session: true });
   });
 
-  // TODO: Add tests.
+  it('should accept a custom session store.', async () => {
+    const store = new MemoryStore();
+    const app = createApp(class {}, {
+      store: session => {
+        strictEqual(typeof session, 'function');
+        return store;
+      }
+    });
+
+    let sessions = await promisify(store.all.bind(store))();
+    strictEqual(Object.keys(sessions).length, 0);
+
+    await  request(app).get('/foo');
+
+    sessions = await promisify(store.all.bind(store))();
+    strictEqual(Object.keys(sessions).length, 1);
+  });
 });
-
-// import * as express from 'express';
-// import * as request from 'supertest';
-
-// import { Controller, HttpMethod, HttpResponseOK } from '../core';
-
-// import { getAppRouter } from './get-app-router';
-
-// function route(httpMethod: HttpMethod, path: string, handler): Controller<'main'> {
-//   const controller = new Controller<'main'>();
-//   controller.addRoute('main', httpMethod, path, handler);
-//   return controller;
-// }
 
 // function httpMethodTest(httpMethod: HttpMethod) {
 //   describe(`when route.httpMethod === "${httpMethod}", route.path === "/foo/bar" and the route returns `

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -2,7 +2,7 @@
 import * as request from 'supertest';
 
 // FoalTS
-import { Context, HttpResponseOK, Post } from '../core';
+import { Context, Get, HttpResponseOK, Post } from '../core';
 import { createApp } from './create-app';
 
 describe('createApp', () => {
@@ -62,6 +62,21 @@ describe('createApp', () => {
       .post('/foo')
       .send('foo=bar')
       .expect({ body: { foo: 'bar' } });
+  });
+
+  it('should have sessions.', () => {
+    class MyController {
+      @Get('/foo')
+      post(ctx: Context) {
+        return new HttpResponseOK({ session: !!ctx.request.session });
+      }
+    }
+    const app = createApp(class {
+      controllers = [ MyController ];
+    });
+    return request(app)
+      .get('/foo')
+      .expect({ session: true });
   });
 
   // TODO: Add tests.

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -17,7 +17,11 @@ import { createMiddleware } from './create-middleware';
 import { handleErrors } from './handle-errors';
 import { notFound } from './not-found';
 
-export function createApp(rootModuleClass: Class<IModule>) {
+export interface CreateAppOptions {
+  store?(session): any;
+}
+
+export function createApp(rootModuleClass: Class<IModule>, options: CreateAppOptions = {}) {
   const app = express();
 
   app.use(logger('[:date] ":method :url HTTP/:http-version" :status - :response-time ms'));
@@ -37,6 +41,7 @@ export function createApp(rootModuleClass: Class<IModule>) {
     resave: Config.get('settings', 'sessionResave', false),
     saveUninitialized: Config.get('settings', 'sessionSaveUninitialized', true),
     secret: Config.get('settings', 'sessionSecret', 'default_secret'),
+    store: options.store ? options.store(session) : undefined,
   }));
 
   if (Config.get('settings', 'csrf', false) as boolean) {

--- a/packages/core/src/express/index.ts
+++ b/packages/core/src/express/index.ts
@@ -1,1 +1,1 @@
-export { createApp } from './create-app';
+export { createApp, CreateAppOptions } from './create-app';


### PR DESCRIPTION
# Issues

- Support custom session stores (https://github.com/FoalTS/foal/issues/107).
- When reloading the server, which happens every time during development, we loose the user authentication. We then have to log in again and again the user.

# Solution and steps

- [x] Support custom session store in create-app.
- [x] [@foal/cli] Generated apps use by default an sqlite3 session store to not loose the user authentication when reloading the server.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.