### PR TITLE
[@foal/cli] Add e2e tests to the generated apps and improve builds

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -55,6 +55,7 @@
 
 * [Introduction](./testing/introduction.md)
 * [Unit Testing](./testing/unit-testing.md)
+* [E2E Testing](./testing/e2e-testing.md)
 
 ## Deployment & environments
 

--- a/docs/databases/generate-and-run-migrations.md
+++ b/docs/databases/generate-and-run-migrations.md
@@ -14,9 +14,9 @@ npm run migration:revert
 
 Generate a migration from the changes in your entities
 ```sh
-npm run build # Build the entities
+npm run build:app # Build the entities
 npm run migration:generate -- -n my-migration # Generate the migration
-npm run build # Build the migrations
+npm run build:migrations # Build the migrations
 npm run migration:run # Run the migrations
 ```
 

--- a/docs/development-environment/build-and-start-the-app.md
+++ b/docs/development-environment/build-and-start-the-app.md
@@ -3,7 +3,7 @@
 FoalTS provides several commands to help you build and develop your app.
 
 - `npm run develop` - Build the source code and start the server. If a file changes then the code is rebuilt and the server reloads. This is usually **the only command that you need during development**.
-- `npm run build` - Build the source code (compile the typescript files and copy the templates).
-- `npm run build:w` - Build the source code (compile the typescript files and copy the templates) and do it again whenever a file changes (watch mode).
+- `npm run build:app` - Build the app code (compile the typescript files and copy the templates).
+- `npm run build:app:w` - Build the app code (compile the typescript files and copy the templates) and do it again whenever a file changes (watch mode).
 - `npm run start` - Start the server from the built files.
 - `npm run start:w` - Start the server from the built files and reload it whenever one of these files changes (watch mode).

--- a/docs/development-environment/create-and-run-scripts.md
+++ b/docs/development-environment/create-and-run-scripts.md
@@ -38,7 +38,7 @@ Encapsulating your code in a `main` function without calling it directly in the 
 To run a script you first need to build it.
 
 ```sh
-npm run build
+npm run build:scripts
 ```
 
 Then you can execute it with this command:

--- a/docs/testing/e2e-testing.md
+++ b/docs/testing/e2e-testing.md
@@ -1,0 +1,46 @@
+# E2E Testing
+
+End-to-end tests are located in the `src/e2e` directory.
+
+## Write, Build and Run E2E Tests
+
+- `npm run e2e` - Build the e2e tests code and execute them. If a file changes then the code is rebuilt and the tests are executed again. This is usually **the only command that you need during development**.
+- `npm run build:e2e` - Build the e2e tests code (compile the typescript files and copy the templates).
+- `npm run build:e2e:w` - Build the e2e tests code (compile the typescript files and copy the templates) and do it again whenever a file changes (watch mode).
+- `npm run start:e2e` - Execute the e2e tests from the built files.
+- `npm run start:e2e:w` - Execute the e2e tests from the built files and do it again whenever one of these files changes (watch mode).
+
+## The `SuperTest` library
+
+You can use [the SuperTest library](https://github.com/visionmedia/supertest) to write your e2e tests. It is installed by default.
+
+*Example:*
+```typescript
+// 3p
+import { createApp } from '@foal/core';
+import * as request from 'supertest';
+import { createConnection, getConnection } from 'typeorm';
+
+// App
+import { AppModule } from '../app/app.module';
+
+describe('The server', () => {
+
+  let app;
+
+  before(async () => {
+    await createConnection();
+    app = createApp(AppModule);
+  });
+
+  after(() => getConnection().close());
+
+  it('should return a 200 status on GET / requests.', () => {
+    return request(app)
+      .get('/')
+      .expect(200);
+  });
+
+});
+
+```

--- a/docs/testing/unit-testing.md
+++ b/docs/testing/unit-testing.md
@@ -11,7 +11,7 @@ Every unit test file should be placed next to the file it tests with the same na
   '- my-service.service.spec.ts
 ```
 
-## Write, Build and Run Tests
+## Write, Build and Run Unit Tests
 
 - `npm run test` - Build the unit tests code and execute them. If a file changes then the code is rebuilt and the tests are executed again. This is usually **the only command that you need during development**.
 - `npm run build:test` - Build the unit tests code (compile the typescript files and copy the templates).

--- a/docs/testing/unit-testing.md
+++ b/docs/testing/unit-testing.md
@@ -13,11 +13,11 @@ Every unit test file should be placed next to the file it tests with the same na
 
 ## Write, Build and Run Tests
 
-- `npm run test` - Build the test code and execute the tests. If a file changes then the code is rebuilt and the tests are executed again. This is usually **the only command that you need during development**.
-- `npm run build:test` - Build the test code (compile the typescript files and copy the templates).
-- `npm run build:test:w` - Build the test code (compile the typescript files and copy the templates) and do it again whenever a file changes (watch mode).
-- `npm run start:test` - Execute the tests from the built files.
-- `npm run start:test:w` - Execute the tests from the built files and do it again whenever one of these files changes (watch mode).
+- `npm run test` - Build the unit tests code and execute them. If a file changes then the code is rebuilt and the tests are executed again. This is usually **the only command that you need during development**.
+- `npm run build:test` - Build the unit tests code (compile the typescript files and copy the templates).
+- `npm run build:test:w` - Build the unit tests code (compile the typescript files and copy the templates) and do it again whenever a file changes (watch mode).
+- `npm run start:test` - Execute the unit tests from the built files.
+- `npm run start:test:w` - Execute the unit tests from the built files and do it again whenever one of these files changes (watch mode).
 
 
 ## Testing Controllers and Services

--- a/docs/the-authentication-system/authentication.md
+++ b/docs/the-authentication-system/authentication.md
@@ -34,7 +34,7 @@ export class User extends AbstractUser {
 
 ```
 
-> You can use the `scripts/create-user.ts` to create users. Simply run `npm run build && node lib/scripts/create-user.js`.
+> You can use the `scripts/create-user.ts` to create users. Simply run `npm run build:scripts && foal run-script create-user`.
 
 ### Create an Authenticator
 

--- a/docs/the-authentication-system/permissions-and-authorization.md
+++ b/docs/the-authentication-system/permissions-and-authorization.md
@@ -25,7 +25,7 @@ The `PermissionRequired(perm: string)` hook returns a `403 Forbidden` if the use
 ## Create permissions, groups and users with the shell scripts.
 
 ```sh
-npm run build
+npm run build:scripts
 
 foal run-script create-perm name="My first permission" codeName="my-first-perm"
 foal run-script create-perm name="My second permission" codeName="my-second-perm"

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -15,12 +15,21 @@ foal g hook foo-bar
 foal g module bar-foo
 foal g script bar-script
 
-# Test building
-npm run build
-npm run build:test
+# Build the app
+npm run build:app
 
-# Run the generated unit tests
+# Build and run the unit tests
+npm run build:test
 npm run start:test
+
+# Build and run the e2e tests
+npm run build:e2e
+npm run start:e2e
+
+# Build and run the migrations
+npm run migration:generate -- -n my-migration
+npm run build:migrations
+npm run migration:run
 
 # Test the application when it is started
 pm2 start lib/index.js
@@ -35,6 +44,8 @@ test "$response" -ge 200 && test "$response" -le 299
 pm2 delete index
 
 # Test the default shell scripts to create permissions, groups and users.
+npm run build:scripts
+
 foal run-script create-perm name="My first permission" codeName="my-first-perm"
 foal run-script create-perm name="My second permission" codeName="my-second-perm"
 

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -6,17 +6,22 @@ foal createapp my-app
 cd my-app
 npm install
 
-# Test linting
-npm run lint
-
 # Test the generators that do not require user interaction
 foal g entity flight
 foal g hook foo-bar
 foal g module bar-foo
 foal g script bar-script
 
+# Test linting
+npm run lint
+
 # Build the app
 npm run build:app
+
+# Build and run the migrations
+npm run migration:generate -- -n my-migration
+npm run build:migrations
+npm run migration:run
 
 # Build and run the unit tests
 npm run build:test
@@ -25,11 +30,6 @@ npm run start:test
 # Build and run the e2e tests
 npm run build:e2e
 npm run start:e2e
-
-# Build and run the migrations
-npm run migration:generate -- -n my-migration
-npm run build:migrations
-npm run migration:run
 
 # Test the application when it is started
 pm2 start lib/index.js

--- a/packages/cli/src/generate/generators/app/create-app.spec.ts
+++ b/packages/cli/src/generate/generators/app/create-app.spec.ts
@@ -12,8 +12,12 @@ describe('createApp', () => {
     testEnv.rmfileIfExists('.gitignore');
     testEnv.rmfileIfExists('ormconfig.json');
     testEnv.rmfileIfExists('package.json');
-    testEnv.rmfileIfExists('tsconfig.json');
     testEnv.rmfileIfExists('tsconfig.app.json');
+    testEnv.rmfileIfExists('tsconfig.e2e.json');
+    testEnv.rmfileIfExists('tsconfig.json');
+    testEnv.rmfileIfExists('tsconfig.migrations.json');
+    testEnv.rmfileIfExists('tsconfig.scripts.json');
+    testEnv.rmfileIfExists('tsconfig.test.json');
     testEnv.rmfileIfExists('tslint.json');
 
     // Config
@@ -150,6 +154,11 @@ describe('createApp', () => {
       .validateSpec('package.json')
       .validateSpec('tsconfig.json')
       .validateSpec('tsconfig.app.json')
+      .validateSpec('tsconfig.e2e.json')
+      .validateSpec('tsconfig.json')
+      .validateSpec('tsconfig.migrations.json')
+      .validateSpec('tsconfig.scripts.json')
+      .validateSpec('tsconfig.test.json')
       .validateSpec('tslint.json');
   });
 

--- a/packages/cli/src/generate/generators/app/create-app.spec.ts
+++ b/packages/cli/src/generate/generators/app/create-app.spec.ts
@@ -54,6 +54,9 @@ describe('createApp', () => {
     testEnv.rmfileIfExists('src/app/app.module.ts');
     testEnv.rmdirIfExists('src/app');
 
+    testEnv.rmfileIfExists('src/e2e/index.ts');
+    testEnv.rmdirIfExists('src/e2e');
+
     testEnv.rmfileIfExists('src/scripts/create-group.ts');
     testEnv.rmfileIfExists('src/scripts/create-perm.ts');
     testEnv.rmfileIfExists('src/scripts/create-user.ts');
@@ -83,12 +86,16 @@ describe('createApp', () => {
       .validateFileSpec('public/logo.png');
   });
 
+  it('shoud copy the src/e2e templates.', () => {
+    testEnv
+      .validateSpec('src/e2e/index.ts');
+  });
+
   it('shoud copy the src/scripts templates.', () => {
     testEnv
       .validateSpec('src/scripts/create-group.ts')
       .validateSpec('src/scripts/create-perm.ts')
       .validateSpec('src/scripts/create-user.ts');
-
   });
 
   it('should render the src/app/controllers templates.', () => {

--- a/packages/cli/src/generate/generators/app/create-app.spec.ts
+++ b/packages/cli/src/generate/generators/app/create-app.spec.ts
@@ -59,6 +59,7 @@ describe('createApp', () => {
     testEnv.rmfileIfExists('src/scripts/create-user.ts');
     testEnv.rmdirIfExists('src/scripts');
 
+    testEnv.rmfileIfExists('src/e2e.ts');
     testEnv.rmfileIfExists('src/index.ts');
     testEnv.rmfileIfExists('src/test.ts');
     testEnv.rmdirIfExists('src');
@@ -130,6 +131,7 @@ describe('createApp', () => {
 
   it('should render the src templates.', () => {
     testEnv
+      .validateSpec('src/e2e.ts')
       .validateSpec('src/index.ts')
       .validateSpec('src/test.ts');
   });

--- a/packages/cli/src/generate/generators/app/create-app.spec.ts
+++ b/packages/cli/src/generate/generators/app/create-app.spec.ts
@@ -22,6 +22,7 @@ describe('createApp', () => {
 
     // Config
     testEnv.rmfileIfExists('config/app.development.json');
+    testEnv.rmfileIfExists('config/app.e2e.json');
     testEnv.rmfileIfExists('config/app.production.json');
     testEnv.rmfileIfExists('config/app.test.json');
     testEnv.rmfileIfExists('config/settings.development.json');
@@ -78,6 +79,7 @@ describe('createApp', () => {
   it('should render the config templates.', () => {
     testEnv
       .validateSpec('config/app.development.json')
+      .validateSpec('config/app.e2e.json')
       .validateSpec('config/app.production.json')
       .validateSpec('config/app.test.json')
       .validateSpec('config/settings.development.json')

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -79,6 +79,9 @@ export function createApp({ name, sessionSecret }:
           // Sub-modules
           .mkdirIfDoesNotExist('src/app/sub-modules')
           .copyFileFromTemplates('src/app/sub-modules/index.ts')
+        // E2E
+        .mkdirIfDoesNotExist('src/e2e')
+        .copyFileFromTemplates('src/e2e/index.ts')
         // Scripts
         .mkdirIfDoesNotExist('src/scripts')
         .copyFileFromTemplates('src/scripts/create-group.ts')

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -46,6 +46,7 @@ export function createApp({ name, sessionSecret }:
       // Config
       .mkdirIfDoesNotExist('config')
       .renderTemplate('config/app.development.json', locals)
+      .renderTemplate('config/app.e2e.json', locals)
       .renderTemplate('config/app.production.json', locals)
       .renderTemplate('config/app.test.json', locals)
       .renderTemplate('config/settings.json', locals)

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -37,7 +37,11 @@ export function createApp({ name, sessionSecret }:
     .copyFileFromTemplates('ormconfig.json')
     .renderTemplate('package.json', locals)
     .copyFileFromTemplates('tsconfig.app.json')
+    .copyFileFromTemplates('tsconfig.e2e.json')
     .copyFileFromTemplates('tsconfig.json')
+    .copyFileFromTemplates('tsconfig.migrations.json')
+    .copyFileFromTemplates('tsconfig.scripts.json')
+    .copyFileFromTemplates('tsconfig.test.json')
     .copyFileFromTemplates('tslint.json')
       // Config
       .mkdirIfDoesNotExist('config')

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -52,6 +52,7 @@ export function createApp({ name, sessionSecret }:
       .copyFileFromTemplates('public/logo.png')
       // Src
       .mkdirIfDoesNotExist('src')
+      .copyFileFromTemplates('src/e2e.ts')
       .copyFileFromTemplates('src/index.ts')
       .copyFileFromTemplates('src/test.ts')
         // App

--- a/packages/cli/src/generate/specs/app/config/app.e2e.json
+++ b/packages/cli/src/generate/specs/app/config/app.e2e.json
@@ -1,0 +1,3 @@
+{
+  "name": "test-foo-bar (e2e)"
+}

--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -32,11 +32,12 @@
     "typeorm": "^0.2.6"
   },
   "devDependencies": {
-    "@types/node": "^8.0.47",
-    "mocha": "^5.2.0",
     "@types/mocha": "^5.2.1",
+    "@types/node": "^8.0.47",
     "concurrently": "^3.5.1",
     "copy": "^0.3.2",
+    "mocha": "^5.2.0",
+    "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
     "typescript": "^2.8.3"

--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -3,19 +3,30 @@
   "version": "0.0.0",
   "description": "",
   "scripts": {
-    "build": "copy-cli \"src/**/*.html\" lib && tsc -p tsconfig.app.json",
-    "build:w": "tsc -p tsconfig.app.json -w",
+    "build:app": "copy-cli \"src/**/*.html\" lib && tsc -p tsconfig.app.json",
+    "build:app:w": "tsc -p tsconfig.app.json -w",
     "start": "node ./lib/index.js",
     "start:w": "supervisor -w ./lib --no-restart-on error ./lib/index.js",
-    "develop": "npm run build && concurrently \"npm run build:w\" \"npm run start:w\"",
+    "develop": "npm run build:app && concurrently \"npm run build:app:w\" \"npm run start:w\"",
 
-    "build:test": "copy-cli \"src/**/*.html\" lib && tsc",
-    "build:test:w": "tsc -w",
+    "build:test": "copy-cli \"src/**/*.html\" lib && tsc -p tsconfig.test.json",
+    "build:test:w": "tsc -p tsconfig.test.json -w",
     "start:test": "mocha --file \"./lib/test.js\" \"./lib/**/*.spec.js\"",
     "start:test:w": "mocha --file \"./lib/test.js\" -w \"./lib/**/*.spec.js\"",
     "test": "npm run build:test && concurrently \"npm run build:test:w\" \"npm run start:test:w\"",
 
+    "build:e2e": "copy-cli \"src/**/*.html\" lib && tsc -p tsconfig.e2e.json",
+    "build:e2e:w": "tsc -p tsconfig.e2e.json -w",
+    "start:e2e": "mocha --file \"./lib/e2e.js\" \"./lib/e2e/**/*.js\"",
+    "start:e2e:w": "mocha --file \"./lib/e2e.js\" -w \"./lib/e2e/**/*.js\"",
+    "e2e": "npm run build:e2e && concurrently \"npm run build:e2e:w\" \"npm run start:e2e:w\"",
+
+    "build:scripts": "tsc -p tsconfig.scripts.json",
+    "build:scripts:w": "tsc -p tsconfig.scripts.json -w",
+
     "lint": "tslint -c tslint.json -p tsconfig.json",
+
+    "build:migrations": "tsc -p tsconfig.migrations.json",
     "migration:generate": "./node_modules/.bin/typeorm migration:generate",
     "migration:run": "./node_modules/.bin/typeorm migration:run",
     "migration:revert": "./node_modules/.bin/typeorm migration:revert"

--- a/packages/cli/src/generate/specs/app/src/e2e.ts
+++ b/packages/cli/src/generate/specs/app/src/e2e.ts
@@ -1,0 +1,1 @@
+process.env.NODE_ENV = 'e2e';

--- a/packages/cli/src/generate/specs/app/src/e2e/index.ts
+++ b/packages/cli/src/generate/specs/app/src/e2e/index.ts
@@ -1,0 +1,26 @@
+// 3p
+import { createApp } from '@foal/core';
+import * as request from 'supertest';
+import { createConnection, getConnection } from 'typeorm';
+
+// App
+import { AppModule } from '../app/app.module';
+
+describe('The server', () => {
+
+  let app;
+
+  before(async () => {
+    await createConnection();
+    app = createApp(AppModule);
+  });
+
+  after(() => getConnection().close());
+
+  it('should return a 200 status on GET / requests.', () => {
+    return request(app)
+      .get('/')
+      .expect(200);
+  });
+
+});

--- a/packages/cli/src/generate/specs/app/tsconfig.e2e.json
+++ b/packages/cli/src/generate/specs/app/tsconfig.e2e.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "include": [
     "src/app/**/*.ts",
-    "src/index.ts"
+    "src/e2e/**/*.ts",
+    "src/e2e.ts"
   ],
   "exclude": [
     "src/app/**/*.spec.ts"

--- a/packages/cli/src/generate/specs/app/tsconfig.json
+++ b/packages/cli/src/generate/specs/app/tsconfig.json
@@ -8,6 +8,7 @@
     "noImplicitAny": false,
     "module": "commonjs",
     "target": "es2017",
+    "rootDir": "src",
     "lib": [
       "es2017",
       "dom"

--- a/packages/cli/src/generate/specs/app/tsconfig.migrations.json
+++ b/packages/cli/src/generate/specs/app/tsconfig.migrations.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false
+  },
+  "include": [
+    "src/migrations/*.ts"
+  ]
+}

--- a/packages/cli/src/generate/specs/app/tsconfig.scripts.json
+++ b/packages/cli/src/generate/specs/app/tsconfig.scripts.json
@@ -2,9 +2,10 @@
   "extends": "./tsconfig.json",
   "include": [
     "src/app/**/*.ts",
-    "src/index.ts"
+    "src/scripts/*.ts"
   ],
   "exclude": [
-    "src/app/**/*.spec.ts"
+    "src/app/**/*.spec.ts",
+    "src/scripts/*.spec.ts"
   ]
 }

--- a/packages/cli/src/generate/specs/app/tsconfig.test.json
+++ b/packages/cli/src/generate/specs/app/tsconfig.test.json
@@ -2,9 +2,6 @@
   "extends": "./tsconfig.json",
   "include": [
     "src/app/**/*.ts",
-    "src/index.ts"
-  ],
-  "exclude": [
-    "src/app/**/*.spec.ts"
+    "src/scripts/*.ts"
   ]
 }

--- a/packages/cli/src/generate/specs/app/tsconfig.test.json
+++ b/packages/cli/src/generate/specs/app/tsconfig.test.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "include": [
     "src/app/**/*.ts",
-    "src/scripts/*.ts"
+    "src/scripts/*.ts",
+    "src/test.ts"
   ]
 }

--- a/packages/cli/src/generate/templates/app/config/app.e2e.json
+++ b/packages/cli/src/generate/templates/app/config/app.e2e.json
@@ -1,0 +1,3 @@
+{
+  "name": "/* kebabName */ (e2e)"
+}

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -32,11 +32,12 @@
     "typeorm": "^0.2.6"
   },
   "devDependencies": {
-    "@types/node": "^8.0.47",
-    "mocha": "^5.2.0",
     "@types/mocha": "^5.2.1",
+    "@types/node": "^8.0.47",
     "concurrently": "^3.5.1",
     "copy": "^0.3.2",
+    "mocha": "^5.2.0",
+    "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
     "typescript": "^2.8.3"

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -3,19 +3,30 @@
   "version": "0.0.0",
   "description": "",
   "scripts": {
-    "build": "copy-cli \"src/**/*.html\" lib && tsc -p tsconfig.app.json",
-    "build:w": "tsc -p tsconfig.app.json -w",
+    "build:app": "copy-cli \"src/**/*.html\" lib && tsc -p tsconfig.app.json",
+    "build:app:w": "tsc -p tsconfig.app.json -w",
     "start": "node ./lib/index.js",
     "start:w": "supervisor -w ./lib --no-restart-on error ./lib/index.js",
-    "develop": "npm run build && concurrently \"npm run build:w\" \"npm run start:w\"",
+    "develop": "npm run build:app && concurrently \"npm run build:app:w\" \"npm run start:w\"",
 
-    "build:test": "copy-cli \"src/**/*.html\" lib && tsc",
-    "build:test:w": "tsc -w",
+    "build:test": "copy-cli \"src/**/*.html\" lib && tsc -p tsconfig.test.json",
+    "build:test:w": "tsc -p tsconfig.test.json -w",
     "start:test": "mocha --file \"./lib/test.js\" \"./lib/**/*.spec.js\"",
     "start:test:w": "mocha --file \"./lib/test.js\" -w \"./lib/**/*.spec.js\"",
     "test": "npm run build:test && concurrently \"npm run build:test:w\" \"npm run start:test:w\"",
 
+    "build:e2e": "copy-cli \"src/**/*.html\" lib && tsc -p tsconfig.e2e.json",
+    "build:e2e:w": "tsc -p tsconfig.e2e.json -w",
+    "start:e2e": "mocha --file \"./lib/e2e.js\" \"./lib/e2e/**/*.js\"",
+    "start:e2e:w": "mocha --file \"./lib/e2e.js\" -w \"./lib/e2e/**/*.js\"",
+    "e2e": "npm run build:e2e && concurrently \"npm run build:e2e:w\" \"npm run start:e2e:w\"",
+
+    "build:scripts": "tsc -p tsconfig.scripts.json",
+    "build:scripts:w": "tsc -p tsconfig.scripts.json -w",
+
     "lint": "tslint -c tslint.json -p tsconfig.json",
+
+    "build:migrations": "tsc -p tsconfig.migrations.json",
     "migration:generate": "./node_modules/.bin/typeorm migration:generate",
     "migration:run": "./node_modules/.bin/typeorm migration:run",
     "migration:revert": "./node_modules/.bin/typeorm migration:revert"

--- a/packages/cli/src/generate/templates/app/src/e2e.ts
+++ b/packages/cli/src/generate/templates/app/src/e2e.ts
@@ -1,0 +1,1 @@
+process.env.NODE_ENV = 'e2e';

--- a/packages/cli/src/generate/templates/app/src/e2e/index.ts
+++ b/packages/cli/src/generate/templates/app/src/e2e/index.ts
@@ -1,0 +1,26 @@
+// 3p
+import { createApp } from '@foal/core';
+import * as request from 'supertest';
+import { createConnection, getConnection } from 'typeorm';
+
+// App
+import { AppModule } from '../app/app.module';
+
+describe('The server', () => {
+
+  let app;
+
+  before(async () => {
+    await createConnection();
+    app = createApp(AppModule);
+  });
+
+  after(() => getConnection().close());
+
+  it('should return a 200 status on GET / requests.', () => {
+    return request(app)
+      .get('/')
+      .expect(200);
+  });
+
+});

--- a/packages/cli/src/generate/templates/app/tsconfig.app.json
+++ b/packages/cli/src/generate/templates/app/tsconfig.app.json
@@ -1,6 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "include": [
+    "src/app/**/*.ts",
+    "src/index.ts"
+  ],
   "exclude": [
-    "src/**/*.spec.ts"
+    "src/app/**/*.spec.ts"
   ]
 }

--- a/packages/cli/src/generate/templates/app/tsconfig.e2e.json
+++ b/packages/cli/src/generate/templates/app/tsconfig.e2e.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "include": [
     "src/app/**/*.ts",
-    "src/index.ts"
+    "src/e2e/**/*.ts",
+    "src/e2e.ts"
   ],
   "exclude": [
     "src/app/**/*.spec.ts"

--- a/packages/cli/src/generate/templates/app/tsconfig.json
+++ b/packages/cli/src/generate/templates/app/tsconfig.json
@@ -8,6 +8,7 @@
     "noImplicitAny": false,
     "module": "commonjs",
     "target": "es2017",
+    "rootDir": "src",
     "lib": [
       "es2017",
       "dom"

--- a/packages/cli/src/generate/templates/app/tsconfig.migrations.json
+++ b/packages/cli/src/generate/templates/app/tsconfig.migrations.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": false
+  },
+  "include": [
+    "src/migrations/*.ts"
+  ]
+}

--- a/packages/cli/src/generate/templates/app/tsconfig.scripts.json
+++ b/packages/cli/src/generate/templates/app/tsconfig.scripts.json
@@ -2,9 +2,10 @@
   "extends": "./tsconfig.json",
   "include": [
     "src/app/**/*.ts",
-    "src/index.ts"
+    "src/scripts/*.ts"
   ],
   "exclude": [
-    "src/app/**/*.spec.ts"
+    "src/app/**/*.spec.ts",
+    "src/scripts/*.spec.ts"
   ]
 }

--- a/packages/cli/src/generate/templates/app/tsconfig.test.json
+++ b/packages/cli/src/generate/templates/app/tsconfig.test.json
@@ -2,9 +2,6 @@
   "extends": "./tsconfig.json",
   "include": [
     "src/app/**/*.ts",
-    "src/index.ts"
-  ],
-  "exclude": [
-    "src/app/**/*.spec.ts"
+    "src/scripts/*.ts"
   ]
 }

--- a/packages/cli/src/generate/templates/app/tsconfig.test.json
+++ b/packages/cli/src/generate/templates/app/tsconfig.test.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "include": [
     "src/app/**/*.ts",
-    "src/scripts/*.ts"
+    "src/scripts/*.ts",
+    "src/test.ts"
   ]
 }

--- a/packages/cli/src/run-script.spec.ts
+++ b/packages/cli/src/run-script.spec.ts
@@ -39,7 +39,7 @@ describe('runScript', () => {
     strictEqual(
       msg,
       'The script "my-script" does not exist in lib/scripts/. But it exists in src/scripts/.'
-        + ' Please build your script by running the command "npm run build".'
+        + ' Please build your script by running the command "npm run build:scripts".'
     );
   });
 

--- a/packages/cli/src/run-script.ts
+++ b/packages/cli/src/run-script.ts
@@ -7,7 +7,7 @@ export function runScript({ name }: { name: string }, log = console.log) {
     if (existsSync(`src/scripts/${name}.ts`)) {
       log(
         `The script "${name}" does not exist in lib/scripts/. But it exists in src/scripts/.`
-          + ' Please build your script by running the command "npm run build".'
+          + ' Please build your script by running the command "npm run build:scripts".'
       );
     } else {
       log(`The script "${name}" does not exist. You can create it by running the command "foal g script ${name}".`);


### PR DESCRIPTION
# Issue

Writing e2e tests should be easy and straightforward in FoalTS. See https://github.com/FoalTS/foal/issues/138.

# Solution and steps

Generate the basic structure to create e2e tests when running `foal createapp`.

- [x] Add `supertest` to `package.json`.
- [x] Create several `tsconfig`.
- [x] Add/update the commands in `package.json`.
- [x] Create a default e2e test in `src/e2e/index.ts`.
- [x] Add `src/e2e.ts` to set the `NODE_ENV` var env to `e2e` on both Unix and Windows systems (see https://github.com/FoalTS/foal/pull/219).
- [x] Add `app.e2e.json`

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.