### PR TITLE
Set `strictPropertyInitialization` to `false` in `tsconfig.json` and remove the `ts-ignore`.

### DIFF
--- a/docs/guide/3-flight-model.md
+++ b/docs/guide/3-flight-model.md
@@ -21,11 +21,9 @@ import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 export class Flight {
 
   @PrimaryGeneratedColumn()
-  // @ts-ignore : Property 'id' has no initializer and is not definitely assigned in theconstructor.
   id: number;
 
   @Column()
-  // @ts-ignore : Property 'destination' has no initializer and is not definitely assigned in theconstructor.
   destination: string;
 
 }

--- a/docs/the-authentication-system/authentication.md
+++ b/docs/the-authentication-system/authentication.md
@@ -15,15 +15,12 @@ import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 export class User extends AbstractUser {
 ​
   @PrimaryGeneratedColumn()
-  // @ts-ignore : Property 'id' has no initializer and is not definitely assigned in theconstructor.
   id: number;
 ​
   @Column({ unique: true })
-  // @ts-ignore : Property 'email' has no initializer and is not definitely assigned in theconstructor.
   email: string;
 ​
   @Column()
-  // @ts-ignore : Property 'email' has no initializer and is not definitely assigned in theconstructor.
   password: string;
 ​
   async setPassword(password: string) {

--- a/packages/cli/src/generate/specs/app/src/app/entities/user.entity.ts
+++ b/packages/cli/src/generate/specs/app/src/app/entities/user.entity.ts
@@ -5,11 +5,9 @@ import { /*Column, */Entity } from 'typeorm';
 export class User extends AbstractUser {
 
   // @Column({ unique: true })
-  // // @ts-ignore : Property 'email' has no initializer and is not definitely assigned in theconstructor.
   // email: string;
 
   // @Column()
-  // // @ts-ignore : Property 'password' has no initializer and is not definitely assigned in theconstructor.
   // password: string;
 
   // async setPassword(password: string) {

--- a/packages/cli/src/generate/specs/app/tsconfig.json
+++ b/packages/cli/src/generate/specs/app/tsconfig.json
@@ -6,6 +6,7 @@
     "emitDecoratorMetadata": true,
     "strict": true,
     "noImplicitAny": false,
+    "strictPropertyInitialization": false,
     "module": "commonjs",
     "target": "es2017",
     "rootDir": "src",

--- a/packages/cli/src/generate/specs/entity/test-foo-bar.entity.ts
+++ b/packages/cli/src/generate/specs/entity/test-foo-bar.entity.ts
@@ -5,7 +5,6 @@ import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 export class TestFooBar {
 
   @PrimaryGeneratedColumn()
-  // @ts-ignore : Property 'id' has no initializer and is not definitely assigned in theconstructor.
   id: number;
 
 }

--- a/packages/cli/src/generate/templates/app/src/app/entities/user.entity.ts
+++ b/packages/cli/src/generate/templates/app/src/app/entities/user.entity.ts
@@ -5,11 +5,9 @@ import { /*Column, */Entity } from 'typeorm';
 export class User extends AbstractUser {
 
   // @Column({ unique: true })
-  // // @ts-ignore : Property 'email' has no initializer and is not definitely assigned in theconstructor.
   // email: string;
 
   // @Column()
-  // // @ts-ignore : Property 'password' has no initializer and is not definitely assigned in theconstructor.
   // password: string;
 
   // async setPassword(password: string) {

--- a/packages/cli/src/generate/templates/app/tsconfig.json
+++ b/packages/cli/src/generate/templates/app/tsconfig.json
@@ -6,6 +6,7 @@
     "emitDecoratorMetadata": true,
     "strict": true,
     "noImplicitAny": false,
+    "strictPropertyInitialization": false,
     "module": "commonjs",
     "target": "es2017",
     "rootDir": "src",

--- a/packages/cli/src/generate/templates/entity/entity.ts
+++ b/packages/cli/src/generate/templates/entity/entity.ts
@@ -5,7 +5,6 @@ import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 export class /* upperFirstCamelName */ {
 
   @PrimaryGeneratedColumn()
-  // @ts-ignore : Property 'id' has no initializer and is not definitely assigned in theconstructor.
   id: number;
 
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -7,6 +7,7 @@
     "experimentalDecorators": true,
     "strict": true,
     "noImplicitAny": false,
+    "strictPropertyInitialization": false,
     "sourceMap": true,
     "declaration": true,
     "lib": [

--- a/packages/core/e2e/auth.spec.ts
+++ b/packages/core/e2e/auth.spec.ts
@@ -46,11 +46,9 @@ it('Authentication and authorization', async () => {
   @Entity()
   class User extends AbstractUser {
     @Column({ unique: true })
-    // @ts-ignore
     email: string;
 
     @Column()
-    // @ts-ignore
     password: string;
   }
 

--- a/packages/core/e2e/rest.spec.ts
+++ b/packages/core/e2e/rest.spec.ts
@@ -77,30 +77,24 @@ xit('REST API with RestController and EntityResourceCollection', async () => {
   @Entity()
   class Org {
     @PrimaryGeneratedColumn()
-    // @ts-ignore
     id: number;
 
     @Column()
-    // @ts-ignore
     name: string;
   }
 
   @Entity()
   class User extends AbstractUser {
     @Column()
-    // @ts-ignore
     name: string;
 
     @Column({ nullable: true })
-    // @ts-ignore
     phone: string;
 
     @Column({ nullable: true })
-    // @ts-ignore
     origin: string;
 
     @ManyToOne(type => Org)
-    // @ts-ignore
     org: Org;
   }
 

--- a/packages/core/src/auth/authentication/authenticate.hook.spec.ts
+++ b/packages/core/src/auth/authentication/authenticate.hook.spec.ts
@@ -18,7 +18,6 @@ describe('Authenticate', () => {
   @Entity()
   class User extends AbstractUser {
     @Column()
-    // @ts-ignore : Property 'email' has no initializer and is not definitely assigned in theconstructor.
     email: string;
   }
 

--- a/packages/core/src/auth/authentication/strategies/email/email-authenticator.service.spec.ts
+++ b/packages/core/src/auth/authentication/strategies/email/email-authenticator.service.spec.ts
@@ -13,15 +13,12 @@ describe('EmailAuthenticator', () => {
   @Entity()
   class User extends AbstractUser {
     @Column({ unique: true })
-    // @ts-ignore : Property 'email' has no initializer and is not definitely assigned in theconstructor.
     email: string;
 
     @Column()
-    // @ts-ignore : Property 'password' has no initializer and is not definitely assigned in theconstructor.
     password: string;
 
     @Column()
-    // @ts-ignore : Property 'username' has no initializer and is not definitely assigned in theconstructor.
     username: string;
   }
 

--- a/packages/core/src/auth/entities/abstract-user.entity.ts
+++ b/packages/core/src/auth/entities/abstract-user.entity.ts
@@ -8,17 +8,14 @@ import { Permission } from './permission.entity';
 export abstract class AbstractUser {
 
   @PrimaryGeneratedColumn()
-  // @ts-ignore : Property 'id' has no initializer and is not definitely assigned in theconstructor.
   id: number;
 
   @ManyToMany(type => Group)
   @JoinTable()
-  // @ts-ignore : Property 'groups' has no initializer and is not definitely assigned in theconstructor.
   groups: Group[];
 
   @ManyToMany(type => Permission)
   @JoinTable()
-  // @ts-ignore : Property 'userPermissions' has no initializer and is not definitely assigned in theconstructor.
   userPermissions: Permission[];
 
   hasPerm(codeName: string): boolean {

--- a/packages/core/src/auth/entities/group.entity.ts
+++ b/packages/core/src/auth/entities/group.entity.ts
@@ -8,20 +8,16 @@ import { Permission } from './permission.entity';
 export class Group {
 
   @PrimaryGeneratedColumn()
-  // @ts-ignore : Property 'id' has no initializer and is not definitely assigned in theconstructor.
   id: number;
 
   @Column({ length: 80 })
-  // @ts-ignore : Property 'name' has no initializer and is not definitely assigned in theconstructor.
   name: string;
 
   @Column({ length: 100, unique: true })
-  // @ts-ignore : Property 'codeName' has no initializer and is not definitely assigned in theconstructor.
   codeName: string;
 
   @ManyToMany(type => Permission)
   @JoinTable()
-  // @ts-ignore : Property 'permissions' has no initializer and is not definitely assigned in theconstructor.
   permissions: Permission[];
 
 }

--- a/packages/core/src/auth/entities/permission.entity.ts
+++ b/packages/core/src/auth/entities/permission.entity.ts
@@ -4,15 +4,12 @@ import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 export class Permission {
 
   @PrimaryGeneratedColumn()
-  // @ts-ignore : Property 'id' has no initializer and is not definitely assigned in theconstructor.
   id: number;
 
   @Column()
-  // @ts-ignore : Property 'name' has no initializer and is not definitely assigned in theconstructor.
   name: string;
 
   @Column({ length: 100, unique: true })
-  // @ts-ignore : Property 'codeName' has no initializer and is not definitely assigned in theconstructor.
   codeName: string;
 
 }

--- a/packages/core/src/common/services/entity-resource-collection.service.spec.ts
+++ b/packages/core/src/common/services/entity-resource-collection.service.spec.ts
@@ -21,44 +21,35 @@ import { EntityResourceCollection, middleware, Middleware } from './entity-resou
 @Entity()
 export class Profile {
   @PrimaryGeneratedColumn()
-  // @ts-ignore : Property 'id' has no initializer and is not definitely assigned in theconstructor.
   id: number;
 
   @Column()
-  // @ts-ignore : Property 'pseudo' has no initializer and is not definitely assigned in theconstructor.
   pseudo: string;
 }
 
 @Entity()
 export class User {
   @PrimaryGeneratedColumn()
-  // @ts-ignore : Property 'id' has no initializer and is not definitely assigned in theconstructor.
   id: number;
 
   @Column()
-  // @ts-ignore : Property 'firstName' has no initializer and is not definitely assigned in theconstructor.
   firstName: string;
 
   @Column()
-  // @ts-ignore : Property 'lastName' has no initializer and is not definitely assigned in theconstructor.
   lastName: string;
 
   @Column({ nullable: true })
-  // @ts-ignore : Property 'password' has no initializer and is not definitely assigned in theconstructor.
   password: string;
 
   @Column({ default: false })
-  // @ts-ignore : Property 'isAdmin' has no initializer and is not definitely assigned in theconstructor.
   isAdmin: boolean;
 
   @OneToOne(type => Profile)
   @JoinColumn()
-  // @ts-ignore : Property 'profile' has no initializer and is not definitely assigned in theconstructor.
   profile1: Profile;
 
   @OneToOne(type => Profile)
   @JoinColumn()
-  // @ts-ignore : Property 'profile' has no initializer and is not definitely assigned in theconstructor.
   profile2: Profile;
 
   async setPassword(password: string) {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -7,6 +7,7 @@
     "experimentalDecorators": true,
     "strict": true,
     "noImplicitAny": false,
+    "strictPropertyInitialization": false,
     "sourceMap": true,
     "declaration": true,
     "types": [ "node", "mocha" ],

--- a/packages/ejs/tsconfig.json
+++ b/packages/ejs/tsconfig.json
@@ -7,6 +7,7 @@
     "experimentalDecorators": true,
     "strict": true,
     "noImplicitAny": false,
+    "strictPropertyInitialization": false,
     "sourceMap": true,
     "declaration": true,
     "lib": [

--- a/packages/password/tsconfig.json
+++ b/packages/password/tsconfig.json
@@ -7,6 +7,7 @@
     "experimentalDecorators": true,
     "strict": true,
     "noImplicitAny": false,
+    "strictPropertyInitialization": false,
     "sourceMap": true,
     "declaration": true,
     "lib": [


### PR DESCRIPTION
# Issue

Having some `@ts-ignore` everywhere in the doc is confusing to people getting started with `TypeScript` (and the strict mode)

# Solution and steps

Set `strictPropertyInitialization` by default to `false` in `tsconfig.json`.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.