### PR TITLE
Add the script generator

### DIFF
--- a/docs/development-environment/create-and-run-scripts.md
+++ b/docs/development-environment/create-and-run-scripts.md
@@ -32,6 +32,7 @@ async function main() {
 main();
 ```
 
+If you want to create a script that is called with some parameters from the command line, you can use the command `foal g script my-script` to generate such a script.
 
 # Build and Run Scripts
 

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -13,6 +13,7 @@ npm run lint
 foal g entity flight
 foal g hook foo-bar
 foal g module bar-foo
+foal g script bar-script
 
 # Test building
 npm run build

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -9,14 +9,14 @@ npm install
 # Test linting
 npm run lint
 
-# Test building
-npm run build
-npm run build:test
-
 # Test the generators that do not require user interaction
 foal g entity flight
 foal g hook foo-bar
 foal g module bar-foo
+
+# Test building
+npm run build
+npm run build:test
 
 # Run the generated unit tests
 npm run start:test

--- a/packages/cli/src/generate/generators/index.ts
+++ b/packages/cli/src/generate/generators/index.ts
@@ -3,4 +3,5 @@ export * from './controller';
 export * from './entity';
 export * from './hook';
 export * from './module';
+export * from './script';
 export * from './service';

--- a/packages/cli/src/generate/generators/script/create-script.spec.ts
+++ b/packages/cli/src/generate/generators/script/create-script.spec.ts
@@ -1,0 +1,45 @@
+// FoalTS
+import {
+  rmdirIfExists,
+  rmfileIfExists,
+  TestEnvironment,
+} from '../../utils';
+import { createScript } from './create-script';
+
+describe('createScript', () => {
+
+  afterEach(() => {
+    rmfileIfExists('src/scripts/test-foo-bar.ts');
+    rmdirIfExists('src/scripts');
+    // We cannot remove src/ since the generator code lives within. This is bad testing
+    // approach.
+    // rmdirIfExists('src');
+
+    rmfileIfExists('test-foo-bar.ts');
+  });
+
+  function test(root: string) {
+
+    describe(`when the directory ${root}/ exists`, () => {
+
+      const testEnv = new TestEnvironment('script', root);
+
+      beforeEach(() => {
+        testEnv.mkRootDirIfDoesNotExist();
+      });
+
+      it('should copy the empty script file in the proper directory.', () => {
+        createScript({ name: 'test-fooBar' });
+
+        testEnv
+          .validateSpec('test-foo-bar.ts');
+      });
+
+    });
+
+  }
+
+  test('src/scripts');
+  test('');
+
+});

--- a/packages/cli/src/generate/generators/script/create-script.ts
+++ b/packages/cli/src/generate/generators/script/create-script.ts
@@ -1,0 +1,18 @@
+// std
+import { existsSync } from 'fs';
+
+// FoalTS
+import { Generator, getNames } from '../../utils';
+
+export function createScript({ name }: { name: string }) {
+  const names = getNames(name);
+
+  let root = '';
+
+  if (existsSync('src/scripts')) {
+    root = 'src/scripts';
+  }
+
+  new Generator('script', root)
+    .copyFileFromTemplates('script.ts', `${names.kebabName}.ts`);
+}

--- a/packages/cli/src/generate/generators/script/index.ts
+++ b/packages/cli/src/generate/generators/script/index.ts
@@ -1,0 +1,1 @@
+export { createScript } from './create-script';

--- a/packages/cli/src/generate/specs/script/test-foo-bar.ts
+++ b/packages/cli/src/generate/specs/script/test-foo-bar.ts
@@ -1,0 +1,34 @@
+// 3p
+import { getCommandLineArguments, validate, ValidationError } from '@foal/core';
+import { createConnection } from 'typeorm';
+
+const argSchema = {
+  additionalProperties: false,
+  properties: {
+    /* To complete */
+  },
+  required: [ /* To complete */ ],
+  type: 'object',
+};
+
+async function main(argv) {
+  const args = getCommandLineArguments(argv);
+
+  try {
+    validate(argSchema, args);
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      error.content.forEach(err => {
+        console.log(`The command line arguments ${err.message}`);
+      });
+      return;
+    }
+    throw error;
+  }
+
+  await createConnection();
+
+  // Do something.
+}
+
+main(process.argv);

--- a/packages/cli/src/generate/templates/script/script.ts
+++ b/packages/cli/src/generate/templates/script/script.ts
@@ -1,0 +1,34 @@
+// 3p
+import { getCommandLineArguments, validate, ValidationError } from '@foal/core';
+import { createConnection } from 'typeorm';
+
+const argSchema = {
+  additionalProperties: false,
+  properties: {
+    /* To complete */
+  },
+  required: [ /* To complete */ ],
+  type: 'object',
+};
+
+async function main(argv) {
+  const args = getCommandLineArguments(argv);
+
+  try {
+    validate(argSchema, args);
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      error.content.forEach(err => {
+        console.log(`The command line arguments ${err.message}`);
+      });
+      return;
+    }
+    throw error;
+  }
+
+  await createConnection();
+
+  // Do something.
+}
+
+main(process.argv);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ import {
   createEntity,
   createHook,
   createModule,
+  createScript,
   createService,
   ServiceType
 } from './generate';
@@ -55,6 +56,9 @@ program
         break;
       case 'module':
         createModule({ name });
+        break;
+      case 'script':
+        createScript({ name });
         break;
       case 'service':
         const serviceChoices: ServiceType[] = [


### PR DESCRIPTION
# Issue

- Creating a script file by hand is a bit tedious.
- It should be easy to users to get started with scripts.

# Solution and steps

- [x] Create a simple script generator with a basic template.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.