### PR TITLE
Let the Log hook print information about the HTTP request.

### DIFF
--- a/docs/cookbook/basic-logging.md
+++ b/docs/cookbook/basic-logging.md
@@ -1,12 +1,17 @@
 # Basic logging
 
-FoalTS provides a convenient hook to log basic messages: `Log(message: string, logFn = console.log)`
+FoalTS provides a convenient hook to log basic messages: `Log(message: string, options: LogOptions = {})`
 
 Example:
 ```typescript
 import { Get, HttpResponseOK, Log } from '@foal/core';
 
-@Log('Message')
+@Log('Message', {
+  body: true,
+  headers: [ 'X-CSRF-Token' ],
+  params: true,
+  query: true
+})
 export class AppController {
   @Get()
   index() {

--- a/packages/core/src/common/hooks/log.hook.spec.ts
+++ b/packages/core/src/common/hooks/log.hook.spec.ts
@@ -1,5 +1,5 @@
 // std
-import { strictEqual } from 'assert';
+import { ok, strictEqual } from 'assert';
 
 // FoalTS
 import { Context, getHookFunction, ServiceManager } from '../../core';
@@ -7,15 +7,93 @@ import { Log } from './log.hook';
 
 describe('Log', () => {
 
-  it('should log the message with the given log function.', () => {
-    let called = false;
-    const logFn = msg => called = true;
-    const hook = getHookFunction(Log('foo', logFn));
+  let logFn;
+
+  beforeEach(() => {
+    logFn = (...args) => {
+      logFn.msgs = logFn.msgs || [];
+      logFn.msgs.push(args);
+    };
+  });
+
+  it('should log the message.', () => {
+    const hook = getHookFunction(Log('foo', { logFn }));
 
     const ctx = new Context({});
     hook(ctx, new ServiceManager());
 
-    strictEqual(called, true);
+    strictEqual(logFn.msgs.length, 1);
+    strictEqual(logFn.msgs[0][0], 'foo');
+  });
+
+  it('should log the request body if options.body = true.', () => {
+    const hook = getHookFunction(Log('foo', { body: true, logFn }));
+
+    const body = { foo: 'bar' };
+    const ctx = new Context({ body });
+    hook(ctx, new ServiceManager());
+
+    strictEqual(logFn.msgs.length, 2);
+    strictEqual(logFn.msgs[1][0], 'Body: ');
+    strictEqual(logFn.msgs[1][1], body);
+  });
+
+  it('should log the request params if options.params = true.', () => {
+    const hook = getHookFunction(Log('foo', { params: true, logFn }));
+
+    const params = { foo: 'bar' };
+    const ctx = new Context({ params });
+    hook(ctx, new ServiceManager());
+
+    strictEqual(logFn.msgs.length, 2);
+    strictEqual(logFn.msgs[1][0], 'Params: ');
+    strictEqual(logFn.msgs[1][1], params);
+  });
+
+  it('should log the request query if options.query = true.', () => {
+    const hook = getHookFunction(Log('foo', { query: true, logFn }));
+
+    const query = { foo: 'bar' };
+    const ctx = new Context({ query });
+    hook(ctx, new ServiceManager());
+
+    strictEqual(logFn.msgs.length, 2);
+    strictEqual(logFn.msgs[1][0], 'Query: ');
+    strictEqual(logFn.msgs[1][1], query);
+  });
+
+  it('should log the request headers if options.headers is a string array.', () => {
+    const hook = getHookFunction(Log('foo', { headers: [ 'my-header1', 'my-header2' ], logFn }));
+
+    const headers = {
+      'my-header1': 'header 1',
+      'my-header2': 'header 2',
+      'my-header3': 'header 3'
+    };
+    const ctx = new Context({ headers });
+    hook(ctx, new ServiceManager());
+
+    strictEqual(logFn.msgs.length, 3);
+    strictEqual(logFn.msgs[1][0], 'my-header1: ');
+    strictEqual(logFn.msgs[1][1], 'header 1');
+    strictEqual(logFn.msgs[2][0], 'my-header2: ');
+    strictEqual(logFn.msgs[2][1], 'header 2');
+  });
+
+  it('should log all the request headers if options.headers = true.', () => {
+    const hook = getHookFunction(Log('foo', { headers: true, logFn }));
+
+    const headers = {
+      'my-header1': 'header 1',
+      'my-header2': 'header 2',
+      'my-header3': 'header 3'
+    };
+    const ctx = new Context({ headers });
+    hook(ctx, new ServiceManager());
+
+    strictEqual(logFn.msgs.length, 2);
+    strictEqual(logFn.msgs[1][0], 'Headers: ');
+    strictEqual(logFn.msgs[1][1], headers);
   });
 
 });

--- a/packages/core/src/common/hooks/log.hook.spec.ts
+++ b/packages/core/src/common/hooks/log.hook.spec.ts
@@ -1,5 +1,5 @@
 // std
-import { ok, strictEqual } from 'assert';
+import { strictEqual } from 'assert';
 
 // FoalTS
 import { Context, getHookFunction, ServiceManager } from '../../core';

--- a/packages/core/src/common/hooks/log.hook.ts
+++ b/packages/core/src/common/hooks/log.hook.ts
@@ -1,5 +1,36 @@
-import { Hook, HookDecorator } from '../../core';
+import { Context, Hook, HookDecorator } from '../../core';
 
-export function Log(message: string, logFn = console.log): HookDecorator {
-  return Hook(() => logFn(message));
+export interface LogOptions {
+  body?: boolean;
+  params?: boolean;
+  headers?: string[]|boolean;
+  query?: boolean;
+  logFn?: typeof console.log;
+}
+
+/**
+ * Logs a message with optional information on the HTTP request.
+ *
+ * @param message The message to print.
+ * @param options Options to specify which information on the HTTP request should be printed.
+ */
+export function Log(message: string, options: LogOptions = {}): HookDecorator {
+  const logFn = options.logFn || console.log;
+  return Hook((ctx: Context) => {
+    logFn(message);
+    if (options.body) {
+      logFn('Body: ', ctx.request.body);
+    }
+    if (options.params) {
+      logFn('Params: ', ctx.request.params);
+    }
+    if (options.query) {
+      logFn('Query: ', ctx.request.query);
+    }
+    if (options.headers === true) {
+      logFn('Headers: ', ctx.request.headers);
+    } else if (Array.isArray(options.headers)) {
+      options.headers.forEach(header => logFn(`${header}: `, ctx.request.headers[header]));
+    }
+  });
 }


### PR DESCRIPTION
# Issue

The `Log` function is not sufficient. Sometimes we need to print information about the HTTP request with the message. 

# Solution and steps

Add four options to the `Log` hook to print the body, query, params or headers of the HTTP request.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.