### PR TITLE
Display code coverage with codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
 before_install:
   - npm install -g lerna
   - npm install -g pm2
+  - npm install -g codecov
 
 install:
   - npm install
@@ -25,3 +26,6 @@ script:
   - lerna run test
   - lerna run e2e
   - ./e2e_test.sh
+
+after_success:
+  - codecov -f packages/core/coverage/*.json

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
   <a href="https://travis-ci.org/FoalTS/foal">
     <img src="https://travis-ci.org/FoalTS/foal.svg?branch=add-travis" alt="Build Status">
   </a>
+  <a href="https://codecov.io/gh/FoalTS/foal/branch/master/graphs/badge.svg">
+    <img src="https://codecov.io/gh/FoalTS/foal/branch/master/graphs/badge.svg" alt="Code coverage">
+  </a>
   <a href="https://snyk.io/test/github/foalts/foal">
     <img src="https://snyk.io/test/github/foalts/foal/badge.svg" alt="Known Vulnerabilities">
   </a>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <a href="https://travis-ci.org/FoalTS/foal">
     <img src="https://travis-ci.org/FoalTS/foal.svg?branch=add-travis" alt="Build Status">
   </a>
-  <a href="https://codecov.io/gh/FoalTS/foal/branch/master/graphs/badge.svg">
+  <a href="https://codecov.io/github/FoalTS/foal">
     <img src="https://codecov.io/gh/FoalTS/foal/branch/master/graphs/badge.svg" alt="Code coverage">
   </a>
   <a href="https://snyk.io/test/github/foalts/foal">

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "scripts": {
-    "test": "nyc --reporter=html --reporter=text mocha --require ts-node/register --require source-map-support/register \"./src/**/*.spec.ts\"",
+    "test": "nyc --reporter=json --reporter=text mocha --require ts-node/register --require source-map-support/register \"./src/**/*.spec.ts\"",
     "e2e": "mocha --require ts-node/register \"./e2e/**/*.spec.ts\"",
     "dev:e2e": "mocha --require ts-node/register --watch --watch-extensions ts \"./e2e/**/*.spec.ts\"",
     "dev:test": "mocha --require ts-node/register --watch --watch-extensions ts \"./src/**/*.spec.ts\"",


### PR DESCRIPTION
# Issue

Code coverage should be displayed in the `README.md` to show that the framework has tests. See https://github.com/FoalTS/foal/issues/136.

# Solution and steps

Use codecov.io

# To improve

Only the code coverage of the package `@foal/core` is computed. The packages `@foal/cli` and `@foal/ejs` should also be included in the computation.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.