### PR TITLE
Generate vscode config files for fast debugging

### DIFF
--- a/docs/development-environment/vscode.md
+++ b/docs/development-environment/vscode.md
@@ -24,7 +24,6 @@ Run the following command to create the suitable debug config files.
 foal generate vscode-config
 ```
 
-
 Now you can add a breakpoint in your code and start the app in debug mode.
 
 ![Debugging demo](./debugger.gif)

--- a/docs/development-environment/vscode.md
+++ b/docs/development-environment/vscode.md
@@ -18,46 +18,12 @@ In order to directly print the tslint errors in VS Code and auto-fix the problem
 
 ## Debugging with VS Code
 
-Create a new folder called `.vscode` in the root directory and add these two files:
+Run the following command to create the suitable debug config files.
 
-*launch.json*
-```json
-{
-  // Utilisez IntelliSense pour en savoir plus sur les attributs possibles.
-  // Pointez pour afficher la description des attributs existants.
-  // Pour plus d'informations, visitez : https://go.microsoft.com/fwlink/?linkid=830387
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Lancer le programme",
-      "program": "${workspaceFolder}/lib/index.js",
-      "preLaunchTask": "build",
-      "outFiles": [
-        "${workspaceFolder}/lib/**/*.js"
-      ]
-    }
-  ]
-}
+```
+foal generate vscode-config
 ```
 
-*tasks.json*
-```json
-{
-  // See https://go.microsoft.com/fwlink/?LinkId=733558
-  // for the documentation about the tasks.json format
-  "version": "2.0.0",
-  "tasks": [
-    {
-      "type": "npm",
-      "script": "build",
-      "label": "build",
-      "problemMatcher": []
-    }
-  ]
-}
-```
 
 Now you can add a breakpoint in your code and start the app in debug mode.
 

--- a/packages/cli/src/generate/generators/index.ts
+++ b/packages/cli/src/generate/generators/index.ts
@@ -5,3 +5,4 @@ export * from './hook';
 export * from './script';
 export * from './service';
 export * from './sub-app';
+export * from './vscode-config';

--- a/packages/cli/src/generate/generators/vscode-config/create-vscode-config.spec.ts
+++ b/packages/cli/src/generate/generators/vscode-config/create-vscode-config.spec.ts
@@ -1,0 +1,27 @@
+// FoalTS
+import {
+  rmdirIfExists,
+  rmfileIfExists,
+  TestEnvironment,
+} from '../../utils';
+import { createVSCodeConfig } from './create-vscode-config';
+
+describe('createVSCodeConfig', () => {
+
+  afterEach(() => {
+    rmfileIfExists('.vscode/launch.json');
+    rmfileIfExists('.vscode/tasks.json');
+    rmdirIfExists('.vscode');
+  });
+
+  const testEnv = new TestEnvironment('vscode-config', '.vscode');
+
+  it('should create the directory .vscode/ with default launch.json and tasks.json files.', () => {
+    createVSCodeConfig();
+
+    testEnv
+      .validateSpec('launch.json')
+      .validateSpec('tasks.json');
+  });
+
+});

--- a/packages/cli/src/generate/generators/vscode-config/create-vscode-config.ts
+++ b/packages/cli/src/generate/generators/vscode-config/create-vscode-config.ts
@@ -1,0 +1,13 @@
+// std
+import { existsSync } from 'fs';
+
+// FoalTS
+import { Generator, mkdirIfDoesNotExist } from '../../utils';
+
+export function createVSCodeConfig() {
+  mkdirIfDoesNotExist('.vscode');
+
+  new Generator('vscode-config', '.vscode')
+    .copyFileFromTemplates('launch.json')
+    .copyFileFromTemplates('tasks.json');
+}

--- a/packages/cli/src/generate/generators/vscode-config/create-vscode-config.ts
+++ b/packages/cli/src/generate/generators/vscode-config/create-vscode-config.ts
@@ -1,6 +1,3 @@
-// std
-import { existsSync } from 'fs';
-
 // FoalTS
 import { Generator, mkdirIfDoesNotExist } from '../../utils';
 

--- a/packages/cli/src/generate/generators/vscode-config/index.ts
+++ b/packages/cli/src/generate/generators/vscode-config/index.ts
@@ -1,0 +1,1 @@
+export { createVSCodeConfig } from './create-vscode-config';

--- a/packages/cli/src/generate/specs/vscode-config/launch.json
+++ b/packages/cli/src/generate/specs/vscode-config/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Start the server",
+      "program": "${workspaceFolder}/lib/index.js",
+      "preLaunchTask": "build",
+      "outFiles": [
+        "${workspaceFolder}/lib/**/*.js"
+      ]
+    }
+  ]
+}

--- a/packages/cli/src/generate/specs/vscode-config/tasks.json
+++ b/packages/cli/src/generate/specs/vscode-config/tasks.json
@@ -1,0 +1,13 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "build:app",
+      "label": "build",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/packages/cli/src/generate/templates/vscode-config/launch.json
+++ b/packages/cli/src/generate/templates/vscode-config/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Start the server",
+      "program": "${workspaceFolder}/lib/index.js",
+      "preLaunchTask": "build",
+      "outFiles": [
+        "${workspaceFolder}/lib/**/*.js"
+      ]
+    }
+  ]
+}

--- a/packages/cli/src/generate/templates/vscode-config/tasks.json
+++ b/packages/cli/src/generate/templates/vscode-config/tasks.json
@@ -1,0 +1,13 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "build:app",
+      "label": "build",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import {
   createScript,
   createService,
   createSubApp,
+  createVSCodeConfig,
   ServiceType
 } from './generate';
 import { runScript } from './run-script';
@@ -44,11 +45,12 @@ program
   });
 
 program
-  .command('generate <type> <name>')
-  .description('Generates files (type: controller|entity|hook|sub-app|service).')
+  .command('generate <type> [name]')
+  .description('Generates files (type: controller|entity|hook|sub-app|service|vscode-config).')
   .option('-r, --register', 'Register the controller into app.controller.ts (only available if type=controller)')
   .alias('g')
   .action(async (type: string, name: string, options) => {
+    name = name || 'no-name';
     switch (type) {
       case 'controller':
         const controllerChoices: ControllerType[] = [ 'Empty', 'REST'/*, 'GraphQL'*/, 'Login' ];
@@ -87,8 +89,11 @@ program
         ]);
         createService({ name, type: serviceAnswers.type});
         break;
+      case 'vscode-config':
+        createVSCodeConfig();
+        break;
       default:
-        console.error('Please provide a valid type: controller|entity|hook|sub-app|service.');
+        console.error('Please provide a valid type: controller|entity|hook|sub-app|service|vscode-config.');
     }
   });
 


### PR DESCRIPTION
# Issue

Starting to debug a FoalTS application with VSCode is not straightforward.

# Solution and steps

Having a command which generates the suitable vscode config files to start the app with the IDE debugger.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.