### PR TITLE
Make ajv global instance coerce types, remove additional properties if required and use default values and add ValidateHeaders/ValidateParams

### DIFF
--- a/docs/cookbook/validation.md
+++ b/docs/cookbook/validation.md
@@ -6,6 +6,14 @@ Data sent from client side cannot be trusted. This document shows you different 
 
 FoalTS validation is based on [Ajv](https://github.com/epoberezkin/ajv), a fast JSON Schema Validator. You'll find more details on how to define a shema on its [website](http://epoberezkin.github.io/ajv/). 
 
+FoalTS's [baseline ajv configuration](https://github.com/epoberezkin/ajv#options-to-modify-validated-data) is:
+```typescript
+{
+  coerceTypes: true,  // change data type of data to match type keyword
+  removeAdditional: true, // remove additional properties
+  useDefaults: true, // replace missing properties and items with the values from corresponding default keyword
+}
+```
 
 ## The `validate` util
 

--- a/docs/cookbook/validation.md
+++ b/docs/cookbook/validation.md
@@ -38,9 +38,9 @@ validate(schema, data);
 // => error.content contains the details of the validation error.
 ```
 
-## The `ValidateBody` and `ValidateQuery` hooks
+## The `ValidateBody`, `ValidateHeaders`, `ValidateParams` and `ValidateQuery` hooks
 
-`ValidateBody` and `ValidateQuery` are hooks to control the body and the query of the requests received by the server. They validate the `context.request.body` with the given schema. If the validation fails then an `HttpResponseBadRequest` is returned with the validation errors as `content`.
+`ValidateBody`, `ValidateHeaders`, `ValidateParams` and `ValidateQuery` are hooks to control the body, headers, route params and the query of the requests received by the server. They validate the `context.request.{body|headers|params|query}` with the given schema. If the validation fails then an `HttpResponseBadRequest` is returned with the validation errors as `content`.
 
 *Example*:
 ```typescript

--- a/docs/cookbook/validation.md
+++ b/docs/cookbook/validation.md
@@ -42,8 +42,6 @@ validate(schema, data);
 
 `ValidateBody` and `ValidateQuery` are hooks to control the body and the query of the requests received by the server. They validate the `context.request.body` with the given schema. If the validation fails then an `HttpResponseBadRequest` is returned with the validation errors as `content`.
 
-Note: You can provide your own instance of Ajv.
-
 *Example*:
 ```typescript
 @Controller()

--- a/packages/core/src/common/hooks/index.ts
+++ b/packages/core/src/common/hooks/index.ts
@@ -1,3 +1,5 @@
 export { Log } from './log.hook';
 export { ValidateBody } from './validate-body.hook';
+export { ValidateHeaders } from './validate-headers.hook';
+export { ValidateParams } from './validate-params.hook';
 export { ValidateQuery } from './validate-query.hook';

--- a/packages/core/src/common/hooks/validate-body.hook.spec.ts
+++ b/packages/core/src/common/hooks/validate-body.hook.spec.ts
@@ -68,26 +68,4 @@ describe('ValidateBody', () => {
     notStrictEqual((actual as HttpResponseBadRequest).content, undefined);
   });
 
-  it('should use the given ajv instance if it exists.', () => {
-    const schema = {
-      properties: {
-        bar: { type: 'integer', default: 4 },
-        foo: { type: 'integer' },
-      },
-      type: 'object',
-    };
-    const ctx = new Context({});
-    ctx.request.body = {
-      foo: 3,
-    };
-
-    let hook = getHookFunction(ValidateBody(schema));
-    hook(ctx, new ServiceManager());
-    strictEqual(ctx.request.body.bar, undefined);
-
-    hook = getHookFunction(ValidateBody(schema, new Ajv({ useDefaults: true })));
-    hook(ctx, new ServiceManager());
-    strictEqual(ctx.request.body.bar, 4);
-  });
-
 });

--- a/packages/core/src/common/hooks/validate-body.hook.spec.ts
+++ b/packages/core/src/common/hooks/validate-body.hook.spec.ts
@@ -1,9 +1,6 @@
 // std
 import { notStrictEqual, ok, strictEqual } from 'assert';
 
-// 3p
-import * as Ajv from 'ajv';
-
 // FoalTS
 import { Context, getHookFunction, HttpResponseBadRequest, ServiceManager } from '../../core';
 import { ValidateBody } from './validate-body.hook';

--- a/packages/core/src/common/hooks/validate-body.hook.spec.ts
+++ b/packages/core/src/common/hooks/validate-body.hook.spec.ts
@@ -49,7 +49,7 @@ describe('ValidateBody', () => {
     ok(hook(context('foo'), new ServiceManager()) instanceof HttpResponseBadRequest);
     ok(hook(context(3), new ServiceManager()) instanceof HttpResponseBadRequest);
     ok(hook(context(true), new ServiceManager()) instanceof HttpResponseBadRequest);
-    ok(hook(context({ foo: '3' }), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context({ foo: 'a' }), new ServiceManager()) instanceof HttpResponseBadRequest);
   });
 
   it('should return an HttpResponseBadRequest with a defined `content` property if '

--- a/packages/core/src/common/hooks/validate-body.hook.ts
+++ b/packages/core/src/common/hooks/validate-body.hook.ts
@@ -3,7 +3,8 @@ import * as Ajv from 'ajv';
 import { Hook, HookDecorator, HttpResponseBadRequest } from '../../core';
 import { getAjvInstance } from '../utils/get-ajv-instance';
 
-export function ValidateBody(schema: object, ajv = getAjvInstance()): HookDecorator {
+export function ValidateBody(schema: object): HookDecorator {
+  const ajv = getAjvInstance();
   const isValid = ajv.compile(schema);
   return Hook(ctx => {
     if (!isValid(ctx.request.body)) {

--- a/packages/core/src/common/hooks/validate-body.hook.ts
+++ b/packages/core/src/common/hooks/validate-body.hook.ts
@@ -1,10 +1,9 @@
 import * as Ajv from 'ajv';
 
 import { Hook, HookDecorator, HttpResponseBadRequest } from '../../core';
+import { getAjvInstance } from '../utils/get-ajv-instance';
 
-const defaultInstance = new Ajv();
-
-export function ValidateBody(schema: object, ajv = defaultInstance): HookDecorator {
+export function ValidateBody(schema: object, ajv = getAjvInstance()): HookDecorator {
   const isValid = ajv.compile(schema);
   return Hook(ctx => {
     if (!isValid(ctx.request.body)) {

--- a/packages/core/src/common/hooks/validate-body.hook.ts
+++ b/packages/core/src/common/hooks/validate-body.hook.ts
@@ -3,6 +3,11 @@ import * as Ajv from 'ajv';
 import { Hook, HookDecorator, HttpResponseBadRequest } from '../../core';
 import { getAjvInstance } from '../utils/get-ajv-instance';
 
+/**
+ * Hook to validate the body of the request.
+ *
+ * @param schema Schema used to validate the body request.
+ */
 export function ValidateBody(schema: object): HookDecorator {
   const ajv = getAjvInstance();
   const isValid = ajv.compile(schema);

--- a/packages/core/src/common/hooks/validate-headers.hook.spec.ts
+++ b/packages/core/src/common/hooks/validate-headers.hook.spec.ts
@@ -1,0 +1,68 @@
+// std
+import { notStrictEqual, ok, strictEqual } from 'assert';
+
+// FoalTS
+import { Context, getHookFunction, HttpResponseBadRequest, ServiceManager } from '../../core';
+import { ValidateHeaders } from './validate-headers.hook';
+
+describe('ValidateHeaders', () => {
+
+  it('should not return an HttpResponseBadRequest if ctx.request.headers is validated '
+      + ' by ajv for the given schema.', () => {
+    const schema = {
+      properties: {
+        foo: { type: 'integer' }
+      },
+      type: 'object',
+    };
+    const hook = getHookFunction(ValidateHeaders(schema));
+    const ctx = new Context({});
+    ctx.request.headers = {
+      foo: 3
+    };
+
+    const actual = hook(ctx, new ServiceManager());
+    strictEqual(actual instanceof HttpResponseBadRequest, false);
+  });
+
+  it('should return an HttpResponseBadRequest if ctx.request.headers is not validated by '
+      + ' ajv for the given schema.', () => {
+    const schema = {
+      properties: {
+        foo: { type: 'integer' }
+      },
+      type: 'object',
+    };
+    const hook = getHookFunction(ValidateHeaders(schema));
+
+    function context(headers) {
+      const ctx = new Context({});
+      ctx.request.headers = headers;
+      return ctx;
+    }
+
+    ok(hook(context(null), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context(undefined), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context('foo'), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context(3), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context(true), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context({ foo: 'a' }), new ServiceManager()) instanceof HttpResponseBadRequest);
+  });
+
+  it('should return an HttpResponseBadRequest with a defined `content` property if '
+      + 'ctx.request.headers is not validated by ajv.', () => {
+    const schema = {
+      properties: {
+        foo: { type: 'integer' }
+      },
+      type: 'object',
+    };
+    const hook = getHookFunction(ValidateHeaders(schema));
+    const ctx = new Context({});
+
+    const actual = hook(ctx, new ServiceManager());
+    ok(actual instanceof HttpResponseBadRequest);
+    notStrictEqual((actual as HttpResponseBadRequest).content, undefined);
+  });
+
+});

--- a/packages/core/src/common/hooks/validate-headers.hook.ts
+++ b/packages/core/src/common/hooks/validate-headers.hook.ts
@@ -1,0 +1,19 @@
+import * as Ajv from 'ajv';
+
+import { Hook, HookDecorator, HttpResponseBadRequest } from '../../core';
+import { getAjvInstance } from '../utils/get-ajv-instance';
+
+/**
+ * Hook to validate the headers of the request.
+ *
+ * @param schema Schema used to validate the headers request.
+ */
+export function ValidateHeaders(schema: object): HookDecorator {
+  const ajv = getAjvInstance();
+  const isValid = ajv.compile(schema);
+  return Hook(ctx => {
+    if (!isValid(ctx.request.headers)) {
+      return new HttpResponseBadRequest(isValid.errors as Ajv.ErrorObject[]);
+    }
+  });
+}

--- a/packages/core/src/common/hooks/validate-params.hook.spec.ts
+++ b/packages/core/src/common/hooks/validate-params.hook.spec.ts
@@ -1,0 +1,68 @@
+// std
+import { notStrictEqual, ok, strictEqual } from 'assert';
+
+// FoalTS
+import { Context, getHookFunction, HttpResponseBadRequest, ServiceManager } from '../../core';
+import { ValidateParams } from './validate-params.hook';
+
+describe('ValidateParams', () => {
+
+  it('should not return an HttpResponseBadRequest if ctx.request.params is validated '
+      + ' by ajv for the given schema.', () => {
+    const schema = {
+      properties: {
+        foo: { type: 'integer' }
+      },
+      type: 'object',
+    };
+    const hook = getHookFunction(ValidateParams(schema));
+    const ctx = new Context({});
+    ctx.request.params = {
+      foo: 3
+    };
+
+    const actual = hook(ctx, new ServiceManager());
+    strictEqual(actual instanceof HttpResponseBadRequest, false);
+  });
+
+  it('should return an HttpResponseBadRequest if ctx.request.params is not validated by '
+      + ' ajv for the given schema.', () => {
+    const schema = {
+      properties: {
+        foo: { type: 'integer' }
+      },
+      type: 'object',
+    };
+    const hook = getHookFunction(ValidateParams(schema));
+
+    function context(params) {
+      const ctx = new Context({});
+      ctx.request.params = params;
+      return ctx;
+    }
+
+    ok(hook(context(null), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context(undefined), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context('foo'), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context(3), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context(true), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context({ foo: 'a' }), new ServiceManager()) instanceof HttpResponseBadRequest);
+  });
+
+  it('should return an HttpResponseBadRequest with a defined `content` property if '
+      + 'ctx.request.params is not validated by ajv.', () => {
+    const schema = {
+      properties: {
+        foo: { type: 'integer' }
+      },
+      type: 'object',
+    };
+    const hook = getHookFunction(ValidateParams(schema));
+    const ctx = new Context({});
+
+    const actual = hook(ctx, new ServiceManager());
+    ok(actual instanceof HttpResponseBadRequest);
+    notStrictEqual((actual as HttpResponseBadRequest).content, undefined);
+  });
+
+});

--- a/packages/core/src/common/hooks/validate-params.hook.ts
+++ b/packages/core/src/common/hooks/validate-params.hook.ts
@@ -1,0 +1,19 @@
+import * as Ajv from 'ajv';
+
+import { Hook, HookDecorator, HttpResponseBadRequest } from '../../core';
+import { getAjvInstance } from '../utils/get-ajv-instance';
+
+/**
+ * Hook to validate the params of the request.
+ *
+ * @param schema Schema used to validate the params request.
+ */
+export function ValidateParams(schema: object): HookDecorator {
+  const ajv = getAjvInstance();
+  const isValid = ajv.compile(schema);
+  return Hook(ctx => {
+    if (!isValid(ctx.request.params)) {
+      return new HttpResponseBadRequest(isValid.errors as Ajv.ErrorObject[]);
+    }
+  });
+}

--- a/packages/core/src/common/hooks/validate-query.hook.spec.ts
+++ b/packages/core/src/common/hooks/validate-query.hook.spec.ts
@@ -49,7 +49,7 @@ describe('ValidateQuery', () => {
     ok(hook(context('foo'), new ServiceManager()) instanceof HttpResponseBadRequest);
     ok(hook(context(3), new ServiceManager()) instanceof HttpResponseBadRequest);
     ok(hook(context(true), new ServiceManager()) instanceof HttpResponseBadRequest);
-    ok(hook(context({ foo: '3' }), new ServiceManager()) instanceof HttpResponseBadRequest);
+    ok(hook(context({ foo: 'a' }), new ServiceManager()) instanceof HttpResponseBadRequest);
   });
 
   it('should return an HttpResponseBadRequest with a defined `content` property if '

--- a/packages/core/src/common/hooks/validate-query.hook.spec.ts
+++ b/packages/core/src/common/hooks/validate-query.hook.spec.ts
@@ -68,26 +68,4 @@ describe('ValidateQuery', () => {
     notStrictEqual((actual as HttpResponseBadRequest).content, undefined);
   });
 
-  it('should use the given ajv instance if it exists.', () => {
-    const schema = {
-      properties: {
-        bar: { type: 'integer', default: 4 },
-        foo: { type: 'integer' },
-      },
-      type: 'object',
-    };
-    const ctx = new Context({});
-    ctx.request.query = {
-      foo: 3,
-    };
-
-    let hook = getHookFunction(ValidateQuery(schema));
-    hook(ctx, new ServiceManager());
-    strictEqual(ctx.request.query.bar, undefined);
-
-    hook = getHookFunction(ValidateQuery(schema, new Ajv({ useDefaults: true })));
-    hook(ctx, new ServiceManager());
-    strictEqual(ctx.request.query.bar, 4);
-  });
-
 });

--- a/packages/core/src/common/hooks/validate-query.hook.spec.ts
+++ b/packages/core/src/common/hooks/validate-query.hook.spec.ts
@@ -1,9 +1,6 @@
 // std
 import { notStrictEqual, ok, strictEqual } from 'assert';
 
-// 3p
-import * as Ajv from 'ajv';
-
 // FoalTS
 import { Context, getHookFunction, HttpResponseBadRequest, ServiceManager } from '../../core';
 import { ValidateQuery } from './validate-query.hook';

--- a/packages/core/src/common/hooks/validate-query.hook.ts
+++ b/packages/core/src/common/hooks/validate-query.hook.ts
@@ -1,10 +1,9 @@
 import * as Ajv from 'ajv';
 
 import { Hook, HookDecorator, HttpResponseBadRequest } from '../../core';
+import { getAjvInstance } from '../utils/get-ajv-instance';
 
-const defaultInstance = new Ajv();
-
-export function ValidateQuery(schema: object, ajv = defaultInstance): HookDecorator {
+export function ValidateQuery(schema: object, ajv = getAjvInstance()): HookDecorator {
   const isValid = ajv.compile(schema);
   return Hook(ctx => {
     if (!isValid(ctx.request.query)) {

--- a/packages/core/src/common/hooks/validate-query.hook.ts
+++ b/packages/core/src/common/hooks/validate-query.hook.ts
@@ -3,6 +3,11 @@ import * as Ajv from 'ajv';
 import { Hook, HookDecorator, HttpResponseBadRequest } from '../../core';
 import { getAjvInstance } from '../utils/get-ajv-instance';
 
+/**
+ * Hook to validate the query of the request.
+ *
+ * @param schema Schema used to validate the query request.
+ */
 export function ValidateQuery(schema: object): HookDecorator {
   const ajv = getAjvInstance();
   const isValid = ajv.compile(schema);

--- a/packages/core/src/common/hooks/validate-query.hook.ts
+++ b/packages/core/src/common/hooks/validate-query.hook.ts
@@ -3,7 +3,8 @@ import * as Ajv from 'ajv';
 import { Hook, HookDecorator, HttpResponseBadRequest } from '../../core';
 import { getAjvInstance } from '../utils/get-ajv-instance';
 
-export function ValidateQuery(schema: object, ajv = getAjvInstance()): HookDecorator {
+export function ValidateQuery(schema: object): HookDecorator {
+  const ajv = getAjvInstance();
   const isValid = ajv.compile(schema);
   return Hook(ctx => {
     if (!isValid(ctx.request.query)) {

--- a/packages/core/src/common/utils/get-ajv-instance.spec.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.spec.ts
@@ -1,0 +1,43 @@
+import { strictEqual } from 'assert';
+import { getAjvInstance } from './get-ajv-instance';
+
+describe('getAjvInstance', () => {
+
+  it('should use defaults.', () => {
+    const schema = {
+      properties: {
+        foo: { type: 'string', default: 'bar'}
+      },
+      type: 'object',
+    };
+    const data = {};
+    getAjvInstance().validate(schema, data);
+    strictEqual((data as any).foo, 'bar');
+  });
+
+  it('should remove additional properties.', () => {
+    const schema = {
+      additionalProperties: false,
+      properties: {},
+      type: 'object',
+    };
+    const data = { hello: 'world' };
+    getAjvInstance().validate(schema, data);
+    strictEqual(data.hasOwnProperty('hello'), false);
+  });
+
+  it('should coerce types.', () => {
+    const schema = {
+      properties: {
+        foo: { type: 'number' }
+      },
+      type: 'object',
+    };
+    const data = {
+      foo: '3'
+    };
+    getAjvInstance().validate(schema, data);
+    strictEqual(data.foo, 3);
+  });
+
+});

--- a/packages/core/src/common/utils/get-ajv-instance.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.ts
@@ -2,9 +2,9 @@
 import * as Ajv from 'ajv';
 
 const ajv = new Ajv({
-  // coerceTypes: true,  // change data type of data to match type keyword
-  // removeAdditional: true, // remove additional properties
-  // useDefaults: true, // replace missing properties and items with the values from corresponding default keyword
+  coerceTypes: true,  // change data type of data to match type keyword
+  removeAdditional: true, // remove additional properties
+  useDefaults: true, // replace missing properties and items with the values from corresponding default keyword
 });
 
 export function getAjvInstance() {

--- a/packages/core/src/common/utils/get-ajv-instance.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.ts
@@ -1,7 +1,11 @@
 // 3p
 import * as Ajv from 'ajv';
 
-const ajv = new Ajv();
+const ajv = new Ajv({
+  // coerceTypes: true,  // change data type of data to match type keyword
+  // removeAdditional: true, // remove additional properties
+  // useDefaults: true, // replace missing properties and items with the values from corresponding default keyword
+});
 
 export function getAjvInstance() {
   return ajv;

--- a/packages/core/src/common/utils/get-ajv-instance.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.ts
@@ -1,0 +1,8 @@
+// 3p
+import * as Ajv from 'ajv';
+
+const ajv = new Ajv();
+
+export function getAjvInstance() {
+  return ajv;
+}

--- a/packages/core/src/common/utils/validate.util.ts
+++ b/packages/core/src/common/utils/validate.util.ts
@@ -3,10 +3,10 @@ import * as Ajv from 'ajv';
 
 // FoalTS
 import { ValidationError } from '../errors';
-
-const ajv = new Ajv();
+import { getAjvInstance } from './get-ajv-instance';
 
 export function validate(schema: object, data: any) {
+  const ajv = getAjvInstance();
   if (!ajv.validate(schema, data)) {
     throw new ValidationError(ajv.errors);
   }

--- a/packages/core/src/common/utils/validate.util.ts
+++ b/packages/core/src/common/utils/validate.util.ts
@@ -1,6 +1,3 @@
-// 3p
-import * as Ajv from 'ajv';
-
 // FoalTS
 import { ValidationError } from '../errors';
 import { getAjvInstance } from './get-ajv-instance';


### PR DESCRIPTION
# Issue

# Solution and steps

Add an internal util `getAjvInstance` than returns a single instance of Ajv which has this configuration:
```typescript
{
  coerceTypes: true,  // change data type of data to match type keyword
  removeAdditional: true, // remove additional properties
  useDefaults: true, // replace missing properties and items with the values from corresponding default keyword
}
```

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.