### PR TITLE
Remove sourcemaps from built packages.

### DIFF
--- a/packages/cli/tsconfig-build.json
+++ b/packages/cli/tsconfig-build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false
+  },
   "exclude": [
     "./src/**/*.spec.ts",
     "./src/generate/mocks/**/*.ts",

--- a/packages/core/tsconfig-build.json
+++ b/packages/core/tsconfig-build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false
+  },
   "exclude": [
     "./src/**/*.spec.ts",
     "./e2e/**/*.spec.ts"

--- a/packages/ejs/tsconfig-build.json
+++ b/packages/ejs/tsconfig-build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false
+  },
   "exclude": [
     "./src/**/*.spec.ts"
   ]

--- a/packages/password/tsconfig-build.json
+++ b/packages/password/tsconfig-build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false
+  },
   "exclude": [
     "./src/**/*.spec.ts"
   ]


### PR DESCRIPTION
# Issue

The packages distributed on npm contain the sourcemaps. They are useless and increase unnecessarily the packages size.

# Solution and steps

Do not bundle the sourcemaps on building.

```
@foal/cli: 80k -> 58k
@foal/core: 142k -> 90k
@foal/ejs: 829o -> 571o
@foal/password: 40k -> 39k
```

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.