### PR TITLE
[Internal] Add e2e tests in Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log
 lerna-debug.log
 .nyc_output/
 coverage/
+e2e-test-temp
 
 lib/
 .vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 install:
   - npm install
   - lerna bootstrap
-  - cd packages/cli && npm link
+  - cd packages/cli && npm link && cd ../..
 
 script:
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ script:
   - npm run lint
   - lerna run test
   - lerna run e2e
+  - ./e2e_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,12 @@ before_script:
 
 before_install:
   - npm install -g lerna
+  - npm install -g pm2
 
 install:
   - npm install
   - lerna bootstrap
+  - cd packages/cli && npm link
 
 script:
   - npm run lint

--- a/docs/the-authentication-system/permissions-and-authorization.md
+++ b/docs/the-authentication-system/permissions-and-authorization.md
@@ -27,8 +27,8 @@ The `PermissionRequired(perm: string)` hook returns a `403 Forbidden` if the use
 ```sh
 npm run build
 
-node lib/scripts/create-permission name="My first permission" codeName="my-first-perm"
-node lib/scripts/create-permission name="My second permission" codeName="my-second-perm"
+node lib/scripts/create-perm name="My first permission" codeName="my-first-perm"
+node lib/scripts/create-perm name="My second permission" codeName="my-second-perm"
 
 node lib/scripts/create-group name="My group" codeName="my-group" permissions='[ "my-second-perm" ]'
 

--- a/docs/the-authentication-system/permissions-and-authorization.md
+++ b/docs/the-authentication-system/permissions-and-authorization.md
@@ -25,7 +25,7 @@ The `PermissionRequired(perm: string)` hook returns a `403 Forbidden` if the use
 ## Create permissions, groups and users with the shell scripts.
 
 ```sh
-npm run script
+npm run build
 
 node lib/scripts/create-permission name="My first permission" codeName="my-first-perm"
 node lib/scripts/create-permission name="My second permission" codeName="my-second-perm"

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -1,0 +1,37 @@
+mkdir e2e-test-temp
+cd e2e-test-temp
+
+# Test app creation
+foal createapp my-app
+cd my-app
+npm install
+
+# Test linting
+npm run lint
+
+# Test building
+npm run build
+npm run build:test
+
+# Run the generated unit tests
+npm run start:test
+
+# Test the application when it is started
+pm2 start lib/index.js
+sleep 1
+response=$(
+    curl http://localhost:3000 \
+        --write-out %{http_code} \
+        --silent \
+        --output /dev/null \
+)
+test "$response" -ge 200 && test "$response" -le 299
+pm2 delete index
+
+# Test the default shell scripts to create permissions, groups and users.
+node lib/scripts/create-perm name="My first permission" codeName="my-first-perm"
+node lib/scripts/create-perm name="My second permission" codeName="my-second-perm"
+
+node lib/scripts/create-group name="My group" codeName="my-group" permissions='[ "my-second-perm" ]'
+
+node lib/scripts/create-user userPermissions='[ "my-first-perm" ]' groups='[ "my-group" ]'

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,8 +5,8 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "scripts": {
-    "test": "NODE_ENV=test mocha --require ts-node/register \"./src/**/*.spec.ts\"",
-    "dev:test": "NODE_ENV=test mocha --require ts-node/register --watch --watch-extensions ts \"./src/**/*.spec.ts\"",
+    "test": "NODE_ENV=test mocha --require ts-node/register \"./src/generate/generators/**/*.spec.ts\"",
+    "dev:test": "NODE_ENV=test mocha --require ts-node/register --watch --watch-extensions ts \"./src/generate/generators/**/*.spec.ts\"",
     "build": "rimraf lib && tsc -p tsconfig-build.json && copyfiles -u 3 \"src/generate/templates/**/*\" lib/generate/templates",
     "prepublish": "npm run build"
   },

--- a/packages/cli/src/generate/generators/app/create-app.spec.ts
+++ b/packages/cli/src/generate/generators/app/create-app.spec.ts
@@ -34,6 +34,7 @@ describe('createApp', () => {
     testEnv.rmdirIfExists('src/app/controllers/templates');
 
     testEnv.rmfileIfExists('src/app/controllers/index.ts');
+    testEnv.rmfileIfExists('src/app/controllers/view.controller.spec.ts');
     testEnv.rmfileIfExists('src/app/controllers/view.controller.ts');
     testEnv.rmdirIfExists('src/app/controllers');
 
@@ -91,6 +92,7 @@ describe('createApp', () => {
   it('should render the src/app/controllers templates.', () => {
     testEnv
       .validateSpec('src/app/controllers/index.ts')
+      .validateSpec('src/app/controllers/view.controller.spec.ts')
       .validateSpec('src/app/controllers/view.controller.ts');
   });
 

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -60,6 +60,7 @@ export function createApp({ name, sessionSecret }:
           .mkdirIfDoesNotExist('src/app/controllers')
           .copyFileFromTemplates('src/app/controllers/index.ts')
           .copyFileFromTemplates('src/app/controllers/view.controller.ts')
+          .copyFileFromTemplates('src/app/controllers/view.controller.spec.ts')
             // Templates
             .mkdirIfDoesNotExist('src/app/controllers/templates')
             .copyFileFromTemplates('src/app/controllers/templates/index.html')

--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -3,13 +3,13 @@
   "version": "0.0.0",
   "description": "",
   "scripts": {
-    "build": "tsc -p tsconfig.app.json && copy-cli \"src/**/*.html\" lib",
+    "build": "copy-cli \"src/**/*.html\" lib && tsc -p tsconfig.app.json",
     "build:w": "tsc -p tsconfig.app.json -w",
     "start": "node ./lib/index.js",
     "start:w": "supervisor -w ./lib --no-restart-on error ./lib/index.js",
     "develop": "npm run build && concurrently \"npm run build:w\" \"npm run start:w\"",
 
-    "build:test": "tsc && copy-cli \"src/**/*.html\" lib",
+    "build:test": "copy-cli \"src/**/*.html\" lib && tsc",
     "build:test:w": "tsc -w",
     "start:test": "mocha \"./lib/**/*.spec.js\"",
     "start:test:w": "mocha -w \"./lib/**/*.spec.js\"",

--- a/packages/cli/src/generate/specs/app/src/app/controllers/view.controller.spec.ts
+++ b/packages/cli/src/generate/specs/app/src/app/controllers/view.controller.spec.ts
@@ -1,0 +1,29 @@
+// std
+import { ok, strictEqual } from 'assert';
+
+// 3p
+import { Context, createController, getHttpMethod, getPath, HttpResponseOk } from '@foal/core';
+
+// App
+import { ViewController } from './view.controller';
+
+describe('ViewController', () => {
+
+  describe('has a "index" method that', () => {
+
+    it('should handle requests at Get /.', () => {
+      strictEqual(getHttpMethod(ViewController, 'index'), 'GET');
+      strictEqual(getPath(ViewController, 'index'), '/');
+    });
+
+    it('should return a HttpResponseOk.', () => {
+      const controller = createController(ViewController);
+      const ctx = new Context({
+        csrfToken: () => {}
+      });
+      ok(controller.index(ctx) instanceof HttpResponseOk);
+    });
+
+  });
+
+});

--- a/packages/cli/src/generate/specs/app/src/app/controllers/view.controller.spec.ts
+++ b/packages/cli/src/generate/specs/app/src/app/controllers/view.controller.spec.ts
@@ -2,7 +2,7 @@
 import { ok, strictEqual } from 'assert';
 
 // 3p
-import { Context, createController, getHttpMethod, getPath, HttpResponseOk } from '@foal/core';
+import { Context, createController, getHttpMethod, getPath, HttpResponseOK } from '@foal/core';
 
 // App
 import { ViewController } from './view.controller';
@@ -16,12 +16,12 @@ describe('ViewController', () => {
       strictEqual(getPath(ViewController, 'index'), '/');
     });
 
-    it('should return a HttpResponseOk.', () => {
+    it('should return a HttpResponseOK.', () => {
       const controller = createController(ViewController);
       const ctx = new Context({
         csrfToken: () => {}
       });
-      ok(controller.index(ctx) instanceof HttpResponseOk);
+      ok(controller.index(ctx) instanceof HttpResponseOK);
     });
 
   });

--- a/packages/cli/src/generate/specs/app/src/app/controllers/view.controller.ts
+++ b/packages/cli/src/generate/specs/app/src/app/controllers/view.controller.ts
@@ -3,7 +3,7 @@ import { Config, Controller, Get, render } from '@foal/core';
 @Controller()
 export class ViewController {
 
-  @Get()
+  @Get('/')
   index(ctx) {
     return render('./templates/index.html', {
       appName: Config.get('app', 'name'),

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -3,13 +3,13 @@
   "version": "0.0.0",
   "description": "",
   "scripts": {
-    "build": "tsc -p tsconfig.app.json && copy-cli \"src/**/*.html\" lib",
+    "build": "copy-cli \"src/**/*.html\" lib && tsc -p tsconfig.app.json",
     "build:w": "tsc -p tsconfig.app.json -w",
     "start": "node ./lib/index.js",
     "start:w": "supervisor -w ./lib --no-restart-on error ./lib/index.js",
     "develop": "npm run build && concurrently \"npm run build:w\" \"npm run start:w\"",
 
-    "build:test": "tsc && copy-cli \"src/**/*.html\" lib",
+    "build:test": "copy-cli \"src/**/*.html\" lib && tsc",
     "build:test:w": "tsc -w",
     "start:test": "mocha \"./lib/**/*.spec.js\"",
     "start:test:w": "mocha -w \"./lib/**/*.spec.js\"",

--- a/packages/cli/src/generate/templates/app/src/app/controllers/view.controller.spec.ts
+++ b/packages/cli/src/generate/templates/app/src/app/controllers/view.controller.spec.ts
@@ -1,0 +1,29 @@
+// std
+import { ok, strictEqual } from 'assert';
+
+// 3p
+import { Context, createController, getHttpMethod, getPath, HttpResponseOk } from '@foal/core';
+
+// App
+import { ViewController } from './view.controller';
+
+describe('ViewController', () => {
+
+  describe('has a "index" method that', () => {
+
+    it('should handle requests at Get /.', () => {
+      strictEqual(getHttpMethod(ViewController, 'index'), 'GET');
+      strictEqual(getPath(ViewController, 'index'), '/');
+    });
+
+    it('should return a HttpResponseOk.', () => {
+      const controller = createController(ViewController);
+      const ctx = new Context({
+        csrfToken: () => {}
+      });
+      ok(controller.index(ctx) instanceof HttpResponseOk);
+    });
+
+  });
+
+});

--- a/packages/cli/src/generate/templates/app/src/app/controllers/view.controller.spec.ts
+++ b/packages/cli/src/generate/templates/app/src/app/controllers/view.controller.spec.ts
@@ -2,7 +2,7 @@
 import { ok, strictEqual } from 'assert';
 
 // 3p
-import { Context, createController, getHttpMethod, getPath, HttpResponseOk } from '@foal/core';
+import { Context, createController, getHttpMethod, getPath, HttpResponseOK } from '@foal/core';
 
 // App
 import { ViewController } from './view.controller';
@@ -16,12 +16,12 @@ describe('ViewController', () => {
       strictEqual(getPath(ViewController, 'index'), '/');
     });
 
-    it('should return a HttpResponseOk.', () => {
+    it('should return a HttpResponseOK.', () => {
       const controller = createController(ViewController);
       const ctx = new Context({
         csrfToken: () => {}
       });
-      ok(controller.index(ctx) instanceof HttpResponseOk);
+      ok(controller.index(ctx) instanceof HttpResponseOK);
     });
 
   });

--- a/packages/cli/src/generate/templates/app/src/app/controllers/view.controller.ts
+++ b/packages/cli/src/generate/templates/app/src/app/controllers/view.controller.ts
@@ -3,7 +3,7 @@ import { Config, Controller, Get, render } from '@foal/core';
 @Controller()
 export class ViewController {
 
-  @Get()
+  @Get('/')
   index(ctx) {
     return render('./templates/index.html', {
       appName: Config.get('app', 'name'),


### PR DESCRIPTION
# Issue

FoalTS lacks of e2e tests. We need to make sure that the "get started" (creating and running a single app), most of the generators, the linting and the default shell scripts always work.

# Solution and steps

Add an `e2e_test.sh` bash script to create an app and run the basic commands.