### PR TITLE
Make render use template paths.

### DIFF
--- a/docs/cookbook/template-engine.md
+++ b/docs/cookbook/template-engine.md
@@ -2,15 +2,20 @@
 
 FoalTS comes up with several tools to render templates.
 
-## `render(template: string, locals?: object): HttpResponseOK`
+## `render(templatePath: string, locals: object, dirname: string): HttpResponseOK`
 
 Renders the template with the given locals and then returns an `HttpResponeOK` whose content is the rendered template.
+
+Example:
+```typescript
+render('./templates/my-template.html', { title: 'foobar' }, __dirname);
+```
 
 ## Using a different template engine
 
 By default FoalTS uses [ejs](http://ejs.co/) as template engine but you can use a different one.
 
-To do so, you need to create a package that exports a function `renderToString(template: string, locals?: object): string` and then to add your package name in `config/settings.js` as follows:
+To do so, you need to create a package that exports a function `renderToString(template: string, locals: object): string` and then to add your package name in `config/settings.js` as follows:
 
 ```json
 {

--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -73,8 +73,6 @@ import { Controller, emailSchema, Get, LoginController, render, strategy } from 
 
 import { Authenticator } from '../services/authenticator.service';
 
-const login = readFileSync(join(__dirname, './templates/login.html'), 'utf8');
-
 @Controller()
 export class AuthController extends LoginController {
   strategies = [
@@ -89,7 +87,7 @@ export class AuthController extends LoginController {
 
   @Get('/login')
   renderLogin(ctx) {
-    return render(login, { csrfToken: ctx.request.csrfToken() });
+    return render('./templates/login.html', { csrfToken: ctx.request.csrfToken() }, __dirname);
   }
 }
 ```

--- a/docs/security/csrf-protection.md
+++ b/docs/security/csrf-protection.md
@@ -10,15 +10,13 @@ You can get the csrf token by calling the `csrfToken` method of the context `req
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
-const index = readFileSync(join(__dirname, './templates/index.html'), 'utf8'); 
-
 @Controller()
 export class ViewController {
   @Get('/')
   index(ctx) {
-    return render(index, {
+    return render('./templates/index.html', {
       csrfToken: ctx.request.csrfToken()
-    });
+    }, __dirname);
   }
 }
 ```

--- a/packages/cli/src/generate/generators/app/create-app.spec.ts
+++ b/packages/cli/src/generate/generators/app/create-app.spec.ts
@@ -37,7 +37,6 @@ describe('createApp', () => {
 
     // Src
     rmfileIfExists('test-foo-bar/src/app/controllers/templates/index.html');
-    rmfileIfExists('test-foo-bar/src/app/controllers/templates/index.ts');
     rmdirIfExists('test-foo-bar/src/app/controllers/templates');
 
     rmfileIfExists('test-foo-bar/src/app/controllers/index.ts');
@@ -164,12 +163,8 @@ describe('createApp', () => {
 
   it('should render the src/app/controllers/templates templates.', () => {
 
-    let expected = readFileFromTemplatesSpec('app/src/app/controllers/templates/index.1.html');
-    let actual = readFileFromRoot('test-foo-bar/src/app/controllers/templates/index.html');
-    strictEqual(actual, expected);
-
-    expected = readFileFromTemplatesSpec('app/src/app/controllers/templates/index.1.ts');
-    actual = readFileFromRoot('test-foo-bar/src/app/controllers/templates/index.ts');
+    const expected = readFileFromTemplatesSpec('app/src/app/controllers/templates/index.1.html');
+    const actual = readFileFromRoot('test-foo-bar/src/app/controllers/templates/index.html');
     strictEqual(actual, expected);
 
   });

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -86,10 +86,6 @@ export function createApp({ name, sessionSecret }:
     'app/src/app/controllers/templates/index.html',
     `${names.kebabName}/src/app/controllers/templates/index.html`
   );
-  copyFileFromTemplates(
-    'app/src/app/controllers/templates/index.ts',
-    `${names.kebabName}/src/app/controllers/templates/index.ts`
-  );
 
   mkdirIfNotExists(`${names.kebabName}/src/app/hooks`);
   copyFileFromTemplates('app/src/app/hooks/index.ts', `${names.kebabName}/src/app/hooks/index.ts`);

--- a/packages/cli/src/generate/generators/module/create-module.spec.ts
+++ b/packages/cli/src/generate/generators/module/create-module.spec.ts
@@ -83,7 +83,7 @@ describe('createModule', () => {
 
   });
 
-  describe('should create the controllers directory.', () => {
+  describe('should render the controllers templates.', () => {
 
     function test(prefix = '') {
       createModule({ name: 'test-fooBar' });

--- a/packages/cli/src/generate/generators/module/create-module.spec.ts
+++ b/packages/cli/src/generate/generators/module/create-module.spec.ts
@@ -1,5 +1,6 @@
 // std
 import { strictEqual } from 'assert';
+import { existsSync } from 'fs';
 
 // FoalTS
 import {
@@ -12,7 +13,6 @@ import {
 import { createModule } from './create-module';
 
 function removeFiles(prefix: string = '') {
-  rmfileIfExists(`${prefix}test-foo-bar/controllers/templates/index.ts`);
   rmdirIfExists(`${prefix}test-foo-bar/controllers/templates`);
   rmfileIfExists(`${prefix}test-foo-bar/controllers/index.ts`);
   rmdirIfExists(`${prefix}test-foo-bar/controllers`);
@@ -83,7 +83,7 @@ describe('createModule', () => {
 
   });
 
-  describe('should render the controllers templates.', () => {
+  describe('should create the controllers directory.', () => {
 
     function test(prefix = '') {
       createModule({ name: 'test-fooBar' });
@@ -223,14 +223,14 @@ describe('createModule', () => {
 
   });
 
-  describe('should render the templates templates.', () => {
+  describe('should create the controllers/templates directory.', () => {
 
     function test(prefix = '') {
       createModule({ name: 'test-fooBar' });
 
-      const expected = readFileFromTemplatesSpec('module/controllers/templates/index.1.ts');
-      const actual = readFileFromRoot(`${prefix}test-foo-bar/controllers/templates/index.ts`);
-      strictEqual(actual, expected);
+      if (!existsSync(`${prefix}test-foo-bar/controllers/templates`)) {
+        throw new Error('The controllers/templates directory should be created.');
+      }
     }
 
     it('in src/app/sub-modules/ if the directory exists.', () => {

--- a/packages/cli/src/generate/generators/module/create-module.ts
+++ b/packages/cli/src/generate/generators/module/create-module.ts
@@ -24,10 +24,6 @@ export function createModule({ name }: { name: string }) {
   mkdirIfNotExists(`${prefix}${names.kebabName}/controllers`);
   copyFileFromTemplates('module/controllers/index.ts', `${prefix}${names.kebabName}/controllers/index.ts`);
   mkdirIfNotExists(`${prefix}${names.kebabName}/controllers/templates`);
-  copyFileFromTemplates(
-    'module/controllers/templates/index.ts',
-    `${prefix}${names.kebabName}/controllers/templates/index.ts`,
-  );
   mkdirIfNotExists(`${prefix}${names.kebabName}/hooks`);
   copyFileFromTemplates('module/hooks/index.ts', `${prefix}${names.kebabName}/hooks/index.ts`);
 

--- a/packages/cli/src/generate/templates-spec/app/src/app/controllers/templates/index.1.ts
+++ b/packages/cli/src/generate/templates-spec/app/src/app/controllers/templates/index.1.ts
@@ -1,5 +1,0 @@
-// std
-import { readFileSync } from 'fs';
-import { join } from 'path';
-
-export const index = readFileSync(join(__dirname, './index.html'), 'utf8');

--- a/packages/cli/src/generate/templates-spec/app/src/app/controllers/view.controller.1.ts
+++ b/packages/cli/src/generate/templates-spec/app/src/app/controllers/view.controller.1.ts
@@ -1,16 +1,14 @@
 import { Config, Controller, Get, render } from '@foal/core';
 
-import { index } from './templates';
-
 @Controller()
 export class ViewController {
 
   @Get()
   index(ctx) {
-    return render(index, {
+    return render('./templates/index.html', {
       appName: Config.get('app', 'name'),
       csrfToken: ctx.request.csrfToken(),
-    });
+    }, __dirname);
   }
 
 }

--- a/packages/cli/src/generate/templates/app/src/app/controllers/templates/index.ts
+++ b/packages/cli/src/generate/templates/app/src/app/controllers/templates/index.ts
@@ -1,5 +1,0 @@
-// std
-import { readFileSync } from 'fs';
-import { join } from 'path';
-
-export const index = readFileSync(join(__dirname, './index.html'), 'utf8');

--- a/packages/cli/src/generate/templates/app/src/app/controllers/view.controller.ts
+++ b/packages/cli/src/generate/templates/app/src/app/controllers/view.controller.ts
@@ -1,16 +1,14 @@
 import { Config, Controller, Get, render } from '@foal/core';
 
-import { index } from './templates';
-
 @Controller()
 export class ViewController {
 
   @Get()
   index(ctx) {
-    return render(index, {
+    return render('./templates/index.html', {
       appName: Config.get('app', 'name'),
       csrfToken: ctx.request.csrfToken(),
-    });
+    }, __dirname);
   }
 
 }

--- a/packages/core/src/common/utils/render.util.spec.ts
+++ b/packages/core/src/common/utils/render.util.spec.ts
@@ -1,31 +1,44 @@
 // std
 import { ok, strictEqual, throws } from 'assert';
+import { existsSync, mkdirSync, rmdirSync, unlinkSync, writeFileSync } from 'fs';
+import { join } from 'path';
 
 // FoalTS
 import { HttpResponseOK } from '../../core';
 import { render } from './render.util';
 
-const template1 = 'Hi!';
-const template2 = 'Hello <%= name %>! How are you?';
+const template = 'Hello <%= name %>! How are you?';
 
 describe('render', () => {
+  const templatesPath = join(__dirname, './templates');
+  const templatePath = join(__dirname, './templates/template.html');
 
-  it('should return the ejs template (HttpResponseOK) with no locals if it is correct.', () => {
-    const actual = render(template1);
-    ok(actual instanceof HttpResponseOK);
-    strictEqual(actual.content, template1);
+  before(() => {
+    if (!existsSync(templatesPath)) {
+      mkdirSync(templatesPath);
+    }
+    writeFileSync(templatePath, template, 'utf8');
+  });
+
+  after(() => {
+    if (existsSync(templatePath)) {
+      unlinkSync(templatePath);
+    }
+    if (existsSync(templatesPath)) {
+      rmdirSync(templatesPath);
+    }
   });
 
   it('should render the ejs template (HttpResponseOK) with the given locals if it is correct.', () => {
     const name = 'Foobar';
     const expected = `Hello ${name}! How are you?`;
-    const actual = render(template2, { name });
+    const actual = render('./templates/template.html', { name }, __dirname);
     ok(actual instanceof HttpResponseOK);
     strictEqual(actual.content, expected);
   });
 
   it('should throw an Error if the template and/or locals are incorrect.', () => {
-    throws(() => render(template2, {}));
+    throws(() => render(templatePath, {}, __dirname));
   });
 
 });

--- a/packages/core/src/common/utils/render.util.ts
+++ b/packages/core/src/common/utils/render.util.ts
@@ -1,10 +1,16 @@
+// std
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// FoalTS
 import { Config, HttpResponseOK } from '../../core';
 
-export function render(template: string, locals?: object): HttpResponseOK {
+export function render(templatePath: string, locals: object, dirname: string): HttpResponseOK {
   const templateEngine = Config.get('settings', 'templateEngine', '@foal/ejs') as string;
   const { renderToString } = require(templateEngine);
   if (!renderToString) {
     throw new Error(`${templateEngine} is not a template engine.`);
   }
+  const template = readFileSync(join(dirname, templatePath), 'utf8');
   return new HttpResponseOK(renderToString(template, locals));
 }

--- a/packages/ejs/src/index.spec.ts
+++ b/packages/ejs/src/index.spec.ts
@@ -6,21 +6,16 @@ import { renderToString } from './index';
 
 describe('renderToString', () => {
 
-  const template1 = 'Hi!';
-  const template2 = 'Hello <%= name %>! How are you?';
-
-  it('should return the ejs template with no locals if it is correct.', () => {
-    strictEqual(renderToString(template1), template1);
-  });
+  const template = 'Hello <%= name %>! How are you?';
 
   it('should render the ejs template with the given locals if it is correct.', () => {
     const name = 'Foobar';
     const expected = `Hello ${name}! How are you?`;
-    strictEqual(renderToString(template2, { name }), expected);
+    strictEqual(renderToString(template, { name }), expected);
   });
 
   it('should throw an Error if the template and/or locals are incorrect.', () => {
-    throws(() => renderToString(template2, {}));
+    throws(() => renderToString(template, {}));
   });
 
 });

--- a/packages/ejs/src/index.ts
+++ b/packages/ejs/src/index.ts
@@ -6,6 +6,6 @@
 
 import { render } from 'ejs';
 
-export function renderToString(template: string, locals?: object): string {
+export function renderToString(template: string, locals: object): string {
   return render(template, locals);
 }

--- a/packages/examples/src/app/controllers/auth.controller.ts
+++ b/packages/examples/src/app/controllers/auth.controller.ts
@@ -1,7 +1,6 @@
 import { Context, Controller, emailSchema, Get, LoginController, render, strategy } from '@foal/core';
 
 import { Authenticator } from '../services/authenticator.service';
-import { login } from './templates';
 
 @Controller()
 export class AuthController extends LoginController {
@@ -16,6 +15,6 @@ export class AuthController extends LoginController {
 
   @Get('/login')
   renderLogin(ctx: Context) {
-    return render(login, { csrfToken: ctx.request.csrfToken() });
+    return render('./templates/login.html', { csrfToken: ctx.request.csrfToken() }, __dirname);
   }
 }

--- a/packages/examples/src/app/controllers/templates/index.ts
+++ b/packages/examples/src/app/controllers/templates/index.ts
@@ -1,7 +1,0 @@
-// std
-import { readFileSync } from 'fs';
-import { join } from 'path';
-
-export const home = readFileSync(join(__dirname, './home.html'), 'utf8');
-export const admin = readFileSync(join(__dirname, './admin.html'), 'utf8');
-export const login = readFileSync(join(__dirname, './login.html'), 'utf8');

--- a/packages/examples/src/app/controllers/view.controller.ts
+++ b/packages/examples/src/app/controllers/view.controller.ts
@@ -1,24 +1,22 @@
 import { Context, Controller, Get, LoginRequired, PermissionRequired, render } from '@foal/core';
 
-import { admin, home } from './templates';
-
 @Controller()
 export class ViewController {
 
   @Get('/')
   @LoginRequired({ redirect: '/login' })
   home(ctx: Context) {
-    return render(home, {
+    return render('./templates/home.html', {
       csrfToken: ctx.request.csrfToken()
-    });
+    }, __dirname);
   }
 
   @Get('/admin')
   @PermissionRequired('admin', { redirect: '/login' })
   admin(ctx: Context) {
-    return render(admin, {
+    return render('./templates/admin.html', {
       csrfToken: ctx.request.csrfToken()
-    });
+    }, __dirname);
   }
 
 }


### PR DESCRIPTION
# Issue

Be able to specify the template path in `render` to not write `readFileSync(join(__dirname, './templates/index.html'), 'utf8')` (https://github.com/FoalTS/foal/issues/179).

# Solution and steps

Use this interface:
```typescript
render(templatePath: string, locals: object, dirname: string): HttpResponseOK;
```

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.