### PR TITLE
Add the `foal run-script` feature.

### DIFF
--- a/docs/development-environment/create-and-run-scripts.md
+++ b/docs/development-environment/create-and-run-scripts.md
@@ -1,20 +1,16 @@
 # Create and Run Scripts
 
-Sometimes we have to execute some tasks from the command line. These tasks can serve different purposes such as populating a database (user creation, etc) for instance. They often need to access some of the app classes and functions. This is where shell scripts come into play.
+Sometimes we have to execute some tasks from the command line. These tasks can serve different purposes such as populating a database (user creation, etc) for instance. They often need to access some of the app classes and functions. This is when shell scripts come into play.
 
 # Create Scripts
 
-A shell script is just a TypeScript file which is called from the command line.
+A shell script is just a TypeScript file located in the `src/scripts`. It must export a `main` function that is then called when running the script.
 
-They are located in the `src/scripts` directory. Let's create one: `src/scripts/display-users.ts`
+Let's create a new one with the command line: `foal g script display-users`. A new file with a default template should appear in you `src/scripts` directory.
 
 # Write Scripts
 
-Usually a script has a `main` function which is called directly in the file. This lets you easily use async/await keywords when dealing with asynchronous code.
-
-From this file you can import the classes and functions of your app and use them. You can also create a database connection based on the database configuration of your app.
-
-Let's take an example: a script that displays the users stored in the database.
+Remove the content of `src/scripts/display-users.ts` and replace it with the below code.
 
 ```typescript
 // 3p
@@ -23,27 +19,32 @@ import { createConnection } from 'typeorm';
 // App
 import { User } from './app/entities';
 
-async function main() {
-  const connection = await createConnection();
+export async function main() {
+  await createConnection();
   const users = await connection.getRepository(User).find();
   console.log(users);
 }
 
-main();
 ```
 
-If you want to create a script that is called with some parameters from the command line, you can use the command `foal g script my-script` to generate such a script.
+As you can see, we can easily establish a connection to the database in the script as well as import some of the app components (the `User` in this case).
+
+Encapsulating your code in a `main` function without calling it directly in the file has several benefits:
+- You can import and test your `main` function in a separate file.
+- Using a function lets you easily use async/await keywords when dealing with asynchronous code.
 
 # Build and Run Scripts
 
-To run a script you first need  to build it.
+To run a script you first need to build it.
 
 ```sh
 npm run build
 ```
 
-Then you can run it with this command:
+Then you can execute it with this command:
 
 ```sh
-node lib/scripts/my-script.js
+foal run-script my-script
 ```
+
+> You can also provide additionnal arguments to your script (for example: `foal run-script my-script foo=1 bar='[ 3, 4 ]'`). The default template in the generated scripts shows you how to handle such behavior.

--- a/docs/the-authentication-system/permissions-and-authorization.md
+++ b/docs/the-authentication-system/permissions-and-authorization.md
@@ -27,15 +27,15 @@ The `PermissionRequired(perm: string)` hook returns a `403 Forbidden` if the use
 ```sh
 npm run build
 
-node lib/scripts/create-perm name="My first permission" codeName="my-first-perm"
-node lib/scripts/create-perm name="My second permission" codeName="my-second-perm"
+foal run-script create-perm name="My first permission" codeName="my-first-perm"
+foal run-script create-perm name="My second permission" codeName="my-second-perm"
 
-node lib/scripts/create-group name="My group" codeName="my-group" permissions='[ "my-second-perm" ]'
+foal run-script create-group name="My group" codeName="my-group" permissions='[ "my-second-perm" ]'
 
-node lib/scripts/create-user userPermissions='[ "my-first-perm" ]' groups='[ "my-group" ]'
+foal run-script create-user userPermissions='[ "my-first-perm" ]' groups='[ "my-group" ]'
 ```
 
 Or if your user has an email and a password:
 ```sh
-node lib/scripts/create-user email="mary@foalts.org" password="my_strong_password" userPermissions='[ "my-first-perm" ]' groups='[ "my-group" ]'
+foal run-script create-user email="mary@foalts.org" password="my_strong_password" userPermissions='[ "my-first-perm" ]' groups='[ "my-group" ]'
 ```

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -35,9 +35,9 @@ test "$response" -ge 200 && test "$response" -le 299
 pm2 delete index
 
 # Test the default shell scripts to create permissions, groups and users.
-node run-script create-perm name="My first permission" codeName="my-first-perm"
-node run-script create-perm name="My second permission" codeName="my-second-perm"
+foal run-script create-perm name="My first permission" codeName="my-first-perm"
+foal run-script create-perm name="My second permission" codeName="my-second-perm"
 
-node run-script create-group name="My group" codeName="my-group" permissions='[ "my-second-perm" ]'
+foal run-script create-group name="My group" codeName="my-group" permissions='[ "my-second-perm" ]'
 
-node run-script create-user userPermissions='[ "my-first-perm" ]' groups='[ "my-group" ]'
+foal run-script create-user userPermissions='[ "my-first-perm" ]' groups='[ "my-group" ]'

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -35,9 +35,9 @@ test "$response" -ge 200 && test "$response" -le 299
 pm2 delete index
 
 # Test the default shell scripts to create permissions, groups and users.
-node lib/scripts/create-perm name="My first permission" codeName="my-first-perm"
-node lib/scripts/create-perm name="My second permission" codeName="my-second-perm"
+node run-script create-perm name="My first permission" codeName="my-first-perm"
+node run-script create-perm name="My second permission" codeName="my-second-perm"
 
-node lib/scripts/create-group name="My group" codeName="my-group" permissions='[ "my-second-perm" ]'
+node run-script create-group name="My group" codeName="my-group" permissions='[ "my-second-perm" ]'
 
-node lib/scripts/create-user userPermissions='[ "my-first-perm" ]' groups='[ "my-group" ]'
+node run-script create-user userPermissions='[ "my-first-perm" ]' groups='[ "my-group" ]'

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "scripts": {
-    "test": "npm run test:generators && npm run dev:test:script",
+    "test": "npm run test:generators && npm run test:script",
     "test:generators": "NODE_ENV=test mocha --require ts-node/register \"./src/generate/generators/**/*.spec.ts\"",
     "dev:test:generators": "NODE_ENV=test mocha --require ts-node/register --watch --watch-extensions ts \"./src/generate/generators/**/*.spec.ts\"",
     "test:script": "NODE_ENV=test mocha --require ts-node/register \"./src/run-script.spec.ts\"",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,8 +5,11 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "scripts": {
-    "test": "NODE_ENV=test mocha --require ts-node/register \"./src/generate/generators/**/*.spec.ts\"",
-    "dev:test": "NODE_ENV=test mocha --require ts-node/register --watch --watch-extensions ts \"./src/generate/generators/**/*.spec.ts\"",
+    "test": "npm run test:generators && npm run dev:test:script",
+    "test:generators": "NODE_ENV=test mocha --require ts-node/register \"./src/generate/generators/**/*.spec.ts\"",
+    "dev:test:generators": "NODE_ENV=test mocha --require ts-node/register --watch --watch-extensions ts \"./src/generate/generators/**/*.spec.ts\"",
+    "test:script": "NODE_ENV=test mocha --require ts-node/register \"./src/run-script.spec.ts\"",
+    "dev:test:script": "NODE_ENV=test mocha --require ts-node/register --watch --watch-extensions ts \"./src/run-script.spec.ts\"",
     "build": "rimraf lib && tsc -p tsconfig-build.json && copyfiles -u 3 \"src/generate/templates/**/*\" lib/generate/templates",
     "prepublish": "npm run build"
   },

--- a/packages/cli/src/generate/specs/app/src/scripts/create-group.ts
+++ b/packages/cli/src/generate/specs/app/src/scripts/create-group.ts
@@ -13,7 +13,7 @@ const argSchema = {
   type: 'object',
 };
 
-async function main(argv) {
+export async function main(argv) {
   const args = getCommandLineArguments(argv);
 
   try {
@@ -54,5 +54,3 @@ async function main(argv) {
     console.log(error.message);
   }
 }
-
-main(process.argv);

--- a/packages/cli/src/generate/specs/app/src/scripts/create-perm.ts
+++ b/packages/cli/src/generate/specs/app/src/scripts/create-perm.ts
@@ -12,7 +12,7 @@ const argSchema = {
   type: 'object',
 };
 
-async function main(argv) {
+export async function main(argv) {
   const args = getCommandLineArguments(argv);
 
   try {
@@ -41,5 +41,3 @@ async function main(argv) {
     console.log(error.message);
   }
 }
-
-main(process.argv);

--- a/packages/cli/src/generate/specs/app/src/scripts/create-user.ts
+++ b/packages/cli/src/generate/specs/app/src/scripts/create-user.ts
@@ -17,7 +17,7 @@ const argSchema = {
   type: 'object',
 };
 
-async function main(argv) {
+export async function main(argv) {
   const args = getCommandLineArguments(argv);
 
   try {
@@ -69,5 +69,3 @@ async function main(argv) {
     console.log(error.message);
   }
 }
-
-main(process.argv);

--- a/packages/cli/src/generate/specs/script/test-foo-bar.ts
+++ b/packages/cli/src/generate/specs/script/test-foo-bar.ts
@@ -11,7 +11,7 @@ const argSchema = {
   type: 'object',
 };
 
-async function main(argv) {
+export async function main(argv) {
   const args = getCommandLineArguments(argv);
 
   try {
@@ -30,5 +30,3 @@ async function main(argv) {
 
   // Do something.
 }
-
-main(process.argv);

--- a/packages/cli/src/generate/templates/app/src/scripts/create-group.ts
+++ b/packages/cli/src/generate/templates/app/src/scripts/create-group.ts
@@ -13,7 +13,7 @@ const argSchema = {
   type: 'object',
 };
 
-async function main(argv) {
+export async function main(argv) {
   const args = getCommandLineArguments(argv);
 
   try {
@@ -54,5 +54,3 @@ async function main(argv) {
     console.log(error.message);
   }
 }
-
-main(process.argv);

--- a/packages/cli/src/generate/templates/app/src/scripts/create-perm.ts
+++ b/packages/cli/src/generate/templates/app/src/scripts/create-perm.ts
@@ -12,7 +12,7 @@ const argSchema = {
   type: 'object',
 };
 
-async function main(argv) {
+export async function main(argv) {
   const args = getCommandLineArguments(argv);
 
   try {
@@ -41,5 +41,3 @@ async function main(argv) {
     console.log(error.message);
   }
 }
-
-main(process.argv);

--- a/packages/cli/src/generate/templates/app/src/scripts/create-user.ts
+++ b/packages/cli/src/generate/templates/app/src/scripts/create-user.ts
@@ -17,7 +17,7 @@ const argSchema = {
   type: 'object',
 };
 
-async function main(argv) {
+export async function main(argv) {
   const args = getCommandLineArguments(argv);
 
   try {
@@ -69,5 +69,3 @@ async function main(argv) {
     console.log(error.message);
   }
 }
-
-main(process.argv);

--- a/packages/cli/src/generate/templates/script/script.ts
+++ b/packages/cli/src/generate/templates/script/script.ts
@@ -11,7 +11,7 @@ const argSchema = {
   type: 'object',
 };
 
-async function main(argv) {
+export async function main(argv) {
   const args = getCommandLineArguments(argv);
 
   try {
@@ -30,5 +30,3 @@ async function main(argv) {
 
   // Do something.
 }
-
-main(process.argv);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ import {
   createService,
   ServiceType
 } from './generate';
+import { runScript } from './run-script';
 
 // tslint:disable-next-line:no-var-requires
 const pkg = require('../package.json');
@@ -33,6 +34,13 @@ program
   .description('Creates a new directory with a new FoalTS app.')
   .action((name: string) => {
     createApp({ name });
+  });
+
+program
+  .command('run-script <name>')
+  .description('Runs the given script.')
+  .action((name: string) => {
+    runScript({ name });
   });
 
 program

--- a/packages/cli/src/run-script.spec.ts
+++ b/packages/cli/src/run-script.spec.ts
@@ -20,7 +20,7 @@ describe('runScript', () => {
   it('should log a suitable message if lib/scripts/my-script.js and src/scripts/my-script.ts do not exist.', () => {
     let msg;
     const log = message => msg = message;
-    runScript('my-script', log);
+    runScript({ name: 'my-script' }, log);
 
     strictEqual(
       msg, 'The script "my-script" does not exist. You can create it by running the command "foal g script my-script".'
@@ -34,12 +34,12 @@ describe('runScript', () => {
 
     let msg;
     const log = message => msg = message;
-    runScript('my-script', log);
+    runScript({ name: 'my-script' }, log);
 
     strictEqual(
       msg,
       'The script "my-script" does not exist in lib/scripts/. But it exists in src/scripts/.'
-        + ' Please build your script first by running the command "npm run build".'
+        + ' Please build your script by running the command "npm run build".'
     );
   });
 
@@ -52,7 +52,7 @@ describe('runScript', () => {
 
     delete require.cache[join(process.cwd(), `./lib/scripts/my-script.js`)];
 
-    runScript('my-script', log);
+    runScript({ name: 'my-script' }, log);
 
     strictEqual(
       msg,
@@ -70,7 +70,7 @@ module.exports.main = function main(argv) {
 
     delete require.cache[join(process.cwd(), `./lib/scripts/my-script.js`)];
 
-    runScript('my-script');
+    runScript({ name: 'my-script' });
 
     if (!existsSync('my-script-temp')) {
       throw new Error('The script was not executed');

--- a/packages/cli/src/run-script.spec.ts
+++ b/packages/cli/src/run-script.spec.ts
@@ -1,0 +1,82 @@
+// std
+import { deepStrictEqual, strictEqual } from 'assert';
+import { join } from 'path';
+
+// FoalTS
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { mkdirIfDoesNotExist, rmdirIfExists, rmfileIfExists } from './generate/utils';
+import { runScript } from './run-script';
+
+describe('runScript', () => {
+
+  afterEach(() => {
+    rmfileIfExists('src/scripts/my-script.ts');
+    rmdirIfExists('src/scripts');
+    rmfileIfExists('lib/scripts/my-script.js');
+    rmdirIfExists('lib/scripts');
+    rmfileIfExists('my-script-temp');
+  });
+
+  it('should log a suitable message if lib/scripts/my-script.js and src/scripts/my-script.ts do not exist.', () => {
+    let msg;
+    const log = message => msg = message;
+    runScript('my-script', log);
+
+    strictEqual(
+      msg, 'The script "my-script" does not exist. You can create it by running the command "foal g script my-script".'
+    );
+  });
+
+  it('should log a suitable message if lib/scripts/my-script.js does not exist but '
+      + 'src/scripts/my-script.ts exists.', () => {
+    mkdirIfDoesNotExist('src/scripts');
+    writeFileSync('src/scripts/my-script.ts', '', 'utf8');
+
+    let msg;
+    const log = message => msg = message;
+    runScript('my-script', log);
+
+    strictEqual(
+      msg,
+      'The script "my-script" does not exist in lib/scripts/. But it exists in src/scripts/.'
+        + ' Please build your script first by running the command "npm run build".'
+    );
+  });
+
+  it('should log a suitable message if no function called "main" was found in lib/scripts/my-script.js.', () => {
+    mkdirIfDoesNotExist('lib/scripts');
+    writeFileSync('lib/scripts/my-script.js', '', 'utf8');
+
+    let msg;
+    const log = message => msg = message;
+
+    delete require.cache[join(process.cwd(), `./lib/scripts/my-script.js`)];
+
+    runScript('my-script', log);
+
+    strictEqual(
+      msg,
+      'Error: No "main" function was found in lib/scripts/my-script.js.'
+    );
+  });
+
+  it('should call the "main" function of lib/scripts/my-script.js with process.argv.', () => {
+    mkdirIfDoesNotExist('lib/scripts');
+    const scriptContent = `const { writeFileSync } = require('fs');
+module.exports.main = function main(argv) {
+  writeFileSync('my-script-temp', JSON.stringify(argv), 'utf8');
+}`;
+    writeFileSync('lib/scripts/my-script.js', scriptContent, 'utf8');
+
+    delete require.cache[join(process.cwd(), `./lib/scripts/my-script.js`)];
+
+    runScript('my-script');
+
+    if (!existsSync('my-script-temp')) {
+      throw new Error('The script was not executed');
+    }
+    const actual = JSON.parse(readFileSync('my-script-temp', 'utf8'));
+    deepStrictEqual(actual, process.argv);
+  });
+
+});

--- a/packages/cli/src/run-script.ts
+++ b/packages/cli/src/run-script.ts
@@ -1,0 +1,26 @@
+// std
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+export function runScript(name: string, log = console.log) {
+  if (!existsSync(`lib/scripts/${name}.js`)) {
+    if (existsSync(`src/scripts/${name}.ts`)) {
+      log(
+        `The script "${name}" does not exist in lib/scripts/. But it exists in src/scripts/.`
+          + ' Please build your script first by running the command "npm run build".'
+      );
+    } else {
+      log(`The script "${name}" does not exist. You can create it by running the command "foal g script ${name}".`);
+    }
+    return;
+  }
+
+  const { main } = require(join(process.cwd(), `./lib/scripts/${name}`));
+
+  if (!main) {
+    log(`Error: No "main" function was found in lib/scripts/${name}.js.`);
+    return;
+  }
+
+  main(process.argv);
+}

--- a/packages/cli/src/run-script.ts
+++ b/packages/cli/src/run-script.ts
@@ -2,12 +2,12 @@
 import { existsSync } from 'fs';
 import { join } from 'path';
 
-export function runScript(name: string, log = console.log) {
+export function runScript({ name }: { name: string }, log = console.log) {
   if (!existsSync(`lib/scripts/${name}.js`)) {
     if (existsSync(`src/scripts/${name}.ts`)) {
       log(
         `The script "${name}" does not exist in lib/scripts/. But it exists in src/scripts/.`
-          + ' Please build your script first by running the command "npm run build".'
+          + ' Please build your script by running the command "npm run build".'
       );
     } else {
       log(`The script "${name}" does not exist. You can create it by running the command "foal g script ${name}".`);

--- a/packages/core/src/common/utils/get-command-line-arguments.util.spec.ts
+++ b/packages/core/src/common/utils/get-command-line-arguments.util.spec.ts
@@ -6,10 +6,12 @@ import { getCommandLineArguments } from './get-command-line-arguments.util';
 
 describe('getCommandLineArguments', () => {
   it('should convert the arguments to an object.', () => {
-    // node foo.js foo=barfoo bar='hello world'
+    // foal run-script foo foo=barfoo bar='hello world'
     const argv = [
       '/Users/loicpoullain/.nvm/versions/node/v8.11.3/bin/node',
-      '/Users/loicpoullain/projects/FoalTS/foal/foo.js',
+      '/Users/loicpoullain/.nvm/versions/node/v8.11.3/bin/foal',
+      'run-script',
+      'foo',
       'prod',
       'foo=barfoo',
       'bar=hello world'
@@ -25,7 +27,9 @@ describe('getCommandLineArguments', () => {
   it('should parse the JSON value.', () => {
     const argv = [
       '/Users/loicpoullain/.nvm/versions/node/v8.11.3/bin/node',
-      '/Users/loicpoullain/projects/FoalTS/foal/foo.js',
+      '/Users/loicpoullain/.nvm/versions/node/v8.11.3/bin/foal',
+      'run-script',
+      'foo',
       'bar={ "foo": "bar" }',
       'foo=3'
     ];

--- a/packages/core/src/common/utils/get-command-line-arguments.util.ts
+++ b/packages/core/src/common/utils/get-command-line-arguments.util.ts
@@ -1,5 +1,5 @@
 export function getCommandLineArguments(argv: string[]) {
-  const args = argv.splice(2);
+  const args = argv.splice(4);
   const result: any = {};
   args.forEach(keyAndValue => {
     const [ key, value ] = keyAndValue.split('=');


### PR DESCRIPTION
# Issue

- Currently we define a `main` function that is called directly in each script. This prevents the user from easily writing unit tests.
- (Writing `node lib/scripts/my-scripts.js` is a bit tedious).

# Solution and steps

Create a command `foal run-script my-script` that runs the scripts by calling their `main` function.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.