### PR TITLE
Add an API section to the docs.

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -60,3 +60,7 @@
 
 * [Configuration](./deployment-and-environments/configuration.md)
 * [Ship to Production](./deployment-and-environments/ship-to-production.md)<!-- * [Serverless Framework](./fundamentals/serverless.md) -->
+
+## API Reference
+
+* [@foal/core](./api/index.md)

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,1679 @@
+# Table of contents
+
+* [index.ts][SourceFile-0]
+    * Functions
+        * [parsePassword][FunctionDeclaration-0]
+        * [Authenticate][FunctionDeclaration-1]
+        * [strategy][FunctionDeclaration-2]
+        * [PermissionRequired][FunctionDeclaration-3]
+        * [LoginRequired][FunctionDeclaration-4]
+        * [isObjectDoesNotExist][FunctionDeclaration-5]
+        * [isPermissionDenied][FunctionDeclaration-6]
+        * [isValidationError][FunctionDeclaration-7]
+        * [Log][FunctionDeclaration-8]
+        * [ValidateBody][FunctionDeclaration-9]
+        * [ValidateQuery][FunctionDeclaration-10]
+        * [middleware][FunctionDeclaration-11]
+        * [controller][FunctionDeclaration-12]
+        * [escapeProp][FunctionDeclaration-13]
+        * [escape][FunctionDeclaration-14]
+        * [getCommandLineArguments][FunctionDeclaration-15]
+        * [render][FunctionDeclaration-16]
+        * [subModule][FunctionDeclaration-17]
+        * [validate][FunctionDeclaration-18]
+        * [Get][FunctionDeclaration-19]
+        * [Post][FunctionDeclaration-20]
+        * [Put][FunctionDeclaration-21]
+        * [Patch][FunctionDeclaration-22]
+        * [Delete][FunctionDeclaration-23]
+        * [isHttpResponse][FunctionDeclaration-24]
+        * [isHttpResponseSuccess][FunctionDeclaration-25]
+        * [isHttpResponseOK][FunctionDeclaration-26]
+        * [isHttpResponseCreated][FunctionDeclaration-27]
+        * [isHttpResponseNoContent][FunctionDeclaration-28]
+        * [isHttpResponseRedirection][FunctionDeclaration-29]
+        * [isHttpResponseRedirect][FunctionDeclaration-30]
+        * [isHttpResponseClientError][FunctionDeclaration-31]
+        * [isHttpResponseBadRequest][FunctionDeclaration-32]
+        * [isHttpResponseUnauthorized][FunctionDeclaration-33]
+        * [isHttpResponseForbidden][FunctionDeclaration-34]
+        * [isHttpResponseNotFound][FunctionDeclaration-35]
+        * [isHttpResponseMethodNotAllowed][FunctionDeclaration-36]
+        * [isHttpResponseConflict][FunctionDeclaration-37]
+        * [isHttpResponseServerError][FunctionDeclaration-38]
+        * [isHttpResponseInternalServerError][FunctionDeclaration-39]
+        * [isHttpResponseNotImplemented][FunctionDeclaration-40]
+        * [Hook][FunctionDeclaration-41]
+        * [getHookFunction][FunctionDeclaration-42]
+        * [makeModuleRoutes][FunctionDeclaration-43]
+        * [getPath][FunctionDeclaration-44]
+        * [getHttpMethod][FunctionDeclaration-45]
+        * [Module][FunctionDeclaration-46]
+        * [createController][FunctionDeclaration-47]
+        * [Controller][FunctionDeclaration-48]
+        * [Service][FunctionDeclaration-49]
+        * [createApp][FunctionDeclaration-50]
+    * Interfaces
+        * [IAuthenticator][InterfaceDeclaration-2]
+        * [Strategy][InterfaceDeclaration-3]
+        * [IResourceCollection][InterfaceDeclaration-4]
+        * [CollectionParams][InterfaceDeclaration-5]
+        * [Class][InterfaceDeclaration-1]
+        * [Route][InterfaceDeclaration-6]
+        * [IModule][InterfaceDeclaration-7]
+        * [CreateAppOptions][InterfaceDeclaration-8]
+    * Types
+        * [Middleware][TypeAliasDeclaration-1]
+        * [HttpMethod][TypeAliasDeclaration-3]
+        * [HookFunction][TypeAliasDeclaration-4]
+        * [HookDecorator][TypeAliasDeclaration-0]
+    * Variables
+        * [emailSchema][VariableDeclaration-0]
+
+# index.ts
+
+## Functions
+
+### parsePassword
+
+```typescript
+function parsePassword(password: string): Promise<string>;
+```
+
+**Parameters**
+
+| Name     | Type   |
+| -------- | ------ |
+| password | string |
+
+**Return type**
+
+Promise<string>
+
+----------
+
+### Authenticate
+
+```typescript
+function Authenticate(UserEntity: Class<AbstractUser>): HookDecorator;
+```
+
+**Parameters**
+
+| Name       | Type                                                                |
+| ---------- | ------------------------------------------------------------------- |
+| UserEntity | [Class][InterfaceDeclaration-1]<[AbstractUser][ClassDeclaration-1]> |
+
+**Return type**
+
+[HookDecorator][TypeAliasDeclaration-0]
+
+----------
+
+### strategy
+
+```typescript
+function strategy(name: Strategy["name"], authenticatorClass: Strategy["authenticatorClass"], schema: Strategy["schema"]): Strategy;
+```
+
+**Parameters**
+
+| Name               | Type                                                     |
+| ------------------ | -------------------------------------------------------- |
+| name               | [Strategy][InterfaceDeclaration-3]["name"]               |
+| authenticatorClass | [Strategy][InterfaceDeclaration-3]["authenticatorClass"] |
+| schema             | [Strategy][InterfaceDeclaration-3]["schema"]             |
+
+**Return type**
+
+[Strategy][InterfaceDeclaration-3]
+
+----------
+
+### PermissionRequired
+
+```typescript
+function PermissionRequired(perm: string, options: { redirect?: string | undefined; } = {}): HookDecorator;
+```
+
+**Parameters**
+
+| Name    | Type                                    | Default value |
+| ------- | --------------------------------------- | ------------- |
+| perm    | string                                  |               |
+| options | { redirect?: string &#124; undefined; } | {}            |
+
+**Return type**
+
+[HookDecorator][TypeAliasDeclaration-0]
+
+----------
+
+### LoginRequired
+
+```typescript
+function LoginRequired(options: { redirect?: string | undefined; } = {}): HookDecorator;
+```
+
+**Parameters**
+
+| Name    | Type                                    | Default value |
+| ------- | --------------------------------------- | ------------- |
+| options | { redirect?: string &#124; undefined; } | {}            |
+
+**Return type**
+
+[HookDecorator][TypeAliasDeclaration-0]
+
+----------
+
+### isObjectDoesNotExist
+
+```typescript
+function isObjectDoesNotExist(err: object): err is ObjectDoesNotExist;
+```
+
+**Parameters**
+
+| Name | Type   |
+| ---- | ------ |
+| err  | object |
+
+**Return type**
+
+err is [ObjectDoesNotExist][ClassDeclaration-22]
+
+----------
+
+### isPermissionDenied
+
+```typescript
+function isPermissionDenied(err: object): err is PermissionDenied;
+```
+
+**Parameters**
+
+| Name | Type   |
+| ---- | ------ |
+| err  | object |
+
+**Return type**
+
+err is [PermissionDenied][ClassDeclaration-23]
+
+----------
+
+### isValidationError
+
+```typescript
+function isValidationError(err: object): err is ValidationError;
+```
+
+**Parameters**
+
+| Name | Type   |
+| ---- | ------ |
+| err  | object |
+
+**Return type**
+
+err is [ValidationError][ClassDeclaration-24]
+
+----------
+
+### Log
+
+```typescript
+function Log(message: string, logFn: { (message?: any, ...optionalParams: any[]): void; (message?: any, ...optionalParams: any[]): voi... = console.log): HookDecorator;
+```
+
+**Parameters**
+
+| Name    | Type                                                                                                 | Default value |
+| ------- | ---------------------------------------------------------------------------------------------------- | ------------- |
+| message | string                                                                                               |               |
+| logFn   | { (message?: any, ...optionalParams: any[]): void; (message?: any, ...optionalParams: any[]): voi... | console.log   |
+
+**Return type**
+
+[HookDecorator][TypeAliasDeclaration-0]
+
+----------
+
+### ValidateBody
+
+```typescript
+function ValidateBody(schema: object, ajv: Ajv = defaultInstance): HookDecorator;
+```
+
+**Parameters**
+
+| Name   | Type   | Default value   |
+| ------ | ------ | --------------- |
+| schema | object |                 |
+| ajv    | Ajv    | defaultInstance |
+
+**Return type**
+
+[HookDecorator][TypeAliasDeclaration-0]
+
+----------
+
+### ValidateQuery
+
+```typescript
+function ValidateQuery(schema: object, ajv: Ajv = defaultInstance): HookDecorator;
+```
+
+**Parameters**
+
+| Name   | Type   | Default value   |
+| ------ | ------ | --------------- |
+| schema | object |                 |
+| ajv    | Ajv    | defaultInstance |
+
+**Return type**
+
+[HookDecorator][TypeAliasDeclaration-0]
+
+----------
+
+### middleware
+
+```typescript
+function middleware(operations: string, middleware: Middleware): Partial<Record<keyof IResourceCollection, Middleware>>;
+```
+
+**Parameters**
+
+| Name       | Type                                 |
+| ---------- | ------------------------------------ |
+| operations | string                               |
+| middleware | [Middleware][TypeAliasDeclaration-1] |
+
+**Return type**
+
+Partial<Record<keyof [IResourceCollection][InterfaceDeclaration-4], [Middleware][TypeAliasDeclaration-1]>>
+
+----------
+
+### controller
+
+```typescript
+function controller(path: string, controllerClass: Class<any>): Class<any>;
+```
+
+**Parameters**
+
+| Name            | Type                                 |
+| --------------- | ------------------------------------ |
+| path            | string                               |
+| controllerClass | [Class][InterfaceDeclaration-1]<any> |
+
+**Return type**
+
+[Class][InterfaceDeclaration-1]<any>
+
+----------
+
+### escapeProp
+
+```typescript
+function escapeProp(object: object, propName: string): void;
+```
+
+**Parameters**
+
+| Name     | Type   |
+| -------- | ------ |
+| object   | object |
+| propName | string |
+
+**Return type**
+
+void
+
+----------
+
+### escape
+
+```typescript
+function escape(str: string): string;
+```
+
+**Parameters**
+
+| Name | Type   |
+| ---- | ------ |
+| str  | string |
+
+**Return type**
+
+string
+
+----------
+
+### getCommandLineArguments
+
+```typescript
+function getCommandLineArguments(argv: string[]): any;
+```
+
+**Parameters**
+
+| Name | Type     |
+| ---- | -------- |
+| argv | string[] |
+
+**Return type**
+
+any
+
+----------
+
+### render
+
+```typescript
+function render(templatePath: string, locals: object, dirname: string): HttpResponseOK;
+```
+
+**Parameters**
+
+| Name         | Type   |
+| ------------ | ------ |
+| templatePath | string |
+| locals       | object |
+| dirname      | string |
+
+**Return type**
+
+[HttpResponseOK][ClassDeclaration-19]
+
+----------
+
+### subModule
+
+```typescript
+function subModule(path: string, moduleClass: Class<any>): Class<any>;
+```
+
+**Parameters**
+
+| Name        | Type                                 |
+| ----------- | ------------------------------------ |
+| path        | string                               |
+| moduleClass | [Class][InterfaceDeclaration-1]<any> |
+
+**Return type**
+
+[Class][InterfaceDeclaration-1]<any>
+
+----------
+
+### validate
+
+```typescript
+function validate(schema: object, data: any): void;
+```
+
+**Parameters**
+
+| Name   | Type   |
+| ------ | ------ |
+| schema | object |
+| data   | any    |
+
+**Return type**
+
+void
+
+----------
+
+### Get
+
+```typescript
+function Get(path?: string | undefined): (target: any, propertyKey: string) => void;
+```
+
+**Parameters**
+
+| Name | Type                    |
+| ---- | ----------------------- |
+| path | string &#124; undefined |
+
+**Return type**
+
+(target: any, propertyKey: string) => void
+
+----------
+
+### Post
+
+```typescript
+function Post(path?: string | undefined): (target: any, propertyKey: string) => void;
+```
+
+**Parameters**
+
+| Name | Type                    |
+| ---- | ----------------------- |
+| path | string &#124; undefined |
+
+**Return type**
+
+(target: any, propertyKey: string) => void
+
+----------
+
+### Put
+
+```typescript
+function Put(path?: string | undefined): (target: any, propertyKey: string) => void;
+```
+
+**Parameters**
+
+| Name | Type                    |
+| ---- | ----------------------- |
+| path | string &#124; undefined |
+
+**Return type**
+
+(target: any, propertyKey: string) => void
+
+----------
+
+### Patch
+
+```typescript
+function Patch(path?: string | undefined): (target: any, propertyKey: string) => void;
+```
+
+**Parameters**
+
+| Name | Type                    |
+| ---- | ----------------------- |
+| path | string &#124; undefined |
+
+**Return type**
+
+(target: any, propertyKey: string) => void
+
+----------
+
+### Delete
+
+```typescript
+function Delete(path?: string | undefined): (target: any, propertyKey: string) => void;
+```
+
+**Parameters**
+
+| Name | Type                    |
+| ---- | ----------------------- |
+| path | string &#124; undefined |
+
+**Return type**
+
+(target: any, propertyKey: string) => void
+
+----------
+
+### isHttpResponse
+
+```typescript
+function isHttpResponse(obj: any): obj is HttpResponse;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponse][ClassDeclaration-8]
+
+----------
+
+### isHttpResponseSuccess
+
+```typescript
+function isHttpResponseSuccess(obj: any): obj is HttpResponseSuccess;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseSuccess][ClassDeclaration-10]
+
+----------
+
+### isHttpResponseOK
+
+```typescript
+function isHttpResponseOK(obj: any): obj is HttpResponseOK;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseOK][ClassDeclaration-19]
+
+----------
+
+### isHttpResponseCreated
+
+```typescript
+function isHttpResponseCreated(obj: any): obj is HttpResponseCreated;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseCreated][ClassDeclaration-21]
+
+----------
+
+### isHttpResponseNoContent
+
+```typescript
+function isHttpResponseNoContent(obj: any): obj is HttpResponseNoContent;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseNoContent][ClassDeclaration-9]
+
+----------
+
+### isHttpResponseRedirection
+
+```typescript
+function isHttpResponseRedirection(obj: any): obj is HttpResponseRedirection;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseRedirection][ClassDeclaration-7]
+
+----------
+
+### isHttpResponseRedirect
+
+```typescript
+function isHttpResponseRedirect(obj: any): obj is HttpResponseRedirect;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseRedirect][ClassDeclaration-6]
+
+----------
+
+### isHttpResponseClientError
+
+```typescript
+function isHttpResponseClientError(obj: any): obj is HttpResponseClientError;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseClientError][ClassDeclaration-12]
+
+----------
+
+### isHttpResponseBadRequest
+
+```typescript
+function isHttpResponseBadRequest(obj: any): obj is HttpResponseBadRequest;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseBadRequest][ClassDeclaration-13]
+
+----------
+
+### isHttpResponseUnauthorized
+
+```typescript
+function isHttpResponseUnauthorized(obj: any): obj is HttpResponseUnauthorized;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseUnauthorized][ClassDeclaration-14]
+
+----------
+
+### isHttpResponseForbidden
+
+```typescript
+function isHttpResponseForbidden(obj: any): obj is HttpResponseForbidden;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseForbidden][ClassDeclaration-20]
+
+----------
+
+### isHttpResponseNotFound
+
+```typescript
+function isHttpResponseNotFound(obj: any): obj is HttpResponseNotFound;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseNotFound][ClassDeclaration-11]
+
+----------
+
+### isHttpResponseMethodNotAllowed
+
+```typescript
+function isHttpResponseMethodNotAllowed(obj: any): obj is HttpResponseMethodNotAllowed;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseMethodNotAllowed][ClassDeclaration-16]
+
+----------
+
+### isHttpResponseConflict
+
+```typescript
+function isHttpResponseConflict(obj: any): obj is HttpResponseConflict;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseConflict][ClassDeclaration-26]
+
+----------
+
+### isHttpResponseServerError
+
+```typescript
+function isHttpResponseServerError(obj: any): obj is HttpResponseServerError;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseServerError][ClassDeclaration-18]
+
+----------
+
+### isHttpResponseInternalServerError
+
+```typescript
+function isHttpResponseInternalServerError(obj: any): obj is HttpResponseInternalServerError;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseInternalServerError][ClassDeclaration-27]
+
+----------
+
+### isHttpResponseNotImplemented
+
+```typescript
+function isHttpResponseNotImplemented(obj: any): obj is HttpResponseNotImplemented;
+```
+
+**Parameters**
+
+| Name | Type |
+| ---- | ---- |
+| obj  | any  |
+
+**Return type**
+
+obj is [HttpResponseNotImplemented][ClassDeclaration-17]
+
+----------
+
+### Hook
+
+```typescript
+function Hook(hookFunction: HookFunction): HookDecorator;
+```
+
+**Parameters**
+
+| Name         | Type                                   |
+| ------------ | -------------------------------------- |
+| hookFunction | [HookFunction][TypeAliasDeclaration-4] |
+
+**Return type**
+
+[HookDecorator][TypeAliasDeclaration-0]
+
+----------
+
+### getHookFunction
+
+```typescript
+function getHookFunction(hook: HookDecorator): HookFunction;
+```
+
+**Parameters**
+
+| Name | Type                                    |
+| ---- | --------------------------------------- |
+| hook | [HookDecorator][TypeAliasDeclaration-0] |
+
+**Return type**
+
+[HookFunction][TypeAliasDeclaration-4]
+
+----------
+
+### makeModuleRoutes
+
+```typescript
+function makeModuleRoutes(parentPath: string, parentHooks: HookFunction[], moduleClass: Class<IModule>, services: ServiceManager): Route[];
+```
+
+**Parameters**
+
+| Name        | Type                                                               |
+| ----------- | ------------------------------------------------------------------ |
+| parentPath  | string                                                             |
+| parentHooks | [HookFunction][TypeAliasDeclaration-4][]                           |
+| moduleClass | [Class][InterfaceDeclaration-1]<[IModule][InterfaceDeclaration-7]> |
+| services    | [ServiceManager][ClassDeclaration-28]                              |
+
+**Return type**
+
+[Route][InterfaceDeclaration-6][]
+
+----------
+
+### getPath
+
+```typescript
+function getPath(target: Class<any>, propertyKey?: string | undefined): string | undefined;
+```
+
+**Parameters**
+
+| Name        | Type                                 |
+| ----------- | ------------------------------------ |
+| target      | [Class][InterfaceDeclaration-1]<any> |
+| propertyKey | string &#124; undefined              |
+
+**Return type**
+
+string | undefined
+
+----------
+
+### getHttpMethod
+
+```typescript
+function getHttpMethod(target: Class<any>, propertyKey?: string | undefined): string | undefined;
+```
+
+**Parameters**
+
+| Name        | Type                                 |
+| ----------- | ------------------------------------ |
+| target      | [Class][InterfaceDeclaration-1]<any> |
+| propertyKey | string &#124; undefined              |
+
+**Return type**
+
+string | undefined
+
+----------
+
+### Module
+
+```typescript
+function Module(path?: string | undefined): { (target: Function): void; (target: Object, propertyKey: string | symbol): void; };
+```
+
+**Parameters**
+
+| Name | Type                    |
+| ---- | ----------------------- |
+| path | string &#124; undefined |
+
+**Return type**
+
+{ (target: Function): void; (target: Object, propertyKey: string | symbol): void; }
+
+----------
+
+### createController
+
+```typescript
+function createController<T>(controllerClass: Class<T>, services?: ServiceManager | undefined): T;
+```
+
+**Type parameters**
+
+| Name |
+| ---- |
+| T    |
+
+**Parameters**
+
+| Name            | Type                               |
+| --------------- | ---------------------------------- |
+| controllerClass | [Class][InterfaceDeclaration-1]<T> |
+| services        | ServiceManager &#124; undefined    |
+
+**Return type**
+
+T
+
+----------
+
+### Controller
+
+```typescript
+function Controller(path?: string | undefined): { (target: Function): void; (target: Object, propertyKey: string | symbol): void; };
+```
+
+**Parameters**
+
+| Name | Type                    |
+| ---- | ----------------------- |
+| path | string &#124; undefined |
+
+**Return type**
+
+{ (target: Function): void; (target: Object, propertyKey: string | symbol): void; }
+
+----------
+
+### Service
+
+```typescript
+function Service(): decorator;
+```
+
+**Return type**
+
+decorator
+
+----------
+
+### createApp
+
+```typescript
+function createApp(rootModuleClass: Class<IModule>, options: CreateAppOptions = {}): any;
+```
+
+**Parameters**
+
+| Name            | Type                                                               | Default value |
+| --------------- | ------------------------------------------------------------------ | ------------- |
+| rootModuleClass | [Class][InterfaceDeclaration-1]<[IModule][InterfaceDeclaration-7]> |               |
+| options         | [CreateAppOptions][InterfaceDeclaration-8]                         | {}            |
+
+**Return type**
+
+any
+
+## Interfaces
+
+### IAuthenticator
+
+```typescript
+interface IAuthenticator<User extends AbstractUser = AbstractUser> {
+    authenticate(credentials: any): User | null | Promise<User | null>;
+}
+```
+
+**Type parameters**
+
+| Name | Constraint                         | Default                            |
+| ---- | ---------------------------------- | ---------------------------------- |
+| User | [AbstractUser][ClassDeclaration-1] | [AbstractUser][ClassDeclaration-1] |
+#### Method
+
+```typescript
+authenticate(credentials: any): User | null | Promise<User | null>;
+```
+
+**Parameters**
+
+| Name        | Type |
+| ----------- | ---- |
+| credentials | any  |
+
+**Return type**
+
+User | null | Promise<User | null>
+
+
+----------
+
+### Strategy
+
+```typescript
+interface Strategy {
+    name: string;
+    authenticatorClass: Class<IAuthenticator<AbstractUser>>;
+    schema: object;
+}
+```
+
+**Properties**
+
+| Name               | Type                                                                                                          | Optional |
+| ------------------ | ------------------------------------------------------------------------------------------------------------- | -------- |
+| name               | string                                                                                                        | false    |
+| authenticatorClass | [Class][InterfaceDeclaration-1]<[IAuthenticator][InterfaceDeclaration-2]<[AbstractUser][ClassDeclaration-1]>> | false    |
+| schema             | object                                                                                                        | false    |
+
+----------
+
+### IResourceCollection
+
+Service interface. Create, read, update or delete resources and return representations of them.
+
+```typescript
+interface IResourceCollection {
+    create(user: AbstractUser | undefined, data: object, params: { fields?: string[]; }): any;
+    find(user: AbstractUser | undefined, params: { query?: object | undefined; fields?: string[]; }): any;
+    findById(user: AbstractUser | undefined, id: any, params: { fields?: string[]; }): any;
+    modifyById(user: AbstractUser | undefined, id: any, data: object, params: { fields?: string[]; }): any;
+    updateById(user: AbstractUser | undefined, id: any, data: object, params: { fields?: string[]; }): any;
+    deleteById(user: AbstractUser | undefined, id: any, params: {}): any;
+}
+```
+#### Method
+
+```typescript
+create(user: AbstractUser | undefined, data: object, params: { fields?: string[]; }): any;
+```
+
+**Parameters**
+
+| Name   | Type                                                |
+| ------ | --------------------------------------------------- |
+| user   | [AbstractUser][ClassDeclaration-1] &#124; undefined |
+| data   | object                                              |
+| params | { fields?: string[]; }                              |
+
+**Return type**
+
+any
+
+```typescript
+find(user: AbstractUser | undefined, params: { query?: object | undefined; fields?: string[]; }): any;
+```
+
+**Parameters**
+
+| Name   | Type                                                    |
+| ------ | ------------------------------------------------------- |
+| user   | [AbstractUser][ClassDeclaration-1] &#124; undefined     |
+| params | { query?: object &#124; undefined; fields?: string[]; } |
+
+**Return type**
+
+any
+
+```typescript
+findById(user: AbstractUser | undefined, id: any, params: { fields?: string[]; }): any;
+```
+
+**Parameters**
+
+| Name   | Type                                                |
+| ------ | --------------------------------------------------- |
+| user   | [AbstractUser][ClassDeclaration-1] &#124; undefined |
+| id     | any                                                 |
+| params | { fields?: string[]; }                              |
+
+**Return type**
+
+any
+
+```typescript
+modifyById(user: AbstractUser | undefined, id: any, data: object, params: { fields?: string[]; }): any;
+```
+
+**Parameters**
+
+| Name   | Type                                                |
+| ------ | --------------------------------------------------- |
+| user   | [AbstractUser][ClassDeclaration-1] &#124; undefined |
+| id     | any                                                 |
+| data   | object                                              |
+| params | { fields?: string[]; }                              |
+
+**Return type**
+
+any
+
+```typescript
+updateById(user: AbstractUser | undefined, id: any, data: object, params: { fields?: string[]; }): any;
+```
+
+**Parameters**
+
+| Name   | Type                                                |
+| ------ | --------------------------------------------------- |
+| user   | [AbstractUser][ClassDeclaration-1] &#124; undefined |
+| id     | any                                                 |
+| data   | object                                              |
+| params | { fields?: string[]; }                              |
+
+**Return type**
+
+any
+
+```typescript
+deleteById(user: AbstractUser | undefined, id: any, params: {}): any;
+```
+
+**Parameters**
+
+| Name   | Type                                                |
+| ------ | --------------------------------------------------- |
+| user   | [AbstractUser][ClassDeclaration-1] &#124; undefined |
+| id     | any                                                 |
+| params | {}                                                  |
+
+**Return type**
+
+any
+
+
+----------
+
+### CollectionParams
+
+```typescript
+interface CollectionParams {
+    query?: object | undefined;
+    fields?: string[];
+}
+```
+
+**Properties**
+
+| Name   | Type                    | Optional |
+| ------ | ----------------------- | -------- |
+| query  | object &#124; undefined | true     |
+| fields | string[]                | true     |
+
+----------
+
+### Class
+
+```typescript
+interface Class<T = any> {
+    new (args: any[]): T;
+}
+```
+
+**Type parameters**
+
+| Name | Default |
+| ---- | ------- |
+| T    | any     |
+#### Construct
+
+```typescript
+new (args: any[]): T;
+```
+
+**Parameters**
+
+| Name | Type  |
+| ---- | ----- |
+| args | any[] |
+
+**Return type**
+
+T
+
+
+----------
+
+### Route
+
+```typescript
+interface Route {
+    httpMethod: HttpMethod;
+    path: string;
+    hooks: HookFunction[];
+    controller: any;
+    propertyKey: string;
+}
+```
+
+**Properties**
+
+| Name        | Type                                     | Optional |
+| ----------- | ---------------------------------------- | -------- |
+| httpMethod  | [HttpMethod][TypeAliasDeclaration-3]     | false    |
+| path        | string                                   | false    |
+| hooks       | [HookFunction][TypeAliasDeclaration-4][] | false    |
+| controller  | any                                      | false    |
+| propertyKey | string                                   | false    |
+
+----------
+
+### IModule
+
+```typescript
+interface IModule {
+    controllers?: Class<any>[];
+    subModules?: Class<IModule>[];
+}
+```
+
+**Properties**
+
+| Name        | Type                                                                 | Optional |
+| ----------- | -------------------------------------------------------------------- | -------- |
+| controllers | [Class][InterfaceDeclaration-1]<any>[]                               | true     |
+| subModules  | [Class][InterfaceDeclaration-1]<[IModule][InterfaceDeclaration-7]>[] | true     |
+
+----------
+
+### CreateAppOptions
+
+```typescript
+interface CreateAppOptions {
+    store(session: any)?: any;
+}
+```
+#### Method
+
+```typescript
+store(session: any)?: any;
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| session | any  |
+
+**Return type**
+
+any
+
+
+## Types
+
+### Middleware
+
+```typescript
+type Middleware = (context: { user: AbstractUser | undefined; resource: any; data: any; params: CollectionParams; }) => any;
+```
+
+**Type**
+
+(context: { user: AbstractUser | undefined; resource: any; data: any; params: CollectionParams; }) => any
+
+----------
+
+### HttpMethod
+
+```typescript
+type HttpMethod = "POST" | "GET" | "PUT" | "PATCH" | "DELETE";
+```
+
+**Type**
+
+"POST" | "GET" | "PUT" | "PATCH" | "DELETE"
+
+----------
+
+### HookFunction
+
+```typescript
+type HookFunction = (ctx: Context<AbstractUser>, services: ServiceManager) => any;
+```
+
+**Type**
+
+(ctx: Context<AbstractUser>, services: ServiceManager) => any
+
+----------
+
+### HookDecorator
+
+```typescript
+type HookDecorator = (target: any, propertyKey?: string | undefined) => any;
+```
+
+**Type**
+
+(target: any, propertyKey?: string | undefined) => any
+
+## Classes
+
+### [EmailAuthenticator][ClassDeclaration-0]
+
+Authenticator with email and password.
+
+
+----------
+
+### [LoginController][ClassDeclaration-4]
+
+
+----------
+
+### [AbstractUser][ClassDeclaration-1]
+
+
+----------
+
+### [Group][ClassDeclaration-2]
+
+
+----------
+
+### [Permission][ClassDeclaration-3]
+
+
+----------
+
+### [RestController][ClassDeclaration-15]
+
+
+----------
+
+### [ObjectDoesNotExist][ClassDeclaration-22]
+
+
+----------
+
+### [PermissionDenied][ClassDeclaration-23]
+
+
+----------
+
+### [ValidationError][ClassDeclaration-24]
+
+
+----------
+
+### [EntityResourceCollection][ClassDeclaration-25]
+
+Create, read, update or delete entities and return representations
+of them.
+
+
+----------
+
+### [Context][ClassDeclaration-5]
+
+
+----------
+
+### [HttpResponse][ClassDeclaration-8]
+
+
+----------
+
+### [HttpResponseSuccess][ClassDeclaration-10]
+
+
+----------
+
+### [HttpResponseOK][ClassDeclaration-19]
+
+
+----------
+
+### [HttpResponseCreated][ClassDeclaration-21]
+
+
+----------
+
+### [HttpResponseNoContent][ClassDeclaration-9]
+
+
+----------
+
+### [HttpResponseRedirection][ClassDeclaration-7]
+
+
+----------
+
+### [HttpResponseRedirect][ClassDeclaration-6]
+
+
+----------
+
+### [HttpResponseClientError][ClassDeclaration-12]
+
+
+----------
+
+### [HttpResponseBadRequest][ClassDeclaration-13]
+
+
+----------
+
+### [HttpResponseUnauthorized][ClassDeclaration-14]
+
+
+----------
+
+### [HttpResponseForbidden][ClassDeclaration-20]
+
+
+----------
+
+### [HttpResponseNotFound][ClassDeclaration-11]
+
+
+----------
+
+### [HttpResponseMethodNotAllowed][ClassDeclaration-16]
+
+
+----------
+
+### [HttpResponseConflict][ClassDeclaration-26]
+
+
+----------
+
+### [HttpResponseServerError][ClassDeclaration-18]
+
+
+----------
+
+### [HttpResponseInternalServerError][ClassDeclaration-27]
+
+
+----------
+
+### [HttpResponseNotImplemented][ClassDeclaration-17]
+
+
+----------
+
+### [Config][ClassDeclaration-29]
+
+
+----------
+
+### [ServiceManager][ClassDeclaration-28]
+
+
+## Variables
+
+### emailSchema
+
+```typescript
+const emailSchema: { additionalProperties: boolean; properties: { email: { type: string; format: string; }; password: { type: string; }; }; required: string[]; type: string; };
+```
+
+**Type**
+
+{ additionalProperties: boolean; properties: { email: { type: string; format: string; }; password: { type: string; }; }; required: string[]; type: string; }
+
+[SourceFile-0]: index.md#indexts
+[FunctionDeclaration-0]: index.md#parsepassword
+[FunctionDeclaration-1]: index.md#authenticate
+[ClassDeclaration-1]: index/abstractuser.md#abstractuser
+[InterfaceDeclaration-1]: index.md#class
+[TypeAliasDeclaration-0]: index.md#hookdecorator
+[FunctionDeclaration-2]: index.md#strategy
+[InterfaceDeclaration-3]: index.md#strategy
+[InterfaceDeclaration-3]: index.md#strategy
+[InterfaceDeclaration-3]: index.md#strategy
+[InterfaceDeclaration-3]: index.md#strategy
+[FunctionDeclaration-3]: index.md#permissionrequired
+[TypeAliasDeclaration-0]: index.md#hookdecorator
+[FunctionDeclaration-4]: index.md#loginrequired
+[TypeAliasDeclaration-0]: index.md#hookdecorator
+[FunctionDeclaration-5]: index.md#isobjectdoesnotexist
+[ClassDeclaration-22]: index/objectdoesnotexist.md#objectdoesnotexist
+[FunctionDeclaration-6]: index.md#ispermissiondenied
+[ClassDeclaration-23]: index/permissiondenied.md#permissiondenied
+[FunctionDeclaration-7]: index.md#isvalidationerror
+[ClassDeclaration-24]: index/validationerror.md#validationerror
+[FunctionDeclaration-8]: index.md#log
+[TypeAliasDeclaration-0]: index.md#hookdecorator
+[FunctionDeclaration-9]: index.md#validatebody
+[TypeAliasDeclaration-0]: index.md#hookdecorator
+[FunctionDeclaration-10]: index.md#validatequery
+[TypeAliasDeclaration-0]: index.md#hookdecorator
+[FunctionDeclaration-11]: index.md#middleware
+[TypeAliasDeclaration-1]: index.md#middleware
+[InterfaceDeclaration-4]: index.md#iresourcecollection
+[TypeAliasDeclaration-1]: index.md#middleware
+[FunctionDeclaration-12]: index.md#controller
+[InterfaceDeclaration-1]: index.md#class
+[InterfaceDeclaration-1]: index.md#class
+[FunctionDeclaration-13]: index.md#escapeprop
+[FunctionDeclaration-14]: index.md#escape
+[FunctionDeclaration-15]: index.md#getcommandlinearguments
+[FunctionDeclaration-16]: index.md#render
+[ClassDeclaration-19]: index/httpresponseok.md#httpresponseok
+[FunctionDeclaration-17]: index.md#submodule
+[InterfaceDeclaration-1]: index.md#class
+[InterfaceDeclaration-1]: index.md#class
+[FunctionDeclaration-18]: index.md#validate
+[FunctionDeclaration-19]: index.md#get
+[FunctionDeclaration-20]: index.md#post
+[FunctionDeclaration-21]: index.md#put
+[FunctionDeclaration-22]: index.md#patch
+[FunctionDeclaration-23]: index.md#delete
+[FunctionDeclaration-24]: index.md#ishttpresponse
+[ClassDeclaration-8]: index/httpresponse.md#httpresponse
+[FunctionDeclaration-25]: index.md#ishttpresponsesuccess
+[ClassDeclaration-10]: index/httpresponsesuccess.md#httpresponsesuccess
+[FunctionDeclaration-26]: index.md#ishttpresponseok
+[ClassDeclaration-19]: index/httpresponseok.md#httpresponseok
+[FunctionDeclaration-27]: index.md#ishttpresponsecreated
+[ClassDeclaration-21]: index/httpresponsecreated.md#httpresponsecreated
+[FunctionDeclaration-28]: index.md#ishttpresponsenocontent
+[ClassDeclaration-9]: index/httpresponsenocontent.md#httpresponsenocontent
+[FunctionDeclaration-29]: index.md#ishttpresponseredirection
+[ClassDeclaration-7]: index/httpresponseredirection.md#httpresponseredirection
+[FunctionDeclaration-30]: index.md#ishttpresponseredirect
+[ClassDeclaration-6]: index/httpresponseredirect.md#httpresponseredirect
+[FunctionDeclaration-31]: index.md#ishttpresponseclienterror
+[ClassDeclaration-12]: index/httpresponseclienterror.md#httpresponseclienterror
+[FunctionDeclaration-32]: index.md#ishttpresponsebadrequest
+[ClassDeclaration-13]: index/httpresponsebadrequest.md#httpresponsebadrequest
+[FunctionDeclaration-33]: index.md#ishttpresponseunauthorized
+[ClassDeclaration-14]: index/httpresponseunauthorized.md#httpresponseunauthorized
+[FunctionDeclaration-34]: index.md#ishttpresponseforbidden
+[ClassDeclaration-20]: index/httpresponseforbidden.md#httpresponseforbidden
+[FunctionDeclaration-35]: index.md#ishttpresponsenotfound
+[ClassDeclaration-11]: index/httpresponsenotfound.md#httpresponsenotfound
+[FunctionDeclaration-36]: index.md#ishttpresponsemethodnotallowed
+[ClassDeclaration-16]: index/httpresponsemethodnotallowed.md#httpresponsemethodnotallowed
+[FunctionDeclaration-37]: index.md#ishttpresponseconflict
+[ClassDeclaration-26]: index/httpresponseconflict.md#httpresponseconflict
+[FunctionDeclaration-38]: index.md#ishttpresponseservererror
+[ClassDeclaration-18]: index/httpresponseservererror.md#httpresponseservererror
+[FunctionDeclaration-39]: index.md#ishttpresponseinternalservererror
+[ClassDeclaration-27]: index/httpresponseinternalservererror.md#httpresponseinternalservererror
+[FunctionDeclaration-40]: index.md#ishttpresponsenotimplemented
+[ClassDeclaration-17]: index/httpresponsenotimplemented.md#httpresponsenotimplemented
+[FunctionDeclaration-41]: index.md#hook
+[TypeAliasDeclaration-4]: index.md#hookfunction
+[TypeAliasDeclaration-0]: index.md#hookdecorator
+[FunctionDeclaration-42]: index.md#gethookfunction
+[TypeAliasDeclaration-0]: index.md#hookdecorator
+[TypeAliasDeclaration-4]: index.md#hookfunction
+[FunctionDeclaration-43]: index.md#makemoduleroutes
+[TypeAliasDeclaration-4]: index.md#hookfunction
+[InterfaceDeclaration-7]: index.md#imodule
+[InterfaceDeclaration-1]: index.md#class
+[ClassDeclaration-28]: index/servicemanager.md#servicemanager
+[InterfaceDeclaration-6]: index.md#route
+[FunctionDeclaration-44]: index.md#getpath
+[InterfaceDeclaration-1]: index.md#class
+[FunctionDeclaration-45]: index.md#gethttpmethod
+[InterfaceDeclaration-1]: index.md#class
+[FunctionDeclaration-46]: index.md#module
+[FunctionDeclaration-47]: index.md#createcontroller
+[InterfaceDeclaration-1]: index.md#class
+[FunctionDeclaration-48]: index.md#controller
+[FunctionDeclaration-49]: index.md#service
+[FunctionDeclaration-50]: index.md#createapp
+[InterfaceDeclaration-7]: index.md#imodule
+[InterfaceDeclaration-1]: index.md#class
+[InterfaceDeclaration-8]: index.md#createappoptions
+[InterfaceDeclaration-2]: index.md#iauthenticator
+[ClassDeclaration-1]: index/abstractuser.md#abstractuser
+[ClassDeclaration-1]: index/abstractuser.md#abstractuser
+[InterfaceDeclaration-3]: index.md#strategy
+[ClassDeclaration-1]: index/abstractuser.md#abstractuser
+[InterfaceDeclaration-2]: index.md#iauthenticator
+[InterfaceDeclaration-1]: index.md#class
+[InterfaceDeclaration-4]: index.md#iresourcecollection
+[ClassDeclaration-1]: index/abstractuser.md#abstractuser
+[ClassDeclaration-1]: index/abstractuser.md#abstractuser
+[ClassDeclaration-1]: index/abstractuser.md#abstractuser
+[ClassDeclaration-1]: index/abstractuser.md#abstractuser
+[ClassDeclaration-1]: index/abstractuser.md#abstractuser
+[ClassDeclaration-1]: index/abstractuser.md#abstractuser
+[InterfaceDeclaration-5]: index.md#collectionparams
+[InterfaceDeclaration-1]: index.md#class
+[InterfaceDeclaration-6]: index.md#route
+[TypeAliasDeclaration-3]: index.md#httpmethod
+[TypeAliasDeclaration-4]: index.md#hookfunction
+[InterfaceDeclaration-7]: index.md#imodule
+[InterfaceDeclaration-1]: index.md#class
+[InterfaceDeclaration-7]: index.md#imodule
+[InterfaceDeclaration-1]: index.md#class
+[InterfaceDeclaration-8]: index.md#createappoptions
+[TypeAliasDeclaration-1]: index.md#middleware
+[TypeAliasDeclaration-3]: index.md#httpmethod
+[TypeAliasDeclaration-4]: index.md#hookfunction
+[TypeAliasDeclaration-0]: index.md#hookdecorator
+[ClassDeclaration-0]: index/emailauthenticator.md#emailauthenticator
+[ClassDeclaration-4]: index/logincontroller.md#logincontroller
+[ClassDeclaration-1]: index/abstractuser.md#abstractuser
+[ClassDeclaration-2]: index/group.md#group
+[ClassDeclaration-3]: index/permission.md#permission
+[ClassDeclaration-15]: index/restcontroller.md#restcontroller
+[ClassDeclaration-22]: index/objectdoesnotexist.md#objectdoesnotexist
+[ClassDeclaration-23]: index/permissiondenied.md#permissiondenied
+[ClassDeclaration-24]: index/validationerror.md#validationerror
+[ClassDeclaration-25]: index/entityresourcecollection.md#entityresourcecollection
+[ClassDeclaration-5]: index/context.md#context
+[ClassDeclaration-8]: index/httpresponse.md#httpresponse
+[ClassDeclaration-10]: index/httpresponsesuccess.md#httpresponsesuccess
+[ClassDeclaration-19]: index/httpresponseok.md#httpresponseok
+[ClassDeclaration-21]: index/httpresponsecreated.md#httpresponsecreated
+[ClassDeclaration-9]: index/httpresponsenocontent.md#httpresponsenocontent
+[ClassDeclaration-7]: index/httpresponseredirection.md#httpresponseredirection
+[ClassDeclaration-6]: index/httpresponseredirect.md#httpresponseredirect
+[ClassDeclaration-12]: index/httpresponseclienterror.md#httpresponseclienterror
+[ClassDeclaration-13]: index/httpresponsebadrequest.md#httpresponsebadrequest
+[ClassDeclaration-14]: index/httpresponseunauthorized.md#httpresponseunauthorized
+[ClassDeclaration-20]: index/httpresponseforbidden.md#httpresponseforbidden
+[ClassDeclaration-11]: index/httpresponsenotfound.md#httpresponsenotfound
+[ClassDeclaration-16]: index/httpresponsemethodnotallowed.md#httpresponsemethodnotallowed
+[ClassDeclaration-26]: index/httpresponseconflict.md#httpresponseconflict
+[ClassDeclaration-18]: index/httpresponseservererror.md#httpresponseservererror
+[ClassDeclaration-27]: index/httpresponseinternalservererror.md#httpresponseinternalservererror
+[ClassDeclaration-17]: index/httpresponsenotimplemented.md#httpresponsenotimplemented
+[ClassDeclaration-29]: index/config.md#config
+[ClassDeclaration-28]: index/servicemanager.md#servicemanager
+[VariableDeclaration-0]: index.md#emailschema

--- a/docs/api/index/abstractuser.md
+++ b/docs/api/index/abstractuser.md
@@ -1,0 +1,76 @@
+# Table of contents
+
+* [AbstractUser][ClassDeclaration-1]
+    * Methods
+        * [hasPerm(codeName)][MethodDeclaration-0]
+    * Properties
+        * [id][PropertyDeclaration-1]
+        * [groups][PropertyDeclaration-2]
+        * [userPermissions][PropertyDeclaration-10]
+
+# AbstractUser
+
+```typescript
+abstract class AbstractUser
+```
+## Methods
+
+### hasPerm(codeName)
+
+```typescript
+public hasPerm(codeName: string): boolean;
+```
+
+**Parameters**
+
+| Name     | Type   |
+| -------- | ------ |
+| codeName | string |
+
+**Return type**
+
+boolean
+
+## Properties
+
+### id
+
+```typescript
+public id: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### groups
+
+```typescript
+public groups: Group[];
+```
+
+**Type**
+
+[Group][ClassDeclaration-2][]
+
+----------
+
+### userPermissions
+
+```typescript
+public userPermissions: Permission[];
+```
+
+**Type**
+
+[Permission][ClassDeclaration-3][]
+
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[MethodDeclaration-0]: abstractuser.md#haspermcodename
+[PropertyDeclaration-1]: abstractuser.md#id
+[PropertyDeclaration-2]: abstractuser.md#groups
+[ClassDeclaration-2]: group.md#group
+[PropertyDeclaration-10]: abstractuser.md#userpermissions
+[ClassDeclaration-3]: permission.md#permission

--- a/docs/api/index/config.md
+++ b/docs/api/index/config.md
@@ -1,0 +1,48 @@
+# Table of contents
+
+* [Config][ClassDeclaration-29]
+    * Methods
+        * [get(configName, propName, defaultValue)][MethodDeclaration-24]
+    * Properties
+        * [root][PropertyDeclaration-70]
+
+# Config
+
+```typescript
+class Config
+```
+## Methods
+
+### get(configName, propName, defaultValue)
+
+```typescript
+public static get(configName: string, propName: string, defaultValue?: number | string | boolean): number | string | boolean | undefined;
+```
+
+**Parameters**
+
+| Name         | Type                                |
+| ------------ | ----------------------------------- |
+| configName   | string                              |
+| propName     | string                              |
+| defaultValue | number &#124; string &#124; boolean |
+
+**Return type**
+
+number | string | boolean | undefined
+
+## Properties
+
+### root
+
+```typescript
+public static root: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-29]: config.md#config
+[MethodDeclaration-24]: config.md#getconfigname-propname-defaultvalue
+[PropertyDeclaration-70]: config.md#root

--- a/docs/api/index/context.md
+++ b/docs/api/index/context.md
@@ -1,0 +1,64 @@
+# Table of contents
+
+* [Context][ClassDeclaration-5]
+    * Constructor
+        * [constructor(request)][Constructor-1]
+    * Properties
+        * [state][PropertyDeclaration-13]
+        * [user][PropertyDeclaration-14]
+
+# Context
+
+```typescript
+class Context<User extends AbstractUser = AbstractUser>
+```
+
+**Type parameters**
+
+| Name | Constraint                         | Default                            |
+| ---- | ---------------------------------- | ---------------------------------- |
+| User | [AbstractUser][ClassDeclaration-1] | [AbstractUser][ClassDeclaration-1] |
+## Constructor
+
+### constructor(request)
+
+```typescript
+public constructor(request: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| request | any  |
+
+## Properties
+
+### state
+
+```typescript
+public state: { [key: string]: any; };
+```
+
+**Type**
+
+{ [key: string]: any; }
+
+----------
+
+### user
+
+```typescript
+public user: User | undefined;
+```
+
+**Type**
+
+User | undefined
+
+[ClassDeclaration-5]: context.md#context
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[Constructor-1]: context.md#constructorrequest
+[PropertyDeclaration-13]: context.md#state
+[PropertyDeclaration-14]: context.md#user

--- a/docs/api/index/emailauthenticator.md
+++ b/docs/api/index/emailauthenticator.md
@@ -1,0 +1,76 @@
+# Table of contents
+
+* [EmailAuthenticator][ClassDeclaration-0]
+    * Methods
+        * [checkPassword(user, password)][MethodDeclaration-1]
+        * [authenticate(__0)][MethodDeclaration-2]
+    * Properties
+        * [entityClass][PropertyDeclaration-0]
+
+# EmailAuthenticator
+
+Authenticator with email and password.
+
+```typescript
+abstract class EmailAuthenticator<User extends EmailUser> implements IAuthenticator<User>
+```
+
+**Type parameters**
+
+| Name | Constraint                          |
+| ---- | ----------------------------------- |
+| User | EmailUser |
+## Methods
+
+### checkPassword(user, password)
+
+```typescript
+public async checkPassword(user: User, password: string): Promise<boolean>;
+```
+
+**Parameters**
+
+| Name     | Type   |
+| -------- | ------ |
+| user     | User   |
+| password | string |
+
+**Return type**
+
+Promise<boolean>
+
+----------
+
+### authenticate(__0)
+
+```typescript
+public async authenticate(__0: { email: string; password: string; }): Promise<User | null>;
+```
+
+**Parameters**
+
+| Name | Type                                 |
+| ---- | ------------------------------------ |
+| __0  | { email: string; password: string; } |
+
+**Return type**
+
+Promise<User | null>
+
+## Properties
+
+### entityClass
+
+```typescript
+public abstract entityClass: Class<User>;
+```
+
+**Type**
+
+[Class][InterfaceDeclaration-1]<User>
+
+[ClassDeclaration-0]: emailauthenticator.md#emailauthenticator
+[MethodDeclaration-1]: emailauthenticator.md#checkpassworduser-password
+[MethodDeclaration-2]: emailauthenticator.md#authenticate__0
+[PropertyDeclaration-0]: emailauthenticator.md#entityclass
+[InterfaceDeclaration-1]: ../index.md#class

--- a/docs/api/index/entityresourcecollection.md
+++ b/docs/api/index/entityresourcecollection.md
@@ -1,0 +1,228 @@
+# Table of contents
+
+* [EntityResourceCollection][ClassDeclaration-25]
+    * Methods
+        * [create(user, data, params)][MethodDeclaration-16]
+        * [findById(user, id, params)][MethodDeclaration-17]
+        * [find(user, params)][MethodDeclaration-18]
+        * [modifyById(user, id, data, params)][MethodDeclaration-19]
+        * [updateById(user, id, data, params)][MethodDeclaration-20]
+        * [deleteById(user, id, params)][MethodDeclaration-21]
+    * Properties
+        * [entityClass][PropertyDeclaration-58]
+        * [allowedOperations][PropertyDeclaration-59]
+        * [middlewares][PropertyDeclaration-60]
+        * [loadedRelations][PropertyDeclaration-61]
+        * [connectionName][PropertyDeclaration-62]
+
+# EntityResourceCollection
+
+Create, read, update or delete entities and return representations
+of them.
+
+```typescript
+abstract class EntityResourceCollection implements IResourceCollection
+```
+## Methods
+
+### create(user, data, params)
+
+```typescript
+public async create(user: AbstractUser | undefined, data: object, params: { fields?: string[]; }): Promise<object>;
+```
+
+**Parameters**
+
+| Name   | Type                                                |
+| ------ | --------------------------------------------------- |
+| user   | [AbstractUser][ClassDeclaration-1] &#124; undefined |
+| data   | object                                              |
+| params | { fields?: string[]; }                              |
+
+**Return type**
+
+Promise<object>
+
+----------
+
+### findById(user, id, params)
+
+```typescript
+public async findById(user: AbstractUser | undefined, id: any, params: { fields?: string[]; }): Promise<object>;
+```
+
+**Parameters**
+
+| Name   | Type                                                |
+| ------ | --------------------------------------------------- |
+| user   | [AbstractUser][ClassDeclaration-1] &#124; undefined |
+| id     | any                                                 |
+| params | { fields?: string[]; }                              |
+
+**Return type**
+
+Promise<object>
+
+----------
+
+### find(user, params)
+
+```typescript
+public async find(user: AbstractUser | undefined, params: { query?: object | undefined; fields?: string[]; }): Promise<object[]>;
+```
+
+**Parameters**
+
+| Name   | Type                                                    |
+| ------ | ------------------------------------------------------- |
+| user   | [AbstractUser][ClassDeclaration-1] &#124; undefined     |
+| params | { query?: object &#124; undefined; fields?: string[]; } |
+
+**Return type**
+
+Promise<object[]>
+
+----------
+
+### modifyById(user, id, data, params)
+
+```typescript
+public async modifyById(user: AbstractUser | undefined, id: any, data: object, params: { fields?: string[]; }): Promise<object>;
+```
+
+**Parameters**
+
+| Name   | Type                                                |
+| ------ | --------------------------------------------------- |
+| user   | [AbstractUser][ClassDeclaration-1] &#124; undefined |
+| id     | any                                                 |
+| data   | object                                              |
+| params | { fields?: string[]; }                              |
+
+**Return type**
+
+Promise<object>
+
+----------
+
+### updateById(user, id, data, params)
+
+```typescript
+public async updateById(user: AbstractUser | undefined, id: any, data: object, params: { fields?: string[]; }): Promise<object>;
+```
+
+**Parameters**
+
+| Name   | Type                                                |
+| ------ | --------------------------------------------------- |
+| user   | [AbstractUser][ClassDeclaration-1] &#124; undefined |
+| id     | any                                                 |
+| data   | object                                              |
+| params | { fields?: string[]; }                              |
+
+**Return type**
+
+Promise<object>
+
+----------
+
+### deleteById(user, id, params)
+
+```typescript
+public async deleteById(user: AbstractUser | undefined, id: any, params: {}): Promise<void>;
+```
+
+**Parameters**
+
+| Name   | Type                                                |
+| ------ | --------------------------------------------------- |
+| user   | [AbstractUser][ClassDeclaration-1] &#124; undefined |
+| id     | any                                                 |
+| params | {}                                                  |
+
+**Return type**
+
+Promise<void>
+
+## Properties
+
+### entityClass
+
+```typescript
+public abstract readonly entityClass: Class<any>;
+```
+
+**Type**
+
+[Class][InterfaceDeclaration-1]<any>
+
+----------
+
+### allowedOperations
+
+```typescript
+public abstract readonly allowedOperations: (keyof IResourceCollection)[];
+```
+
+**Type**
+
+(keyof [IResourceCollection][InterfaceDeclaration-4])[]
+
+----------
+
+### middlewares
+
+```typescript
+public readonly middlewares: Partial<Record<keyof IResourceCollection, Middleware>>[];
+```
+
+**Type**
+
+Partial<Record<keyof [IResourceCollection][InterfaceDeclaration-4], [Middleware][TypeAliasDeclaration-1]>>[]
+
+----------
+
+### loadedRelations
+
+```typescript
+public readonly loadedRelations: Partial<Record<"find" | "findById", RelationLoader>>;
+```
+
+**Type**
+
+Partial<Record<"find" | "findById", RelationLoader>>
+
+----------
+
+### connectionName
+
+```typescript
+public readonly connectionName: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-25]: entityresourcecollection.md#entityresourcecollection
+[MethodDeclaration-16]: entityresourcecollection.md#createuser-data-params
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[MethodDeclaration-17]: entityresourcecollection.md#findbyiduser-id-params
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[MethodDeclaration-18]: entityresourcecollection.md#finduser-params
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[MethodDeclaration-19]: entityresourcecollection.md#modifybyiduser-id-data-params
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[MethodDeclaration-20]: entityresourcecollection.md#updatebyiduser-id-data-params
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[MethodDeclaration-21]: entityresourcecollection.md#deletebyiduser-id-params
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[PropertyDeclaration-58]: entityresourcecollection.md#entityclass
+[InterfaceDeclaration-1]: ../index.md#class
+[PropertyDeclaration-59]: entityresourcecollection.md#allowedoperations
+[InterfaceDeclaration-4]: ../index.md#iresourcecollection
+[PropertyDeclaration-60]: entityresourcecollection.md#middlewares
+[InterfaceDeclaration-4]: ../index.md#iresourcecollection
+[TypeAliasDeclaration-1]: ../index.md#middleware
+[PropertyDeclaration-61]: entityresourcecollection.md#loadedrelations
+[PropertyDeclaration-62]: entityresourcecollection.md#connectionname

--- a/docs/api/index/group.md
+++ b/docs/api/index/group.md
@@ -1,0 +1,68 @@
+# Table of contents
+
+* [Group][ClassDeclaration-2]
+    * Properties
+        * [id][PropertyDeclaration-3]
+        * [name][PropertyDeclaration-4]
+        * [codeName][PropertyDeclaration-5]
+        * [permissions][PropertyDeclaration-6]
+
+# Group
+
+```typescript
+class Group
+```
+## Properties
+
+### id
+
+```typescript
+public id: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### name
+
+```typescript
+public name: string;
+```
+
+**Type**
+
+string
+
+----------
+
+### codeName
+
+```typescript
+public codeName: string;
+```
+
+**Type**
+
+string
+
+----------
+
+### permissions
+
+```typescript
+public permissions: Permission[];
+```
+
+**Type**
+
+[Permission][ClassDeclaration-3][]
+
+[ClassDeclaration-2]: group.md#group
+[PropertyDeclaration-3]: group.md#id
+[PropertyDeclaration-4]: group.md#name
+[PropertyDeclaration-5]: group.md#codename
+[PropertyDeclaration-6]: group.md#permissions
+[ClassDeclaration-3]: permission.md#permission

--- a/docs/api/index/httpresponse.md
+++ b/docs/api/index/httpresponse.md
@@ -1,0 +1,84 @@
+# Table of contents
+
+* [HttpResponse][ClassDeclaration-8]
+    * Constructor
+        * [constructor(content)][Constructor-4]
+    * Properties
+        * [isHttpResponse][PropertyDeclaration-19]
+        * [headers][PropertyDeclaration-20]
+        * [statusCode][PropertyDeclaration-21]
+        * [statusMessage][PropertyDeclaration-22]
+
+# HttpResponse
+
+```typescript
+abstract class HttpResponse
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponse
+
+```typescript
+public readonly isHttpResponse: true;
+```
+
+**Type**
+
+true
+
+----------
+
+### headers
+
+```typescript
+public headers: { [key: string]: string; };
+```
+
+**Type**
+
+{ [key: string]: string; }
+
+----------
+
+### statusCode
+
+```typescript
+public abstract statusCode: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### statusMessage
+
+```typescript
+public abstract statusMessage: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-8]: httpresponse.md#httpresponse
+[Constructor-4]: httpresponse.md#constructorcontent
+[PropertyDeclaration-19]: httpresponse.md#ishttpresponse
+[PropertyDeclaration-20]: httpresponse.md#headers
+[PropertyDeclaration-21]: httpresponse.md#statuscode
+[PropertyDeclaration-22]: httpresponse.md#statusmessage

--- a/docs/api/index/httpresponsebadrequest.md
+++ b/docs/api/index/httpresponsebadrequest.md
@@ -1,0 +1,70 @@
+# Table of contents
+
+* [HttpResponseBadRequest][ClassDeclaration-13]
+    * Constructor
+        * [constructor(content)][Constructor-9]
+    * Properties
+        * [isHttpResponseBadRequest][PropertyDeclaration-31]
+        * [statusCode][PropertyDeclaration-32]
+        * [statusMessage][PropertyDeclaration-33]
+
+# HttpResponseBadRequest
+
+```typescript
+class HttpResponseBadRequest
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponseBadRequest
+
+```typescript
+public readonly isHttpResponseBadRequest: true;
+```
+
+**Type**
+
+true
+
+----------
+
+### statusCode
+
+```typescript
+public statusCode: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### statusMessage
+
+```typescript
+public statusMessage: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-13]: httpresponsebadrequest.md#httpresponsebadrequest
+[Constructor-9]: httpresponsebadrequest.md#constructorcontent
+[PropertyDeclaration-31]: httpresponsebadrequest.md#ishttpresponsebadrequest
+[PropertyDeclaration-32]: httpresponsebadrequest.md#statuscode
+[PropertyDeclaration-33]: httpresponsebadrequest.md#statusmessage

--- a/docs/api/index/httpresponseclienterror.md
+++ b/docs/api/index/httpresponseclienterror.md
@@ -1,0 +1,42 @@
+# Table of contents
+
+* [HttpResponseClientError][ClassDeclaration-12]
+    * Constructor
+        * [constructor(content)][Constructor-8]
+    * Properties
+        * [isHttpResponseClientError][PropertyDeclaration-30]
+
+# HttpResponseClientError
+
+```typescript
+abstract class HttpResponseClientError
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponseClientError
+
+```typescript
+public readonly isHttpResponseClientError: true;
+```
+
+**Type**
+
+true
+
+[ClassDeclaration-12]: httpresponseclienterror.md#httpresponseclienterror
+[Constructor-8]: httpresponseclienterror.md#constructorcontent
+[PropertyDeclaration-30]: httpresponseclienterror.md#ishttpresponseclienterror

--- a/docs/api/index/httpresponseconflict.md
+++ b/docs/api/index/httpresponseconflict.md
@@ -1,0 +1,70 @@
+# Table of contents
+
+* [HttpResponseConflict][ClassDeclaration-26]
+    * Constructor
+        * [constructor(content)][Constructor-21]
+    * Properties
+        * [isHttpResponseConflict][PropertyDeclaration-63]
+        * [statusCode][PropertyDeclaration-64]
+        * [statusMessage][PropertyDeclaration-65]
+
+# HttpResponseConflict
+
+```typescript
+class HttpResponseConflict
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponseConflict
+
+```typescript
+public readonly isHttpResponseConflict: true;
+```
+
+**Type**
+
+true
+
+----------
+
+### statusCode
+
+```typescript
+public statusCode: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### statusMessage
+
+```typescript
+public statusMessage: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-26]: httpresponseconflict.md#httpresponseconflict
+[Constructor-21]: httpresponseconflict.md#constructorcontent
+[PropertyDeclaration-63]: httpresponseconflict.md#ishttpresponseconflict
+[PropertyDeclaration-64]: httpresponseconflict.md#statuscode
+[PropertyDeclaration-65]: httpresponseconflict.md#statusmessage

--- a/docs/api/index/httpresponsecreated.md
+++ b/docs/api/index/httpresponsecreated.md
@@ -1,0 +1,70 @@
+# Table of contents
+
+* [HttpResponseCreated][ClassDeclaration-21]
+    * Constructor
+        * [constructor(content)][Constructor-17]
+    * Properties
+        * [isHttpResponseCreated][PropertyDeclaration-52]
+        * [statusCode][PropertyDeclaration-53]
+        * [statusMessage][PropertyDeclaration-54]
+
+# HttpResponseCreated
+
+```typescript
+class HttpResponseCreated
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponseCreated
+
+```typescript
+public readonly isHttpResponseCreated: true;
+```
+
+**Type**
+
+true
+
+----------
+
+### statusCode
+
+```typescript
+public statusCode: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### statusMessage
+
+```typescript
+public statusMessage: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-21]: httpresponsecreated.md#httpresponsecreated
+[Constructor-17]: httpresponsecreated.md#constructorcontent
+[PropertyDeclaration-52]: httpresponsecreated.md#ishttpresponsecreated
+[PropertyDeclaration-53]: httpresponsecreated.md#statuscode
+[PropertyDeclaration-54]: httpresponsecreated.md#statusmessage

--- a/docs/api/index/httpresponseforbidden.md
+++ b/docs/api/index/httpresponseforbidden.md
@@ -1,0 +1,70 @@
+# Table of contents
+
+* [HttpResponseForbidden][ClassDeclaration-20]
+    * Constructor
+        * [constructor(content)][Constructor-16]
+    * Properties
+        * [isHttpResponseForbidden][PropertyDeclaration-49]
+        * [statusCode][PropertyDeclaration-50]
+        * [statusMessage][PropertyDeclaration-51]
+
+# HttpResponseForbidden
+
+```typescript
+class HttpResponseForbidden
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponseForbidden
+
+```typescript
+public readonly isHttpResponseForbidden: true;
+```
+
+**Type**
+
+true
+
+----------
+
+### statusCode
+
+```typescript
+public statusCode: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### statusMessage
+
+```typescript
+public statusMessage: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-20]: httpresponseforbidden.md#httpresponseforbidden
+[Constructor-16]: httpresponseforbidden.md#constructorcontent
+[PropertyDeclaration-49]: httpresponseforbidden.md#ishttpresponseforbidden
+[PropertyDeclaration-50]: httpresponseforbidden.md#statuscode
+[PropertyDeclaration-51]: httpresponseforbidden.md#statusmessage

--- a/docs/api/index/httpresponseinternalservererror.md
+++ b/docs/api/index/httpresponseinternalservererror.md
@@ -1,0 +1,70 @@
+# Table of contents
+
+* [HttpResponseInternalServerError][ClassDeclaration-27]
+    * Constructor
+        * [constructor(content)][Constructor-22]
+    * Properties
+        * [isHttpResponseInternalServerError][PropertyDeclaration-66]
+        * [statusCode][PropertyDeclaration-67]
+        * [statusMessage][PropertyDeclaration-68]
+
+# HttpResponseInternalServerError
+
+```typescript
+class HttpResponseInternalServerError
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponseInternalServerError
+
+```typescript
+public readonly isHttpResponseInternalServerError: true;
+```
+
+**Type**
+
+true
+
+----------
+
+### statusCode
+
+```typescript
+public statusCode: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### statusMessage
+
+```typescript
+public statusMessage: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-27]: httpresponseinternalservererror.md#httpresponseinternalservererror
+[Constructor-22]: httpresponseinternalservererror.md#constructorcontent
+[PropertyDeclaration-66]: httpresponseinternalservererror.md#ishttpresponseinternalservererror
+[PropertyDeclaration-67]: httpresponseinternalservererror.md#statuscode
+[PropertyDeclaration-68]: httpresponseinternalservererror.md#statusmessage

--- a/docs/api/index/httpresponsemethodnotallowed.md
+++ b/docs/api/index/httpresponsemethodnotallowed.md
@@ -1,0 +1,70 @@
+# Table of contents
+
+* [HttpResponseMethodNotAllowed][ClassDeclaration-16]
+    * Constructor
+        * [constructor(content)][Constructor-12]
+    * Properties
+        * [isHttpResponseMethodNotAllowed][PropertyDeclaration-39]
+        * [statusCode][PropertyDeclaration-40]
+        * [statusMessage][PropertyDeclaration-41]
+
+# HttpResponseMethodNotAllowed
+
+```typescript
+class HttpResponseMethodNotAllowed
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponseMethodNotAllowed
+
+```typescript
+public readonly isHttpResponseMethodNotAllowed: true;
+```
+
+**Type**
+
+true
+
+----------
+
+### statusCode
+
+```typescript
+public statusCode: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### statusMessage
+
+```typescript
+public statusMessage: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-16]: httpresponsemethodnotallowed.md#httpresponsemethodnotallowed
+[Constructor-12]: httpresponsemethodnotallowed.md#constructorcontent
+[PropertyDeclaration-39]: httpresponsemethodnotallowed.md#ishttpresponsemethodnotallowed
+[PropertyDeclaration-40]: httpresponsemethodnotallowed.md#statuscode
+[PropertyDeclaration-41]: httpresponsemethodnotallowed.md#statusmessage

--- a/docs/api/index/httpresponsenocontent.md
+++ b/docs/api/index/httpresponsenocontent.md
@@ -1,0 +1,64 @@
+# Table of contents
+
+* [HttpResponseNoContent][ClassDeclaration-9]
+    * Constructor
+        * [constructor()][Constructor-5]
+    * Properties
+        * [isHttpResponseNoContent][PropertyDeclaration-23]
+        * [statusCode][PropertyDeclaration-24]
+        * [statusMessage][PropertyDeclaration-25]
+
+# HttpResponseNoContent
+
+```typescript
+class HttpResponseNoContent
+```
+## Constructor
+
+### constructor()
+
+```typescript
+public constructor();
+```
+
+## Properties
+
+### isHttpResponseNoContent
+
+```typescript
+public readonly isHttpResponseNoContent: true;
+```
+
+**Type**
+
+true
+
+----------
+
+### statusCode
+
+```typescript
+public statusCode: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### statusMessage
+
+```typescript
+public statusMessage: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-9]: httpresponsenocontent.md#httpresponsenocontent
+[Constructor-5]: httpresponsenocontent.md#constructor
+[PropertyDeclaration-23]: httpresponsenocontent.md#ishttpresponsenocontent
+[PropertyDeclaration-24]: httpresponsenocontent.md#statuscode
+[PropertyDeclaration-25]: httpresponsenocontent.md#statusmessage

--- a/docs/api/index/httpresponsenotfound.md
+++ b/docs/api/index/httpresponsenotfound.md
@@ -1,0 +1,70 @@
+# Table of contents
+
+* [HttpResponseNotFound][ClassDeclaration-11]
+    * Constructor
+        * [constructor(content)][Constructor-7]
+    * Properties
+        * [isHttpResponseNotFound][PropertyDeclaration-27]
+        * [statusCode][PropertyDeclaration-28]
+        * [statusMessage][PropertyDeclaration-29]
+
+# HttpResponseNotFound
+
+```typescript
+class HttpResponseNotFound
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponseNotFound
+
+```typescript
+public readonly isHttpResponseNotFound: true;
+```
+
+**Type**
+
+true
+
+----------
+
+### statusCode
+
+```typescript
+public statusCode: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### statusMessage
+
+```typescript
+public statusMessage: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-11]: httpresponsenotfound.md#httpresponsenotfound
+[Constructor-7]: httpresponsenotfound.md#constructorcontent
+[PropertyDeclaration-27]: httpresponsenotfound.md#ishttpresponsenotfound
+[PropertyDeclaration-28]: httpresponsenotfound.md#statuscode
+[PropertyDeclaration-29]: httpresponsenotfound.md#statusmessage

--- a/docs/api/index/httpresponsenotimplemented.md
+++ b/docs/api/index/httpresponsenotimplemented.md
@@ -1,0 +1,70 @@
+# Table of contents
+
+* [HttpResponseNotImplemented][ClassDeclaration-17]
+    * Constructor
+        * [constructor(content)][Constructor-13]
+    * Properties
+        * [isHttpResponseNotImplemented][PropertyDeclaration-42]
+        * [statusCode][PropertyDeclaration-43]
+        * [statusMessage][PropertyDeclaration-44]
+
+# HttpResponseNotImplemented
+
+```typescript
+class HttpResponseNotImplemented
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponseNotImplemented
+
+```typescript
+public readonly isHttpResponseNotImplemented: true;
+```
+
+**Type**
+
+true
+
+----------
+
+### statusCode
+
+```typescript
+public statusCode: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### statusMessage
+
+```typescript
+public statusMessage: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-17]: httpresponsenotimplemented.md#httpresponsenotimplemented
+[Constructor-13]: httpresponsenotimplemented.md#constructorcontent
+[PropertyDeclaration-42]: httpresponsenotimplemented.md#ishttpresponsenotimplemented
+[PropertyDeclaration-43]: httpresponsenotimplemented.md#statuscode
+[PropertyDeclaration-44]: httpresponsenotimplemented.md#statusmessage

--- a/docs/api/index/httpresponseok.md
+++ b/docs/api/index/httpresponseok.md
@@ -1,0 +1,70 @@
+# Table of contents
+
+* [HttpResponseOK][ClassDeclaration-19]
+    * Constructor
+        * [constructor(content)][Constructor-15]
+    * Properties
+        * [isHttpResponseOK][PropertyDeclaration-46]
+        * [statusCode][PropertyDeclaration-47]
+        * [statusMessage][PropertyDeclaration-48]
+
+# HttpResponseOK
+
+```typescript
+class HttpResponseOK
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponseOK
+
+```typescript
+public readonly isHttpResponseOK: true;
+```
+
+**Type**
+
+true
+
+----------
+
+### statusCode
+
+```typescript
+public statusCode: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### statusMessage
+
+```typescript
+public statusMessage: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-19]: httpresponseok.md#httpresponseok
+[Constructor-15]: httpresponseok.md#constructorcontent
+[PropertyDeclaration-46]: httpresponseok.md#ishttpresponseok
+[PropertyDeclaration-47]: httpresponseok.md#statuscode
+[PropertyDeclaration-48]: httpresponseok.md#statusmessage

--- a/docs/api/index/httpresponseredirect.md
+++ b/docs/api/index/httpresponseredirect.md
@@ -1,0 +1,71 @@
+# Table of contents
+
+* [HttpResponseRedirect][ClassDeclaration-6]
+    * Constructor
+        * [constructor(path, content)][Constructor-2]
+    * Properties
+        * [isHttpResponseRedirect][PropertyDeclaration-15]
+        * [statusCode][PropertyDeclaration-16]
+        * [statusMessage][PropertyDeclaration-17]
+
+# HttpResponseRedirect
+
+```typescript
+class HttpResponseRedirect
+```
+## Constructor
+
+### constructor(path, content)
+
+```typescript
+public constructor(path: string, content?: any);
+```
+
+**Parameters**
+
+| Name    | Type   |
+| ------- | ------ |
+| path    | string |
+| content | any    |
+
+## Properties
+
+### isHttpResponseRedirect
+
+```typescript
+public readonly isHttpResponseRedirect: true;
+```
+
+**Type**
+
+true
+
+----------
+
+### statusCode
+
+```typescript
+public statusCode: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### statusMessage
+
+```typescript
+public statusMessage: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-6]: httpresponseredirect.md#httpresponseredirect
+[Constructor-2]: httpresponseredirect.md#constructorpath-content
+[PropertyDeclaration-15]: httpresponseredirect.md#ishttpresponseredirect
+[PropertyDeclaration-16]: httpresponseredirect.md#statuscode
+[PropertyDeclaration-17]: httpresponseredirect.md#statusmessage

--- a/docs/api/index/httpresponseredirection.md
+++ b/docs/api/index/httpresponseredirection.md
@@ -1,0 +1,42 @@
+# Table of contents
+
+* [HttpResponseRedirection][ClassDeclaration-7]
+    * Constructor
+        * [constructor(content)][Constructor-3]
+    * Properties
+        * [isHttpResponseRedirection][PropertyDeclaration-18]
+
+# HttpResponseRedirection
+
+```typescript
+abstract class HttpResponseRedirection
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponseRedirection
+
+```typescript
+public readonly isHttpResponseRedirection: true;
+```
+
+**Type**
+
+true
+
+[ClassDeclaration-7]: httpresponseredirection.md#httpresponseredirection
+[Constructor-3]: httpresponseredirection.md#constructorcontent
+[PropertyDeclaration-18]: httpresponseredirection.md#ishttpresponseredirection

--- a/docs/api/index/httpresponseservererror.md
+++ b/docs/api/index/httpresponseservererror.md
@@ -1,0 +1,42 @@
+# Table of contents
+
+* [HttpResponseServerError][ClassDeclaration-18]
+    * Constructor
+        * [constructor(content)][Constructor-14]
+    * Properties
+        * [isHttpResponseServerError][PropertyDeclaration-45]
+
+# HttpResponseServerError
+
+```typescript
+abstract class HttpResponseServerError
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponseServerError
+
+```typescript
+public readonly isHttpResponseServerError: true;
+```
+
+**Type**
+
+true
+
+[ClassDeclaration-18]: httpresponseservererror.md#httpresponseservererror
+[Constructor-14]: httpresponseservererror.md#constructorcontent
+[PropertyDeclaration-45]: httpresponseservererror.md#ishttpresponseservererror

--- a/docs/api/index/httpresponsesuccess.md
+++ b/docs/api/index/httpresponsesuccess.md
@@ -1,0 +1,42 @@
+# Table of contents
+
+* [HttpResponseSuccess][ClassDeclaration-10]
+    * Constructor
+        * [constructor(content)][Constructor-6]
+    * Properties
+        * [isHttpResponseSuccess][PropertyDeclaration-26]
+
+# HttpResponseSuccess
+
+```typescript
+abstract class HttpResponseSuccess
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponseSuccess
+
+```typescript
+public readonly isHttpResponseSuccess: true;
+```
+
+**Type**
+
+true
+
+[ClassDeclaration-10]: httpresponsesuccess.md#httpresponsesuccess
+[Constructor-6]: httpresponsesuccess.md#constructorcontent
+[PropertyDeclaration-26]: httpresponsesuccess.md#ishttpresponsesuccess

--- a/docs/api/index/httpresponseunauthorized.md
+++ b/docs/api/index/httpresponseunauthorized.md
@@ -1,0 +1,84 @@
+# Table of contents
+
+* [HttpResponseUnauthorized][ClassDeclaration-14]
+    * Constructor
+        * [constructor(content)][Constructor-10]
+    * Properties
+        * [isHttpResponseUnauthorized][PropertyDeclaration-34]
+        * [statusCode][PropertyDeclaration-35]
+        * [statusMessage][PropertyDeclaration-36]
+        * [headers][PropertyDeclaration-37]
+
+# HttpResponseUnauthorized
+
+```typescript
+class HttpResponseUnauthorized
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isHttpResponseUnauthorized
+
+```typescript
+public readonly isHttpResponseUnauthorized: true;
+```
+
+**Type**
+
+true
+
+----------
+
+### statusCode
+
+```typescript
+public statusCode: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### statusMessage
+
+```typescript
+public statusMessage: string;
+```
+
+**Type**
+
+string
+
+----------
+
+### headers
+
+```typescript
+public headers: { WWW-Authenticate: string; };
+```
+
+**Type**
+
+{ WWW-Authenticate: string; }
+
+[ClassDeclaration-14]: httpresponseunauthorized.md#httpresponseunauthorized
+[Constructor-10]: httpresponseunauthorized.md#constructorcontent
+[PropertyDeclaration-34]: httpresponseunauthorized.md#ishttpresponseunauthorized
+[PropertyDeclaration-35]: httpresponseunauthorized.md#statuscode
+[PropertyDeclaration-36]: httpresponseunauthorized.md#statusmessage
+[PropertyDeclaration-37]: httpresponseunauthorized.md#headers

--- a/docs/api/index/logincontroller.md
+++ b/docs/api/index/logincontroller.md
@@ -1,0 +1,103 @@
+# Table of contents
+
+* [LoginController][ClassDeclaration-4]
+    * Constructor
+        * [constructor()][Constructor-0]
+    * Methods
+        * [logout(ctx)][MethodDeclaration-3]
+        * [login(ctx)][MethodDeclaration-4]
+    * Properties
+        * [redirect][PropertyDeclaration-11]
+        * [strategies][PropertyDeclaration-12]
+
+# LoginController
+
+```typescript
+abstract class LoginController
+```
+## Constructor
+
+### constructor()
+
+```typescript
+public constructor();
+```
+
+## Methods
+
+### logout(ctx)
+
+```typescript
+public logout(ctx: Context<AbstractUser>): HttpResponseRedirect | HttpResponseNoContent;
+```
+
+**Parameters**
+
+| Name | Type                                                              |
+| ---- | ----------------------------------------------------------------- |
+| ctx  | [Context][ClassDeclaration-5]<[AbstractUser][ClassDeclaration-1]> |
+
+**Return type**
+
+[HttpResponseRedirect][ClassDeclaration-6] | [HttpResponseNoContent][ClassDeclaration-9]
+
+----------
+
+### login(ctx)
+
+```typescript
+public async login(ctx: Context<AbstractUser>): Promise<HttpResponseRedirect | HttpResponseNoContent | HttpResponseNotFound | HttpResponseBadRequest | HttpResponseUnauthorized>;
+```
+
+**Parameters**
+
+| Name | Type                                                              |
+| ---- | ----------------------------------------------------------------- |
+| ctx  | [Context][ClassDeclaration-5]<[AbstractUser][ClassDeclaration-1]> |
+
+**Return type**
+
+Promise<[HttpResponseRedirect][ClassDeclaration-6] | [HttpResponseNoContent][ClassDeclaration-9] | [HttpResponseNotFound][ClassDeclaration-11] | [HttpResponseBadRequest][ClassDeclaration-13] | [HttpResponseUnauthorized][ClassDeclaration-14]>
+
+## Properties
+
+### redirect
+
+```typescript
+public redirect: { logout?: string | undefined; success?: string | undefined; failure?: string | undefined; } | undefined;
+```
+
+**Type**
+
+{ logout?: string | undefined; success?: string | undefined; failure?: string | undefined; } | undefined
+
+----------
+
+### strategies
+
+```typescript
+public abstract strategies: Strategy[];
+```
+
+**Type**
+
+[Strategy][InterfaceDeclaration-3][]
+
+[ClassDeclaration-4]: logincontroller.md#logincontroller
+[Constructor-0]: logincontroller.md#constructor
+[MethodDeclaration-3]: logincontroller.md#logoutctx
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[ClassDeclaration-5]: context.md#context
+[ClassDeclaration-6]: httpresponseredirect.md#httpresponseredirect
+[ClassDeclaration-9]: httpresponsenocontent.md#httpresponsenocontent
+[MethodDeclaration-4]: logincontroller.md#loginctx
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[ClassDeclaration-5]: context.md#context
+[ClassDeclaration-6]: httpresponseredirect.md#httpresponseredirect
+[ClassDeclaration-9]: httpresponsenocontent.md#httpresponsenocontent
+[ClassDeclaration-11]: httpresponsenotfound.md#httpresponsenotfound
+[ClassDeclaration-13]: httpresponsebadrequest.md#httpresponsebadrequest
+[ClassDeclaration-14]: httpresponseunauthorized.md#httpresponseunauthorized
+[PropertyDeclaration-11]: logincontroller.md#redirect
+[PropertyDeclaration-12]: logincontroller.md#strategies
+[InterfaceDeclaration-3]: ../index.md#strategy

--- a/docs/api/index/objectdoesnotexist.md
+++ b/docs/api/index/objectdoesnotexist.md
@@ -1,0 +1,42 @@
+# Table of contents
+
+* [ObjectDoesNotExist][ClassDeclaration-22]
+    * Constructor
+        * [constructor(content)][Constructor-18]
+    * Properties
+        * [isObjectDoesNotExist][PropertyDeclaration-55]
+
+# ObjectDoesNotExist
+
+```typescript
+class ObjectDoesNotExist
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isObjectDoesNotExist
+
+```typescript
+public readonly isObjectDoesNotExist: true;
+```
+
+**Type**
+
+true
+
+[ClassDeclaration-22]: objectdoesnotexist.md#objectdoesnotexist
+[Constructor-18]: objectdoesnotexist.md#constructorcontent
+[PropertyDeclaration-55]: objectdoesnotexist.md#isobjectdoesnotexist

--- a/docs/api/index/permission.md
+++ b/docs/api/index/permission.md
@@ -1,0 +1,53 @@
+# Table of contents
+
+* [Permission][ClassDeclaration-3]
+    * Properties
+        * [id][PropertyDeclaration-7]
+        * [name][PropertyDeclaration-8]
+        * [codeName][PropertyDeclaration-9]
+
+# Permission
+
+```typescript
+class Permission
+```
+## Properties
+
+### id
+
+```typescript
+public id: number;
+```
+
+**Type**
+
+number
+
+----------
+
+### name
+
+```typescript
+public name: string;
+```
+
+**Type**
+
+string
+
+----------
+
+### codeName
+
+```typescript
+public codeName: string;
+```
+
+**Type**
+
+string
+
+[ClassDeclaration-3]: permission.md#permission
+[PropertyDeclaration-7]: permission.md#id
+[PropertyDeclaration-8]: permission.md#name
+[PropertyDeclaration-9]: permission.md#codename

--- a/docs/api/index/permissiondenied.md
+++ b/docs/api/index/permissiondenied.md
@@ -1,0 +1,42 @@
+# Table of contents
+
+* [PermissionDenied][ClassDeclaration-23]
+    * Constructor
+        * [constructor(content)][Constructor-19]
+    * Properties
+        * [isPermissionDenied][PropertyDeclaration-56]
+
+# PermissionDenied
+
+```typescript
+class PermissionDenied
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isPermissionDenied
+
+```typescript
+public readonly isPermissionDenied: true;
+```
+
+**Type**
+
+true
+
+[ClassDeclaration-23]: permissiondenied.md#permissiondenied
+[Constructor-19]: permissiondenied.md#constructorcontent
+[PropertyDeclaration-56]: permissiondenied.md#ispermissiondenied

--- a/docs/api/index/restcontroller.md
+++ b/docs/api/index/restcontroller.md
@@ -1,0 +1,284 @@
+# Table of contents
+
+* [RestController][ClassDeclaration-15]
+    * Constructor
+        * [constructor()][Constructor-11]
+    * Methods
+        * [extendParams(ctx, params)][MethodDeclaration-5]
+        * [delete()][MethodDeclaration-6]
+        * [deleteById(ctx)][MethodDeclaration-7]
+        * [get(ctx)][MethodDeclaration-8]
+        * [getById(ctx)][MethodDeclaration-9]
+        * [patch()][MethodDeclaration-10]
+        * [patchById(ctx)][MethodDeclaration-11]
+        * [post(ctx)][MethodDeclaration-12]
+        * [postById()][MethodDeclaration-13]
+        * [put()][MethodDeclaration-14]
+        * [putById(ctx)][MethodDeclaration-15]
+    * Properties
+        * [collectionClass][PropertyDeclaration-38]
+
+# RestController
+
+```typescript
+abstract class RestController
+```
+## Constructor
+
+### constructor()
+
+```typescript
+public constructor();
+```
+
+## Methods
+
+### extendParams(ctx, params)
+
+```typescript
+public extendParams(ctx: Context<AbstractUser>, params: CollectionParams): CollectionParams;
+```
+
+**Parameters**
+
+| Name   | Type                                                              |
+| ------ | ----------------------------------------------------------------- |
+| ctx    | [Context][ClassDeclaration-5]<[AbstractUser][ClassDeclaration-1]> |
+| params | [CollectionParams][InterfaceDeclaration-5]                        |
+
+**Return type**
+
+[CollectionParams][InterfaceDeclaration-5]
+
+----------
+
+### delete()
+
+```typescript
+public delete(): HttpResponseMethodNotAllowed;
+```
+
+**Return type**
+
+[HttpResponseMethodNotAllowed][ClassDeclaration-16]
+
+----------
+
+### deleteById(ctx)
+
+```typescript
+public async deleteById(ctx: Context<AbstractUser>): Promise<HttpResponseNotFound | HttpResponseBadRequest | HttpResponseNotImplemented | HttpResponseOK | HttpResponseForbidden>;
+```
+
+**Parameters**
+
+| Name | Type                                                              |
+| ---- | ----------------------------------------------------------------- |
+| ctx  | [Context][ClassDeclaration-5]<[AbstractUser][ClassDeclaration-1]> |
+
+**Return type**
+
+Promise<[HttpResponseNotFound][ClassDeclaration-11] | [HttpResponseBadRequest][ClassDeclaration-13] | [HttpResponseNotImplemented][ClassDeclaration-17] | [HttpResponseOK][ClassDeclaration-19] | [HttpResponseForbidden][ClassDeclaration-20]>
+
+----------
+
+### get(ctx)
+
+```typescript
+public async get(ctx: Context<AbstractUser>): Promise<HttpResponseBadRequest | HttpResponseNotImplemented | HttpResponseOK | HttpResponseForbidden>;
+```
+
+**Parameters**
+
+| Name | Type                                                              |
+| ---- | ----------------------------------------------------------------- |
+| ctx  | [Context][ClassDeclaration-5]<[AbstractUser][ClassDeclaration-1]> |
+
+**Return type**
+
+Promise<[HttpResponseBadRequest][ClassDeclaration-13] | [HttpResponseNotImplemented][ClassDeclaration-17] | [HttpResponseOK][ClassDeclaration-19] | [HttpResponseForbidden][ClassDeclaration-20]>
+
+----------
+
+### getById(ctx)
+
+```typescript
+public async getById(ctx: Context<AbstractUser>): Promise<HttpResponseNotFound | HttpResponseBadRequest | HttpResponseNotImplemented | HttpResponseOK | HttpResponseForbidden>;
+```
+
+**Parameters**
+
+| Name | Type                                                              |
+| ---- | ----------------------------------------------------------------- |
+| ctx  | [Context][ClassDeclaration-5]<[AbstractUser][ClassDeclaration-1]> |
+
+**Return type**
+
+Promise<[HttpResponseNotFound][ClassDeclaration-11] | [HttpResponseBadRequest][ClassDeclaration-13] | [HttpResponseNotImplemented][ClassDeclaration-17] | [HttpResponseOK][ClassDeclaration-19] | [HttpResponseForbidden][ClassDeclaration-20]>
+
+----------
+
+### patch()
+
+```typescript
+public patch(): HttpResponseMethodNotAllowed;
+```
+
+**Return type**
+
+[HttpResponseMethodNotAllowed][ClassDeclaration-16]
+
+----------
+
+### patchById(ctx)
+
+```typescript
+public async patchById(ctx: Context<AbstractUser>): Promise<HttpResponseNotFound | HttpResponseBadRequest | HttpResponseNotImplemented | HttpResponseOK | HttpResponseForbidden>;
+```
+
+**Parameters**
+
+| Name | Type                                                              |
+| ---- | ----------------------------------------------------------------- |
+| ctx  | [Context][ClassDeclaration-5]<[AbstractUser][ClassDeclaration-1]> |
+
+**Return type**
+
+Promise<[HttpResponseNotFound][ClassDeclaration-11] | [HttpResponseBadRequest][ClassDeclaration-13] | [HttpResponseNotImplemented][ClassDeclaration-17] | [HttpResponseOK][ClassDeclaration-19] | [HttpResponseForbidden][ClassDeclaration-20]>
+
+----------
+
+### post(ctx)
+
+```typescript
+public async post(ctx: Context<AbstractUser>): Promise<HttpResponseBadRequest | HttpResponseNotImplemented | HttpResponseForbidden | HttpResponseCreated>;
+```
+
+**Parameters**
+
+| Name | Type                                                              |
+| ---- | ----------------------------------------------------------------- |
+| ctx  | [Context][ClassDeclaration-5]<[AbstractUser][ClassDeclaration-1]> |
+
+**Return type**
+
+Promise<[HttpResponseBadRequest][ClassDeclaration-13] | [HttpResponseNotImplemented][ClassDeclaration-17] | [HttpResponseForbidden][ClassDeclaration-20] | [HttpResponseCreated][ClassDeclaration-21]>
+
+----------
+
+### postById()
+
+```typescript
+public postById(): HttpResponseMethodNotAllowed;
+```
+
+**Return type**
+
+[HttpResponseMethodNotAllowed][ClassDeclaration-16]
+
+----------
+
+### put()
+
+```typescript
+public put(): HttpResponseMethodNotAllowed;
+```
+
+**Return type**
+
+[HttpResponseMethodNotAllowed][ClassDeclaration-16]
+
+----------
+
+### putById(ctx)
+
+```typescript
+public async putById(ctx: Context<AbstractUser>): Promise<HttpResponseNotFound | HttpResponseBadRequest | HttpResponseNotImplemented | HttpResponseOK | HttpResponseForbidden>;
+```
+
+**Parameters**
+
+| Name | Type                                                              |
+| ---- | ----------------------------------------------------------------- |
+| ctx  | [Context][ClassDeclaration-5]<[AbstractUser][ClassDeclaration-1]> |
+
+**Return type**
+
+Promise<[HttpResponseNotFound][ClassDeclaration-11] | [HttpResponseBadRequest][ClassDeclaration-13] | [HttpResponseNotImplemented][ClassDeclaration-17] | [HttpResponseOK][ClassDeclaration-19] | [HttpResponseForbidden][ClassDeclaration-20]>
+
+## Properties
+
+### collectionClass
+
+```typescript
+public abstract collectionClass: Class<Partial<IResourceCollection>>;
+```
+
+**Type**
+
+[Class][InterfaceDeclaration-1]<Partial<[IResourceCollection][InterfaceDeclaration-4]>>
+
+[ClassDeclaration-15]: restcontroller.md#restcontroller
+[Constructor-11]: restcontroller.md#constructor
+[MethodDeclaration-5]: restcontroller.md#extendparamsctx-params
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[ClassDeclaration-5]: context.md#context
+[InterfaceDeclaration-5]: ../index.md#collectionparams
+[InterfaceDeclaration-5]: ../index.md#collectionparams
+[MethodDeclaration-6]: restcontroller.md#delete
+[ClassDeclaration-16]: httpresponsemethodnotallowed.md#httpresponsemethodnotallowed
+[MethodDeclaration-7]: restcontroller.md#deletebyidctx
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[ClassDeclaration-5]: context.md#context
+[ClassDeclaration-11]: httpresponsenotfound.md#httpresponsenotfound
+[ClassDeclaration-13]: httpresponsebadrequest.md#httpresponsebadrequest
+[ClassDeclaration-17]: httpresponsenotimplemented.md#httpresponsenotimplemented
+[ClassDeclaration-19]: httpresponseok.md#httpresponseok
+[ClassDeclaration-20]: httpresponseforbidden.md#httpresponseforbidden
+[MethodDeclaration-8]: restcontroller.md#getctx
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[ClassDeclaration-5]: context.md#context
+[ClassDeclaration-13]: httpresponsebadrequest.md#httpresponsebadrequest
+[ClassDeclaration-17]: httpresponsenotimplemented.md#httpresponsenotimplemented
+[ClassDeclaration-19]: httpresponseok.md#httpresponseok
+[ClassDeclaration-20]: httpresponseforbidden.md#httpresponseforbidden
+[MethodDeclaration-9]: restcontroller.md#getbyidctx
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[ClassDeclaration-5]: context.md#context
+[ClassDeclaration-11]: httpresponsenotfound.md#httpresponsenotfound
+[ClassDeclaration-13]: httpresponsebadrequest.md#httpresponsebadrequest
+[ClassDeclaration-17]: httpresponsenotimplemented.md#httpresponsenotimplemented
+[ClassDeclaration-19]: httpresponseok.md#httpresponseok
+[ClassDeclaration-20]: httpresponseforbidden.md#httpresponseforbidden
+[MethodDeclaration-10]: restcontroller.md#patch
+[ClassDeclaration-16]: httpresponsemethodnotallowed.md#httpresponsemethodnotallowed
+[MethodDeclaration-11]: restcontroller.md#patchbyidctx
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[ClassDeclaration-5]: context.md#context
+[ClassDeclaration-11]: httpresponsenotfound.md#httpresponsenotfound
+[ClassDeclaration-13]: httpresponsebadrequest.md#httpresponsebadrequest
+[ClassDeclaration-17]: httpresponsenotimplemented.md#httpresponsenotimplemented
+[ClassDeclaration-19]: httpresponseok.md#httpresponseok
+[ClassDeclaration-20]: httpresponseforbidden.md#httpresponseforbidden
+[MethodDeclaration-12]: restcontroller.md#postctx
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[ClassDeclaration-5]: context.md#context
+[ClassDeclaration-13]: httpresponsebadrequest.md#httpresponsebadrequest
+[ClassDeclaration-17]: httpresponsenotimplemented.md#httpresponsenotimplemented
+[ClassDeclaration-20]: httpresponseforbidden.md#httpresponseforbidden
+[ClassDeclaration-21]: httpresponsecreated.md#httpresponsecreated
+[MethodDeclaration-13]: restcontroller.md#postbyid
+[ClassDeclaration-16]: httpresponsemethodnotallowed.md#httpresponsemethodnotallowed
+[MethodDeclaration-14]: restcontroller.md#put
+[ClassDeclaration-16]: httpresponsemethodnotallowed.md#httpresponsemethodnotallowed
+[MethodDeclaration-15]: restcontroller.md#putbyidctx
+[ClassDeclaration-1]: abstractuser.md#abstractuser
+[ClassDeclaration-5]: context.md#context
+[ClassDeclaration-11]: httpresponsenotfound.md#httpresponsenotfound
+[ClassDeclaration-13]: httpresponsebadrequest.md#httpresponsebadrequest
+[ClassDeclaration-17]: httpresponsenotimplemented.md#httpresponsenotimplemented
+[ClassDeclaration-19]: httpresponseok.md#httpresponseok
+[ClassDeclaration-20]: httpresponseforbidden.md#httpresponseforbidden
+[PropertyDeclaration-38]: restcontroller.md#collectionclass
+[InterfaceDeclaration-4]: ../index.md#iresourcecollection
+[InterfaceDeclaration-1]: ../index.md#class

--- a/docs/api/index/servicemanager.md
+++ b/docs/api/index/servicemanager.md
@@ -1,0 +1,82 @@
+# Table of contents
+
+* [ServiceManager][ClassDeclaration-28]
+    * Methods
+        * [set(serviceClass, service)][MethodDeclaration-22]
+        * [get(serviceClass)][MethodDeclaration-23]
+    * Properties
+        * [map][PropertyDeclaration-69]
+
+# ServiceManager
+
+```typescript
+class ServiceManager
+```
+## Methods
+
+### set(serviceClass, service)
+
+```typescript
+public set<Service>(serviceClass: Class<Service>, service: any): void;
+```
+
+**Type parameters**
+
+| Name    |
+| ------- |
+| Service |
+
+**Parameters**
+
+| Name         | Type                                     |
+| ------------ | ---------------------------------------- |
+| serviceClass | [Class][InterfaceDeclaration-1]<Service> |
+| service      | any                                      |
+
+**Return type**
+
+void
+
+----------
+
+### get(serviceClass)
+
+```typescript
+public get<Service>(serviceClass: Class<Service>): Service;
+```
+
+**Type parameters**
+
+| Name    |
+| ------- |
+| Service |
+
+**Parameters**
+
+| Name         | Type                                     |
+| ------------ | ---------------------------------------- |
+| serviceClass | [Class][InterfaceDeclaration-1]<Service> |
+
+**Return type**
+
+Service
+
+## Properties
+
+### map
+
+```typescript
+public readonly map: Map<Class<any>, any>;
+```
+
+**Type**
+
+Map<[Class][InterfaceDeclaration-1]<any>, any>
+
+[ClassDeclaration-28]: servicemanager.md#servicemanager
+[MethodDeclaration-22]: servicemanager.md#setserviceclass-service
+[InterfaceDeclaration-1]: ../index.md#class
+[MethodDeclaration-23]: servicemanager.md#getserviceclass
+[InterfaceDeclaration-1]: ../index.md#class
+[PropertyDeclaration-69]: servicemanager.md#map
+[InterfaceDeclaration-1]: ../index.md#class

--- a/docs/api/index/validationerror.md
+++ b/docs/api/index/validationerror.md
@@ -1,0 +1,42 @@
+# Table of contents
+
+* [ValidationError][ClassDeclaration-24]
+    * Constructor
+        * [constructor(content)][Constructor-20]
+    * Properties
+        * [isValidationError][PropertyDeclaration-57]
+
+# ValidationError
+
+```typescript
+class ValidationError
+```
+## Constructor
+
+### constructor(content)
+
+```typescript
+public constructor(content?: any);
+```
+
+**Parameters**
+
+| Name    | Type |
+| ------- | ---- |
+| content | any  |
+
+## Properties
+
+### isValidationError
+
+```typescript
+public readonly isValidationError: true;
+```
+
+**Type**
+
+true
+
+[ClassDeclaration-24]: validationerror.md#validationerror
+[Constructor-20]: validationerror.md#constructorcontent
+[PropertyDeclaration-57]: validationerror.md#isvalidationerror

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -111,10 +111,27 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@simplrjs/markdown": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@simplrjs/markdown/-/markdown-1.1.0.tgz",
+			"integrity": "sha512-YkSe0VmOzAEtVz5qTEPZAc1nu4h1WBmNmSo3JqnN0+PEkZ3QJDCykUZ0AsLd4mJddDSJN9QcphuhqtZPry/BOA==",
+			"requires": {
+				"@types/string": "0.0.29",
+				"string": "^3.3.3"
+			}
+		},
 		"@types/cookiejar": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.0.tgz",
 			"integrity": "sha512-EIjmpvnHj+T4nMcKwHwxZKUfDmphIKJc2qnEMhSoOvr1lYEQpuRKRz8orWr//krYIIArS/KGGLfL2YGVUYXmIA=="
+		},
+		"@types/fs-extra": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
+			"integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/mocha": {
 			"version": "2.2.48",
@@ -125,6 +142,11 @@
 			"version": "10.7.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.1.tgz",
 			"integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w=="
+		},
+		"@types/string": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/string/-/string-0.0.29.tgz",
+			"integrity": "sha512-p8YTvb6vTWL38JxSe1rCduwP2l0jNRZpHlDUWqLt5A3F4SOc7yBPPd3jBiSk3b66urjs2tFM2QOhf4yEzz9wiQ=="
 		},
 		"@types/superagent": {
 			"version": "3.8.3",
@@ -142,6 +164,11 @@
 			"requires": {
 				"@types/superagent": "*"
 			}
+		},
+		"@types/yargs": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-10.0.2.tgz",
+			"integrity": "sha512-VbsIazac1gy20qTjEZVgDUhs8uuVmGbFkSGcdHpcMoXSC4+0vn/PRHz9YBqpgxKwUi8qoxf3eHff07w7aKNBOg=="
 		},
 		"abbrev": {
 			"version": "1.1.1",
@@ -350,6 +377,11 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
 			"integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg="
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
 		"bytes": {
 			"version": "3.0.0",
@@ -929,6 +961,16 @@
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
+		"fs-extra": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+			"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			}
+		},
 		"fs-minipass": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
@@ -992,6 +1034,11 @@
 			"version": "11.7.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
 			"integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
+		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 		},
 		"graceful-readlink": {
 			"version": "1.0.1",
@@ -1117,6 +1164,11 @@
 				"parse-passwd": "^1.0.0"
 			}
 		},
+		"hosted-git-info": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+		},
 		"hpkp": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/hpkp/-/hpkp-2.0.0.tgz",
@@ -1207,6 +1259,14 @@
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
 			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
 		},
+		"is-builtin-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+			"requires": {
+				"builtin-modules": "^1.0.0"
+			}
+		},
 		"is-fullwidth-code-point": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -1284,6 +1344,11 @@
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
 			"integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
 		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -1303,6 +1368,14 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
 			"integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"requires": {
+				"graceful-fs": "^4.1.6"
+			}
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -1661,6 +1734,17 @@
 			"requires": {
 				"abbrev": "1",
 				"osenv": "^0.1.4"
+			}
+		},
+		"normalize-package-data": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"requires": {
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"npm-bundled": {
@@ -3810,6 +3894,18 @@
 				}
 			}
 		},
+		"read-package-json": {
+			"version": "2.0.13",
+			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
+			"integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
+			"requires": {
+				"glob": "^7.1.1",
+				"graceful-fs": "^4.1.2",
+				"json-parse-better-errors": "^1.0.1",
+				"normalize-package-data": "^2.0.0",
+				"slash": "^1.0.0"
+			}
+		},
 		"readable-stream": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -3998,6 +4094,19 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
+		"simplr-logger": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simplr-logger/-/simplr-logger-1.0.1.tgz",
+			"integrity": "sha512-lyDPiwbPi3jlOMj1Zufdmy60ibE3EyHgJ3nH/FzFNe9pfSz15mWYOt4FT860XFvxVQkZX7RxrqzPMoPSgAU3nQ==",
+			"requires": {
+				"tslib": "^1.8.0"
+			}
+		},
+		"slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+		},
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -4018,6 +4127,34 @@
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
+		},
+		"spdx-correct": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+			"requires": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
+			"integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w=="
 		},
 		"split": {
 			"version": "1.0.1",
@@ -4067,6 +4204,11 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+		},
+		"string": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
+			"integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA="
 		},
 		"string-width": {
 			"version": "1.0.2",
@@ -4221,6 +4363,33 @@
 			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
+		"ts-docs-gen": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ts-docs-gen/-/ts-docs-gen-0.2.0.tgz",
+			"integrity": "sha512-QnuHLyK2yAvRezcBD0uYpvDTCq+KED3SPdXuFO2niG7Is6diuvn/8Av3jg6cRV1fYcrMH4qDreiQk1jdds0toQ==",
+			"requires": {
+				"@simplrjs/markdown": "^1.1.0",
+				"@types/fs-extra": "^5.0.0",
+				"@types/yargs": "^10.0.1",
+				"fs-extra": "^5.0.0",
+				"simplr-logger": "^1.0.1",
+				"ts-extractor": "^4.0.0-rc.4",
+				"typescript": "^2.7.1",
+				"yargs": "^11.0.0"
+			}
+		},
+		"ts-extractor": {
+			"version": "4.0.0-rc.4",
+			"resolved": "https://registry.npmjs.org/ts-extractor/-/ts-extractor-4.0.0-rc.4.tgz",
+			"integrity": "sha512-eP+kJ59pwa2h2OrrdMi+OrcpgsZaMNXMrpAEBinfjE4ZC8E+ic3ahzhkfK+Gs/5t7vop2DsL+qz1Nxa3oFq6eg==",
+			"requires": {
+				"@types/fs-extra": "^5.0.0",
+				"fs-extra": "^5.0.0",
+				"read-package-json": "^2.0.12",
+				"simplr-logger": "^1.0.1",
+				"typescript": "^2.7.1"
+			}
+		},
 		"ts-node": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.3.0.tgz",
@@ -4261,6 +4430,11 @@
 				"strip-bom": "^3.0.0",
 				"strip-json-comments": "^2.0.0"
 			}
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
 		},
 		"tsscmp": {
 			"version": "1.0.5",
@@ -4346,6 +4520,11 @@
 				"random-bytes": "~1.0.0"
 			}
 		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+		},
 		"unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -4380,6 +4559,15 @@
 			"integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
+			}
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"vary": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "scripts": {
+    "generate:api:docs": "ts-docs-gen --entryFile ./src/index.ts --output ../../docs",
     "test": "nyc --reporter=json --reporter=text mocha --require ts-node/register --require source-map-support/register \"./src/**/*.spec.ts\"",
     "e2e": "mocha --require ts-node/register \"./e2e/**/*.spec.ts\"",
     "dev:e2e": "mocha --require ts-node/register --watch --watch-extensions ts \"./e2e/**/*.spec.ts\"",
@@ -102,6 +103,7 @@
     "supertest": "^3.1.0",
     "ts-node": "^3.3.0",
     "typeorm": "^0.2.6",
-    "typescript": "^2.5.2"
+    "typescript": "^2.5.2",
+    "ts-docs-gen": "0.2.0"
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,6 +9,7 @@
     "noImplicitAny": false,
     "sourceMap": true,
     "declaration": true,
+    "types": [ "node" ],
     "lib": [
       "es2017",
       "dom"

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,7 +9,7 @@
     "noImplicitAny": false,
     "sourceMap": true,
     "declaration": true,
-    "types": [ "node" ],
+    "types": [ "node", "mocha" ],
     "lib": [
       "es2017",
       "dom"


### PR DESCRIPTION
# Issue

The docs are missing an "API reference" section. See https://github.com/FoalTS/foal/issues/217.

# Solution and steps

Use the `ts-docs-gen` library to generate the API docs from the source code.

# What could be better

- Generate the API docs of all packages (not only `@foal/core`).
- Having a webhook to generate the API docs automatically.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.