### PR TITLE
[@foal/cli] Make `User` entity and `scripts/create-users` consistent.

### DIFF
--- a/packages/cli/src/generate/templates-spec/app/scripts/create-users.1.ts
+++ b/packages/cli/src/generate/templates-spec/app/scripts/create-users.1.ts
@@ -8,12 +8,12 @@ async function main() {
   await createConnection();
 
   const user = new User();
-  user.email = 'john@foalts.org';
-  await user.setPassword('password');
+  // user.email = 'john@foalts.org';
+  // await user.setPassword('password');
 
   const user2 = new User();
-  user2.email = 'jack@foalts.org';
-  await user2.setPassword('password2');
+  // user2.email = 'jack@foalts.org';
+  // await user2.setPassword('password2');
 
   const permission = new Permission();
   permission.name = 'Admin permission';

--- a/packages/cli/src/generate/templates-spec/app/src/app/entities/user.entity.1.ts
+++ b/packages/cli/src/generate/templates-spec/app/src/app/entities/user.entity.1.ts
@@ -1,8 +1,20 @@
-import { AbstractUser } from '@foal/core';
-import { Entity } from 'typeorm';
+import { AbstractUser/*, parsePassword*/ } from '@foal/core';
+import { /*Column, */Entity } from 'typeorm';
 
 @Entity()
 export class User extends AbstractUser {
+
+  // @Column({ unique: true })
+  // // @ts-ignore : Property 'email' has no initializer and is not definitely assigned in theconstructor.
+  // email: string;
+
+  // @Column()
+  // // @ts-ignore : Property 'password' has no initializer and is not definitely assigned in theconstructor.
+  // password: string;
+
+  // async setPassword(password: string) {
+  //   this.password = await parsePassword(password);
+  // }
 
 }
 

--- a/packages/cli/src/generate/templates/app/scripts/create-users.ts
+++ b/packages/cli/src/generate/templates/app/scripts/create-users.ts
@@ -8,12 +8,12 @@ async function main() {
   await createConnection();
 
   const user = new User();
-  user.email = 'john@foalts.org';
-  await user.setPassword('password');
+  // user.email = 'john@foalts.org';
+  // await user.setPassword('password');
 
   const user2 = new User();
-  user2.email = 'jack@foalts.org';
-  await user2.setPassword('password2');
+  // user2.email = 'jack@foalts.org';
+  // await user2.setPassword('password2');
 
   const permission = new Permission();
   permission.name = 'Admin permission';

--- a/packages/cli/src/generate/templates/app/src/app/entities/user.entity.ts
+++ b/packages/cli/src/generate/templates/app/src/app/entities/user.entity.ts
@@ -1,8 +1,20 @@
-import { AbstractUser } from '@foal/core';
-import { Entity } from 'typeorm';
+import { AbstractUser/*, parsePassword*/ } from '@foal/core';
+import { /*Column, */Entity } from 'typeorm';
 
 @Entity()
 export class User extends AbstractUser {
+
+  // @Column({ unique: true })
+  // // @ts-ignore : Property 'email' has no initializer and is not definitely assigned in theconstructor.
+  // email: string;
+
+  // @Column()
+  // // @ts-ignore : Property 'password' has no initializer and is not definitely assigned in theconstructor.
+  // password: string;
+
+  // async setPassword(password: string) {
+  //   this.password = await parsePassword(password);
+  // }
 
 }
 


### PR DESCRIPTION
# Issue

Running the script `create-users.ts` fails since the `User` entity does not have an `email` property nor a `password`.

# Solution and steps

- Add an email and a password in `user.entity.ts`.
- Comment the lines mentioning any email or password (in both files).

**Note:** Requires also the export fix in https://github.com/FoalTS/foal/pull/173.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.