### PR TITLE
Make the tests run with NODE_ENV=test (on Unix/Windows)

### DIFF
--- a/packages/cli/src/generate/generators/app/create-app.spec.ts
+++ b/packages/cli/src/generate/generators/app/create-app.spec.ts
@@ -60,6 +60,7 @@ describe('createApp', () => {
     testEnv.rmdirIfExists('src/scripts');
 
     testEnv.rmfileIfExists('src/index.ts');
+    testEnv.rmfileIfExists('src/test.ts');
     testEnv.rmdirIfExists('src');
 
     // Root
@@ -129,7 +130,8 @@ describe('createApp', () => {
 
   it('should render the src templates.', () => {
     testEnv
-      .validateSpec('src/index.ts');
+      .validateSpec('src/index.ts')
+      .validateSpec('src/test.ts');
   });
 
   it('should render the root templates.', () => {

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -53,6 +53,7 @@ export function createApp({ name, sessionSecret }:
       // Src
       .mkdirIfDoesNotExist('src')
       .copyFileFromTemplates('src/index.ts')
+      .copyFileFromTemplates('src/test.ts')
         // App
         .mkdirIfDoesNotExist('src/app')
         .copyFileFromTemplates('src/app/app.module.ts')

--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -11,8 +11,8 @@
 
     "build:test": "copy-cli \"src/**/*.html\" lib && tsc",
     "build:test:w": "tsc -w",
-    "start:test": "mocha \"./lib/**/*.spec.js\"",
-    "start:test:w": "mocha -w \"./lib/**/*.spec.js\"",
+    "start:test": "mocha --file \"./lib/test.js\" \"./lib/**/*.spec.js\"",
+    "start:test:w": "mocha --file \"./lib/test.js\" -w \"./lib/**/*.spec.js\"",
     "test": "npm run build:test && concurrently \"npm run build:test:w\" \"npm run start:test:w\"",
 
     "lint": "tslint -c tslint.json -p tsconfig.json",

--- a/packages/cli/src/generate/specs/app/src/test.ts
+++ b/packages/cli/src/generate/specs/app/src/test.ts
@@ -1,0 +1,1 @@
+process.env.NODE_ENV = 'test';

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -11,8 +11,8 @@
 
     "build:test": "copy-cli \"src/**/*.html\" lib && tsc",
     "build:test:w": "tsc -w",
-    "start:test": "mocha \"./lib/**/*.spec.js\"",
-    "start:test:w": "mocha -w \"./lib/**/*.spec.js\"",
+    "start:test": "mocha --file \"./lib/test.js\" \"./lib/**/*.spec.js\"",
+    "start:test:w": "mocha --file \"./lib/test.js\" -w \"./lib/**/*.spec.js\"",
     "test": "npm run build:test && concurrently \"npm run build:test:w\" \"npm run start:test:w\"",
 
     "lint": "tslint -c tslint.json -p tsconfig.json",

--- a/packages/cli/src/generate/templates/app/src/test.ts
+++ b/packages/cli/src/generate/templates/app/src/test.ts
@@ -1,0 +1,1 @@
+process.env.NODE_ENV = 'test';


### PR DESCRIPTION
# Issue

Test do not run with `NODE_ENV=test` causing the configuration not to use the `xxx.test.json` files (issue https://github.com/FoalTS/foal/issues/187).

# Solution and steps

The solution should work both on Windows and Unix systems.

- [x] Add a new file `src/test.ts` that sets the env variable `NODE_ENV` to `test`.
- [x] Update `package.json` to execute this file before running the tests.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.