### PR TITLE
Automatically register controllers upon creation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,20 +63,8 @@ $ foal g service flight
 ```
 Create a REST controller.
 ```shell
-$ foal g controller flight
+$ foal g controller flight --register
 > REST
-```
-Register you controller in the `src/app/app.module.ts` file.
-```typescript
-...
-import { controller } from '@foal/core';
-import { FlightController } from './controllers/flight.controller';
-...
-export class AppModule implements IModule {
-  controllers = [
-    controller('/flights', FlightController)
-  ]
-}
 ```
 
 The `npm run develop` command rebuilds the app and reloads the server. `http://localhost:3000/flights` now returns an empty array!

--- a/docs/development-environment/code-generation.md
+++ b/docs/development-environment/code-generation.md
@@ -19,6 +19,12 @@ foal g controller foobar
 
 Create a new controller in `./src/app/controllers`, in `./controllers` or in the current directory depending on which folders are found.
 
+If you are in the root directory and you want to automatically register the controller within the app module you can add the `--register` flag.
+
+```shell
+foal g controller foobar --register
+```
+
 ## Create an entity (simple model)
 
 ```shell

--- a/packages/cli/src/generate/generators/controller/create-controller.spec.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.spec.ts
@@ -1,4 +1,5 @@
 // FoalTS
+import { it } from 'mocha';
 import {
   rmdirIfExists,
   rmfileIfExists,
@@ -13,6 +14,7 @@ describe('createController', () => {
     rmfileIfExists('src/app/controllers/test-foo-bar.controller.spec.ts');
     rmfileIfExists('src/app/controllers/index.ts');
     rmdirIfExists('src/app/controllers');
+    rmfileIfExists('src/app/app.module.ts');
     rmdirIfExists('src/app');
     // We cannot remove src/ since the generator code lives within. This is bad testing
     // approach.
@@ -79,5 +81,70 @@ describe('createController', () => {
   test('src/app/controllers');
   test('controllers');
   test('');
+
+  describe('when the directory src/app/controllers exists', () => {
+
+    const testEnv = new TestEnvironment('controller', 'src/app/controllers');
+
+    beforeEach(() => {
+      testEnv.mkRootDirIfDoesNotExist();
+      testEnv.copyFileFromMocks('index.ts');
+    });
+
+    it('should update the "controllers" import in src/app/app.module.ts if it exists.', () => {
+      testEnv.copyFileFromMocks('app.module.controller-import.ts', '../app.module.ts');
+
+      createController({ name: 'test-fooBar', type: 'Empty' });
+
+      testEnv
+        .validateSpec('app.module.controller-import.ts', '../app.module.ts');
+    });
+
+    it('should add a "controllers" import in src/app/app.module.ts if none already exists.', () => {
+      testEnv.copyFileFromMocks('app.module.no-controller-import.ts', '../app.module.ts');
+
+      createController({ name: 'test-fooBar', type: 'Empty' });
+
+      testEnv
+        .validateSpec('app.module.no-controller-import.ts', '../app.module.ts');
+    });
+
+    it('should update the "@foal/core" import in src/app/app.module.ts if it exists.', () => {
+      testEnv.copyFileFromMocks('app.module.core-import.ts', '../app.module.ts');
+
+      createController({ name: 'test-fooBar', type: 'Empty' });
+
+      testEnv
+        .validateSpec('app.module.core-import.ts', '../app.module.ts');
+    });
+
+    it('should update the "controllers = []" property in src/app/app.module.ts if it exists.', () => {
+      testEnv.copyFileFromMocks('app.module.empty-property.ts', '../app.module.ts');
+
+      createController({ name: 'test-fooBar', type: 'Empty' });
+
+      testEnv
+        .validateSpec('app.module.empty-property.ts', '../app.module.ts');
+    });
+
+    it('should update the "controllers = [ \n \n ]" property in src/app/app.module.ts if it exists.', () => {
+      testEnv.copyFileFromMocks('app.module.empty-spaced-property.ts', '../app.module.ts');
+
+      createController({ name: 'test-fooBar', type: 'Empty' });
+
+      testEnv
+        .validateSpec('app.module.empty-spaced-property.ts', '../app.module.ts');
+    });
+
+    it('should update the "controllers = [ \n (.*) \n ]" property in src/app/app.module.ts if it exists.', () => {
+      testEnv.copyFileFromMocks('app.module.no-empty-property.ts', '../app.module.ts');
+
+      createController({ name: 'test-fooBar', type: 'Empty' });
+
+      testEnv
+        .validateSpec('app.module.no-empty-property.ts', '../app.module.ts');
+    });
+
+  });
 
 });

--- a/packages/cli/src/generate/generators/controller/create-controller.spec.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.spec.ts
@@ -126,7 +126,7 @@ describe('createController', () => {
         .validateSpec('app.module.empty-property.ts', '../app.module.ts');
     });
 
-    it('should update the "controllers = [ \n \n ]" property in src/app/app.module.ts if it exists.', () => {
+    it('should update the "controllers = [ \\n \\n ]" property in src/app/app.module.ts if it exists.', () => {
       testEnv.copyFileFromMocks('app.module.empty-spaced-property.ts', '../app.module.ts');
 
       createController({ name: 'test-fooBar', type: 'Empty', register: true });
@@ -135,7 +135,7 @@ describe('createController', () => {
         .validateSpec('app.module.empty-spaced-property.ts', '../app.module.ts');
     });
 
-    it('should update the "controllers = [ \n (.*) \n ]" property in src/app/app.module.ts if it exists.', () => {
+    it('should update the "controllers = [ \\n (.*) \\n ]" property in src/app/app.module.ts if it exists.', () => {
       testEnv.copyFileFromMocks('app.module.no-empty-property.ts', '../app.module.ts');
 
       createController({ name: 'test-fooBar', type: 'Empty', register: true });

--- a/packages/cli/src/generate/generators/controller/create-controller.spec.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.spec.ts
@@ -1,5 +1,4 @@
 // FoalTS
-import { it } from 'mocha';
 import {
   rmdirIfExists,
   rmfileIfExists,

--- a/packages/cli/src/generate/generators/controller/create-controller.spec.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.spec.ts
@@ -41,7 +41,7 @@ describe('createController', () => {
       });
 
       it('should render the empty templates in the proper directory.', () => {
-        createController({ name: 'test-fooBar', type: 'Empty' });
+        createController({ name: 'test-fooBar', type: 'Empty', register: false });
 
         testEnv
           .validateSpec('test-foo-bar.controller.empty.ts', 'test-foo-bar.controller.ts')
@@ -50,7 +50,7 @@ describe('createController', () => {
       });
 
       it('should render the REST templates in the proper directory.', () => {
-        createController({ name: 'test-fooBar', type: 'REST' });
+        createController({ name: 'test-fooBar', type: 'REST', register: false });
 
         testEnv
           .validateSpec('test-foo-bar.controller.rest.ts', 'test-foo-bar.controller.ts')
@@ -58,7 +58,7 @@ describe('createController', () => {
       });
 
       it('should render the GraphQL templates in the proper directory.', () => {
-        createController({ name: 'test-fooBar', type: 'GraphQL' });
+        createController({ name: 'test-fooBar', type: 'GraphQL', register: false });
 
         testEnv
           .validateSpec('test-foo-bar.controller.graphql.ts', 'test-foo-bar.controller.ts')
@@ -66,7 +66,7 @@ describe('createController', () => {
       });
 
       it('should render the Login templates in the proper directory.', () => {
-        createController({ name: 'test-fooBar', type: 'Login' });
+        createController({ name: 'test-fooBar', type: 'Login', register: false });
 
         testEnv
           .validateSpec('test-foo-bar.controller.login.ts', 'test-foo-bar.controller.ts')
@@ -81,7 +81,7 @@ describe('createController', () => {
   test('controllers');
   test('');
 
-  describe('when the directory src/app/controllers exists', () => {
+  describe('when the directory src/app/controllers exists and if register is true', () => {
 
     const testEnv = new TestEnvironment('controller', 'src/app/controllers');
 
@@ -93,7 +93,7 @@ describe('createController', () => {
     it('should update the "controllers" import in src/app/app.module.ts if it exists.', () => {
       testEnv.copyFileFromMocks('app.module.controller-import.ts', '../app.module.ts');
 
-      createController({ name: 'test-fooBar', type: 'Empty' });
+      createController({ name: 'test-fooBar', type: 'Empty', register: true });
 
       testEnv
         .validateSpec('app.module.controller-import.ts', '../app.module.ts');
@@ -102,7 +102,7 @@ describe('createController', () => {
     it('should add a "controllers" import in src/app/app.module.ts if none already exists.', () => {
       testEnv.copyFileFromMocks('app.module.no-controller-import.ts', '../app.module.ts');
 
-      createController({ name: 'test-fooBar', type: 'Empty' });
+      createController({ name: 'test-fooBar', type: 'Empty', register: true });
 
       testEnv
         .validateSpec('app.module.no-controller-import.ts', '../app.module.ts');
@@ -111,7 +111,7 @@ describe('createController', () => {
     it('should update the "@foal/core" import in src/app/app.module.ts if it exists.', () => {
       testEnv.copyFileFromMocks('app.module.core-import.ts', '../app.module.ts');
 
-      createController({ name: 'test-fooBar', type: 'Empty' });
+      createController({ name: 'test-fooBar', type: 'Empty', register: true });
 
       testEnv
         .validateSpec('app.module.core-import.ts', '../app.module.ts');
@@ -120,7 +120,7 @@ describe('createController', () => {
     it('should update the "controllers = []" property in src/app/app.module.ts if it exists.', () => {
       testEnv.copyFileFromMocks('app.module.empty-property.ts', '../app.module.ts');
 
-      createController({ name: 'test-fooBar', type: 'Empty' });
+      createController({ name: 'test-fooBar', type: 'Empty', register: true });
 
       testEnv
         .validateSpec('app.module.empty-property.ts', '../app.module.ts');
@@ -129,7 +129,7 @@ describe('createController', () => {
     it('should update the "controllers = [ \n \n ]" property in src/app/app.module.ts if it exists.', () => {
       testEnv.copyFileFromMocks('app.module.empty-spaced-property.ts', '../app.module.ts');
 
-      createController({ name: 'test-fooBar', type: 'Empty' });
+      createController({ name: 'test-fooBar', type: 'Empty', register: true });
 
       testEnv
         .validateSpec('app.module.empty-spaced-property.ts', '../app.module.ts');
@@ -138,7 +138,7 @@ describe('createController', () => {
     it('should update the "controllers = [ \n (.*) \n ]" property in src/app/app.module.ts if it exists.', () => {
       testEnv.copyFileFromMocks('app.module.no-empty-property.ts', '../app.module.ts');
 
-      createController({ name: 'test-fooBar', type: 'Empty' });
+      createController({ name: 'test-fooBar', type: 'Empty', register: true });
 
       testEnv
         .validateSpec('app.module.no-empty-property.ts', '../app.module.ts');

--- a/packages/cli/src/generate/generators/controller/create-controller.spec.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.spec.ts
@@ -144,6 +144,15 @@ describe('createController', () => {
         .validateSpec('app.module.no-empty-property.ts', '../app.module.ts');
     });
 
+    it('should update the "controllers" property with a special URL if the controller is a REST controller.', () => {
+      testEnv.copyFileFromMocks('app.module.rest.ts', '../app.module.ts');
+
+      createController({ name: 'test-fooBar', type: 'REST', register: true });
+
+      testEnv
+        .validateSpec('app.module.rest.ts', '../app.module.ts');
+    });
+
   });
 
 });

--- a/packages/cli/src/generate/generators/controller/create-controller.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.ts
@@ -26,15 +26,14 @@ export function createController({ name, type, register }: { name: string, type:
     .updateFile('index.ts', content => {
       content += `export { ${names.upperFirstCamelName}Controller } from './${names.kebabName}.controller';\n`;
       return content;
-    })
-  
+    });
+
   if (register) {
     generator
       .updateFile('../app.module.ts', content => {
         return registerController(content, `${names.upperFirstCamelName}Controller`);
       }, { allowFailure: true });
   }
-    
 
   if (type === 'Empty') {
     generator

--- a/packages/cli/src/generate/generators/controller/create-controller.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.ts
@@ -29,9 +29,10 @@ export function createController({ name, type, register }: { name: string, type:
     });
 
   if (register) {
+    const path = type === 'REST' ? `/${names.kebabName}s` : '/';
     generator
       .updateFile('../app.module.ts', content => {
-        return registerController(content, `${names.upperFirstCamelName}Controller`);
+        return registerController(content, `${names.upperFirstCamelName}Controller`, path);
       }, { allowFailure: true });
   }
 

--- a/packages/cli/src/generate/generators/controller/create-controller.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'fs';
 
 // FoalTS
 import { Generator, getNames } from '../../utils';
+import { registerController } from './register-controller';
 
 export type ControllerType = 'Empty'|'REST'|'GraphQL'|'Login';
 
@@ -26,9 +27,9 @@ export function createController({ name, type }: { name: string, type: Controlle
       content += `export { ${names.upperFirstCamelName}Controller } from './${names.kebabName}.controller';\n`;
       return content;
     })
-    /*.updateFile('../app.module.ts', content => {
+    .updateFile('../app.module.ts', content => {
       return registerController(content, `${names.upperFirstCamelName}Controller`);
-    }, { allowFailure: true })*/;
+    }, { allowFailure: true });
 
   if (type === 'Empty') {
     generator

--- a/packages/cli/src/generate/generators/controller/create-controller.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.ts
@@ -7,7 +7,7 @@ import { registerController } from './register-controller';
 
 export type ControllerType = 'Empty'|'REST'|'GraphQL'|'Login';
 
-export function createController({ name, type }: { name: string, type: ControllerType }) {
+export function createController({ name, type, register }: { name: string, type: ControllerType, register: boolean }) {
   const names = getNames(name);
 
   const fileName = `${names.kebabName}.controller.ts`;
@@ -27,9 +27,14 @@ export function createController({ name, type }: { name: string, type: Controlle
       content += `export { ${names.upperFirstCamelName}Controller } from './${names.kebabName}.controller';\n`;
       return content;
     })
-    .updateFile('../app.module.ts', content => {
-      return registerController(content, `${names.upperFirstCamelName}Controller`);
-    }, { allowFailure: true });
+  
+  if (register) {
+    generator
+      .updateFile('../app.module.ts', content => {
+        return registerController(content, `${names.upperFirstCamelName}Controller`);
+      }, { allowFailure: true });
+  }
+    
 
   if (type === 'Empty') {
     generator

--- a/packages/cli/src/generate/generators/controller/register-controller.ts
+++ b/packages/cli/src/generate/generators/controller/register-controller.ts
@@ -1,5 +1,3 @@
-import { ControllerType } from './create-controller';
-
 class ImportNotFound extends Error {}
 
 function createNamedImport(specifiers: string[], path: string): string {

--- a/packages/cli/src/generate/generators/controller/register-controller.ts
+++ b/packages/cli/src/generate/generators/controller/register-controller.ts
@@ -49,7 +49,7 @@ export function registerController(moduleContent: string, controllerName: string
       const controllerCalls = content.match(regex) || [];
       controllerCalls.push(`controller('/', ${controllerName})`);
       const formattedCalls = controllerCalls.join(`,\n${spaces}  `);
-      return `${spaces}controllers = [\n${spaces}  ${formattedCalls}\n${spaces}];`
-    })
+      return `${spaces}controllers = [\n${spaces}  ${formattedCalls}\n${spaces}];`;
+    });
   return moduleContent;
 }

--- a/packages/cli/src/generate/generators/controller/register-controller.ts
+++ b/packages/cli/src/generate/generators/controller/register-controller.ts
@@ -45,7 +45,7 @@ export function registerController(moduleContent: string, controllerName: string
   } catch (err) {}
   moduleContent = moduleContent
     .replace(/( *)controllers = \[((.|\n)*)\];/, (str, spaces, content: string) => {
-      const regex = new RegExp('controller\((.*)\)', 'g');
+      const regex = /controller\((.*)\)/g;
       const controllerCalls = content.match(regex) || [];
       controllerCalls.push(`controller('/', ${controllerName})`);
       const formattedCalls = controllerCalls.join(`,\n${spaces}  `);

--- a/packages/cli/src/generate/generators/controller/register-controller.ts
+++ b/packages/cli/src/generate/generators/controller/register-controller.ts
@@ -1,3 +1,5 @@
+import { ControllerType } from './create-controller';
+
 class ImportNotFound extends Error {}
 
 function createNamedImport(specifiers: string[], path: string): string {
@@ -36,7 +38,7 @@ function addSpecifierToNamedImport(source: string, path: string, specifier: stri
   return result;
 }
 
-export function registerController(moduleContent: string, controllerName: string): string {
+export function registerController(moduleContent: string, controllerName: string, path: string): string {
   try {
     moduleContent = addSpecifierToNamedImport(moduleContent, './controllers', controllerName);
   } catch (err) {
@@ -50,7 +52,7 @@ export function registerController(moduleContent: string, controllerName: string
     .replace(/( *)controllers = \[((.|\n)*)\];/, (str, spaces, content: string) => {
       const regex = /controller\((.*)\)/g;
       const controllerCalls = content.match(regex) || [];
-      controllerCalls.push(`controller('/', ${controllerName})`);
+      controllerCalls.push(`controller('${path}', ${controllerName})`);
       const formattedCalls = controllerCalls.join(`,\n${spaces}  `);
       return `${spaces}controllers = [\n${spaces}  ${formattedCalls}\n${spaces}];`;
     });

--- a/packages/cli/src/generate/generators/controller/register-controller.ts
+++ b/packages/cli/src/generate/generators/controller/register-controller.ts
@@ -23,6 +23,9 @@ function addSpecifierToNamedImport(source: string, path: string, specifier: stri
       namedImportFound = true;
 
       const importSpecifiers = content.split(',').map(imp => imp.trim());
+      if (importSpecifiers.includes('controller')) {
+        return str;
+      }
       importSpecifiers.push(specifier);
       importSpecifiers.sort((a, b) => a.localeCompare(b));
       return createNamedImport(importSpecifiers, path);

--- a/packages/cli/src/generate/mocks/controller/app.module.controller-import.ts
+++ b/packages/cli/src/generate/mocks/controller/app.module.controller-import.ts
@@ -1,0 +1,4 @@
+// App
+import { ViewController } from './controllers';
+
+export class MyModule {}

--- a/packages/cli/src/generate/mocks/controller/app.module.core-import.ts
+++ b/packages/cli/src/generate/mocks/controller/app.module.core-import.ts
@@ -1,0 +1,5 @@
+// 3p
+import { Module } from '@foal/core';
+
+@Module()
+export class MyModule {}

--- a/packages/cli/src/generate/mocks/controller/app.module.empty-property.ts
+++ b/packages/cli/src/generate/mocks/controller/app.module.empty-property.ts
@@ -1,0 +1,6 @@
+// 3p
+import {} from 'somewhere';
+
+export class MyModule {
+  controllers = [];
+}

--- a/packages/cli/src/generate/mocks/controller/app.module.empty-spaced-property.ts
+++ b/packages/cli/src/generate/mocks/controller/app.module.empty-spaced-property.ts
@@ -1,0 +1,8 @@
+// 3p
+import {} from 'somewhere';
+
+export class MyModule {
+  controllers = [
+
+  ];
+}

--- a/packages/cli/src/generate/mocks/controller/app.module.no-controller-import.ts
+++ b/packages/cli/src/generate/mocks/controller/app.module.no-controller-import.ts
@@ -1,0 +1,4 @@
+// 3p
+import { Something } from '@somewhere';
+
+export class MyModule {}

--- a/packages/cli/src/generate/mocks/controller/app.module.no-empty-property.ts
+++ b/packages/cli/src/generate/mocks/controller/app.module.no-empty-property.ts
@@ -3,6 +3,7 @@ import {} from 'somewhere';
 
 export class MyModule {
   controllers = [
-    controller('/', MyController)
+    controller('/', MyController),
+    controller('/', MyController2)
   ];
 }

--- a/packages/cli/src/generate/mocks/controller/app.module.no-empty-property.ts
+++ b/packages/cli/src/generate/mocks/controller/app.module.no-empty-property.ts
@@ -1,0 +1,8 @@
+// 3p
+import {} from 'somewhere';
+
+export class MyModule {
+  controllers = [
+    controller('/', MyController)
+  ];
+}

--- a/packages/cli/src/generate/mocks/controller/app.module.no-empty-property.ts
+++ b/packages/cli/src/generate/mocks/controller/app.module.no-empty-property.ts
@@ -1,5 +1,5 @@
 // 3p
-import {} from 'somewhere';
+import { controller } from '@foal/core';
 
 export class MyModule {
   controllers = [

--- a/packages/cli/src/generate/mocks/controller/app.module.rest.ts
+++ b/packages/cli/src/generate/mocks/controller/app.module.rest.ts
@@ -1,0 +1,6 @@
+// 3p
+import {} from 'somewhere';
+
+export class MyModule {
+  controllers = [];
+}

--- a/packages/cli/src/generate/specs/controller/app.module.controller-import.ts
+++ b/packages/cli/src/generate/specs/controller/app.module.controller-import.ts
@@ -1,0 +1,4 @@
+// App
+import { TestFooBarController, ViewController } from './controllers';
+
+export class MyModule {}

--- a/packages/cli/src/generate/specs/controller/app.module.core-import.ts
+++ b/packages/cli/src/generate/specs/controller/app.module.core-import.ts
@@ -1,0 +1,6 @@
+// 3p
+import { controller, Module } from '@foal/core';
+import { TestFooBarController } from './controllers';
+
+@Module()
+export class MyModule {}

--- a/packages/cli/src/generate/specs/controller/app.module.empty-property.ts
+++ b/packages/cli/src/generate/specs/controller/app.module.empty-property.ts
@@ -1,0 +1,9 @@
+// 3p
+import {} from 'somewhere';
+import { TestFooBarController } from './controllers';
+
+export class MyModule {
+  controllers = [
+    controller('/', TestFooBarController)
+  ];
+}

--- a/packages/cli/src/generate/specs/controller/app.module.empty-spaced-property.ts
+++ b/packages/cli/src/generate/specs/controller/app.module.empty-spaced-property.ts
@@ -1,0 +1,9 @@
+// 3p
+import {} from 'somewhere';
+import { TestFooBarController } from './controllers';
+
+export class MyModule {
+  controllers = [
+    controller('/', TestFooBarController)
+  ];
+}

--- a/packages/cli/src/generate/specs/controller/app.module.no-controller-import.ts
+++ b/packages/cli/src/generate/specs/controller/app.module.no-controller-import.ts
@@ -1,0 +1,5 @@
+// 3p
+import { Something } from '@somewhere';
+import { TestFooBarController } from './controllers';
+
+export class MyModule {}

--- a/packages/cli/src/generate/specs/controller/app.module.no-empty-property.ts
+++ b/packages/cli/src/generate/specs/controller/app.module.no-empty-property.ts
@@ -1,5 +1,5 @@
 // 3p
-import {} from 'somewhere';
+import { controller } from '@foal/core';
 import { TestFooBarController } from './controllers';
 
 export class MyModule {

--- a/packages/cli/src/generate/specs/controller/app.module.no-empty-property.ts
+++ b/packages/cli/src/generate/specs/controller/app.module.no-empty-property.ts
@@ -5,6 +5,7 @@ import { TestFooBarController } from './controllers';
 export class MyModule {
   controllers = [
     controller('/', MyController),
+    controller('/', MyController2),
     controller('/', TestFooBarController)
   ];
 }

--- a/packages/cli/src/generate/specs/controller/app.module.no-empty-property.ts
+++ b/packages/cli/src/generate/specs/controller/app.module.no-empty-property.ts
@@ -1,0 +1,10 @@
+// 3p
+import {} from 'somewhere';
+import { TestFooBarController } from './controllers';
+
+export class MyModule {
+  controllers = [
+    controller('/', MyController),
+    controller('/', TestFooBarController)
+  ];
+}

--- a/packages/cli/src/generate/specs/controller/app.module.rest.ts
+++ b/packages/cli/src/generate/specs/controller/app.module.rest.ts
@@ -1,0 +1,9 @@
+// 3p
+import {} from 'somewhere';
+import { TestFooBarController } from './controllers';
+
+export class MyModule {
+  controllers = [
+    controller('/test-foo-bars', TestFooBarController)
+  ];
+}

--- a/packages/cli/src/generate/utils/generator.ts
+++ b/packages/cli/src/generate/utils/generator.ts
@@ -73,7 +73,7 @@ export class Generator {
 
   private logUpdate(path: string) {
     if (this.root) {
-      path = this.root + '/' + path;
+      path = join(this.root, path);
     }
     if (process.env.NODE_ENV !== 'test') {
       console.log(`UPDATE ${path}`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,15 +38,16 @@ program
 program
   .command('generate <type> <name>')
   .description('Generates files (type: controller|entity|hook|module|service).')
+  .option('-r, --register', 'Register the controller into app.module.ts (only available if type=controller)')
   .alias('g')
-  .action(async (type: string, name: string) => {
+  .action(async (type: string, name: string, options) => {
     switch (type) {
       case 'controller':
         const controllerChoices: ControllerType[] = [ 'Empty', 'REST'/*, 'GraphQL'*/, 'Login' ];
         const controllerAnswers = await prompt([
           { choices: controllerChoices, name: 'type', type: 'list', message: 'Type' }
         ]);
-        createController({ name, type: controllerAnswers.type });
+        createController({ name, type: controllerAnswers.type, register: options.register || false  });
         break;
       case 'entity':
         createEntity({ name });
@@ -76,7 +77,7 @@ program
         const serviceAnswers = await prompt([
           { choices: serviceChoices, name: 'type', type: 'list', message: 'Type', pageSize: 10 }
         ]);
-        createService({ name, type: serviceAnswers.type });
+        createService({ name, type: serviceAnswers.type});
         break;
       default:
         console.error('Please provide a valid type: controller|entity|hook|module|service.');

--- a/tslint.json
+++ b/tslint.json
@@ -17,10 +17,15 @@
       "no-empty-interface": false,
       "no-unused-variable": true,
       "no-duplicate-imports": true,
+      "no-conditional-assignment": false,
       "member-access": [true, "no-public"]
     },
     "rulesDirectory": [],
     "linterOptions": {
-        "exclude": "**/src/migrations/*.ts"
+        "exclude": [
+            "**/src/migrations/*.ts",
+            "**/src/generate/mocks/**/*.ts",
+            "**/src/generate/specs/**/app.module.*.ts"
+        ]
     }
 }


### PR DESCRIPTION
# Issue

It is tedious to always have to register the controllers in `app.module.ts` upon creation. Especially it does not facilitate the "on-boarding" process.

# Solution and steps

Add the option `--register` to `foal g controller foo-bar` that seeks for the `app.module.ts` and automatically registers the controller within the module class.

- [x] Add the "register" feature.
- [x] Link it to the `--register` option.
- [x] Use a special URL for REST controllers.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.