### PR TITLE
Add validate util and add it by default when generating an `EntityResourceCollection`

### DIFF
--- a/docs/cookbook/validation.md
+++ b/docs/cookbook/validation.md
@@ -1,8 +1,40 @@
 # Validation
 
-`ValidateBody` and `ValidateQuery` are hooks to control the body and the query of the requests received by the server. [Ajv](https://github.com/epoberezkin/ajv), a fast JSON Schema Validator, validates the `context.request.body` with the given schema. If the validation fails then an `HttpResponseBadRequest` is returned with the validation errors as `content`.
+Data sent from client side cannot be trusted. This document shows you different tools to perform server side input validation.
 
-You can provide your own instance of Ajv.
+## Ajv, the JSON Schema Validator
+
+FoalTS validation is based on [Ajv](https://github.com/epoberezkin/ajv), a fast JSON Schema Validator. You'll find more details on how to define a shema on its [website](http://epoberezkin.github.io/ajv/). 
+
+
+## The `validate` util
+
+The `validate` util throws a `ValidationError` if the given data does not fit the shema.
+
+*Example*
+```typescript
+import { validate } from '@foal/core';
+
+const schema ={
+  properties: {
+    a: { type: 'number' }
+  }
+  type: 'object'
+};
+const data = {
+  a: 'foo'
+};
+
+validate(schema, data);
+// => Throws an error (ValidationError)
+// => error.content contains the details of the validation error.
+```
+
+## The `ValidateBody` and `ValidateQuery` hooks
+
+`ValidateBody` and `ValidateQuery` are hooks to control the body and the query of the requests received by the server. They validate the `context.request.body` with the given schema. If the validation fails then an `HttpResponseBadRequest` is returned with the validation errors as `content`.
+
+Note: You can provide your own instance of Ajv.
 
 *Example*:
 ```typescript
@@ -29,4 +61,4 @@ export class MyController {
 
 ```
 
-Please visit [the official Ajv website](http://epoberezkin.github.io/ajv/) to learn more on Ajv.
+

--- a/docs/guide/4-rest-api-endpoint.md
+++ b/docs/guide/4-rest-api-endpoint.md
@@ -37,10 +37,21 @@ foal g service flight
 > EntityResourceCollection
 ```
 
+A new file is generated. Open it and complete the schema definition.
+
 ```typescript
 import { EntityResourceCollection, Service } from '@foal/core';
 
 import { Flight } from '../entities';
+
+const schema = {
+  additionalProperties: false,
+  properties: {
+    destination: { type: 'string' }
+  },
+  required: [ 'destination' ],
+  type: 'object',
+};
 
 @Service()
 export class FlightCollection extends EntityResourceCollection {
@@ -48,11 +59,15 @@ export class FlightCollection extends EntityResourceCollection {
   allowedOperations: EntityResourceCollection['allowedOperations'] = [
     'create', 'findById', 'find', 'modifyById', 'updateById', 'deleteById'
   ];
+
+  middlewares = [
+    middleware('create|modifyById|updateById', ({ data }) => validate(schema, data))
+  ];
 }
 
 ```
 
-Here is your collection. Now you need to register your REST controller. Open `src/app/app.module.ts` and add the "flight" line:
+Now you need to register your REST controller. Open `src/app/app.module.ts` and add the "flight" line:
 
 ```typescript
 import { controller, IModule, Module } from '@foal/core';

--- a/packages/cli/src/generate/specs/service/test-foo-bar.service.entity-resource-collection.ts
+++ b/packages/cli/src/generate/specs/service/test-foo-bar.service.entity-resource-collection.ts
@@ -1,6 +1,15 @@
-import { EntityResourceCollection, Service } from '@foal/core';
+import { EntityResourceCollection, middleware, Service, validate } from '@foal/core';
 
 import { TestFooBar } from '../entities';
+
+const schema = {
+  additionalProperties: false,
+  properties: {
+    // To complete
+  },
+  required: [ /* To complete */ ],
+  type: 'object',
+};
 
 @Service()
 export class TestFooBarCollection extends EntityResourceCollection {
@@ -8,5 +17,9 @@ export class TestFooBarCollection extends EntityResourceCollection {
   entityClass = TestFooBar;
   allowedOperations: EntityResourceCollection['allowedOperations'] = [
     'create', 'findById', 'find', 'modifyById', 'updateById', 'deleteById'
+  ];
+
+  middlewares = [
+    middleware('create|modifyById|updateById', ({ data }) => validate(schema, data))
   ];
 }

--- a/packages/cli/src/generate/templates/service/service.entity-resource-collection.ts
+++ b/packages/cli/src/generate/templates/service/service.entity-resource-collection.ts
@@ -1,6 +1,15 @@
-import { EntityResourceCollection, Service } from '@foal/core';
+import { EntityResourceCollection, middleware, Service, validate } from '@foal/core';
 
 import { /* upperFirstCamelName */ } from '../entities';
+
+const schema = {
+  additionalProperties: false,
+  properties: {
+    // To complete
+  },
+  required: [ /* To complete */ ],
+  type: 'object',
+};
 
 @Service()
 export class /* upperFirstCamelName */Collection extends EntityResourceCollection {
@@ -8,5 +17,9 @@ export class /* upperFirstCamelName */Collection extends EntityResourceCollectio
   entityClass = /* upperFirstCamelName */;
   allowedOperations: EntityResourceCollection['allowedOperations'] = [
     'create', 'findById', 'find', 'modifyById', 'updateById', 'deleteById'
+  ];
+
+  middlewares = [
+    middleware('create|modifyById|updateById', ({ data }) => validate(schema, data))
   ];
 }

--- a/packages/core/src/common/utils/index.ts
+++ b/packages/core/src/common/utils/index.ts
@@ -3,3 +3,4 @@ export { escapeProp } from './escape-prop';
 export { escape } from './escape';
 export { render } from './render.util';
 export { subModule } from './sub-module.util';
+export { validate } from './validate.util';

--- a/packages/core/src/common/utils/validate.util.spec.ts
+++ b/packages/core/src/common/utils/validate.util.spec.ts
@@ -1,5 +1,5 @@
 // std
-import { deepStrictEqual, doesNotThrow, ok, throws } from 'assert';
+import { deepStrictEqual, doesNotThrow, throws } from 'assert';
 
 // FoalTS
 import { ValidationError } from '../errors';

--- a/packages/core/src/common/utils/validate.util.spec.ts
+++ b/packages/core/src/common/utils/validate.util.spec.ts
@@ -1,0 +1,45 @@
+// std
+import { deepStrictEqual, doesNotThrow, ok, throws } from 'assert';
+
+// FoalTS
+import { ValidationError } from '../errors';
+import { validate } from './validate.util';
+
+describe('validate', () => {
+
+  const schema = {
+    properties: {
+      a: { type: 'number' }
+    },
+    type: 'object',
+  };
+
+  it('should throw a ValidationError if the schema does not valid the object.', () => {
+    const object = {
+      a: 'foo'
+    };
+
+    throws(() => validate(schema, object), ValidationError);
+    throws(() => validate(schema, object), err => {
+      deepStrictEqual(err.content, [
+        {
+          dataPath: '.a',
+          keyword: 'type',
+          message: 'should be number',
+          params: { type: 'number' },
+          schemaPath: '#/properties/a/type',
+        }
+      ]);
+      return true;
+    });
+  });
+
+  it('should do nothing if the schema validate the object.', () => {
+    const object = {
+      a: 3
+    };
+
+    doesNotThrow(() => validate(schema, object));
+  });
+
+});

--- a/packages/core/src/common/utils/validate.util.ts
+++ b/packages/core/src/common/utils/validate.util.ts
@@ -1,0 +1,13 @@
+// 3p
+import * as Ajv from 'ajv';
+
+// FoalTS
+import { ValidationError } from '../errors';
+
+const ajv = new Ajv();
+
+export function validate(schema: object, data: any) {
+  if (!ajv.validate(schema, data)) {
+    throw new ValidationError(ajv.errors);
+  }
+}


### PR DESCRIPTION
# Issue

- Schema validation should be done in the blink of an eye.
- Currently there is no "get started" to properly use an `EntityResourceCollection` with data validation.

# Solution and steps

- [x] Create the `validate` util.
- [x] Add `validate` to the generated `EntityResourceCollection`.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.