### PR TITLE
Add the logIn and logOut utilities.

### DIFF
--- a/docs/authentication-and-access-control/usage-in-web-requests.md
+++ b/docs/authentication-and-access-control/usage-in-web-requests.md
@@ -21,13 +21,12 @@ export class AppController {
 If you want to attach an authenticated user to the current session, proceed as follows:
 
 ```typescript
-ctx.request.session.authentication = ctx.request.session.authentication || {};
-ctx.request.session.authentication.id = user.id;
+logIn(ctx, user); // The logIn utility is in the @foal/core package.
 ```
 
-To log out a user, delete the `authentication` property of the session:
+To log out a user, use the `logOut` utility:
 ```typescript
-delete ctx.request.session.authentication;
+logOut(ctx);
 ```
 
 > Note: The `LoginController` presented below does these steps for you.

--- a/packages/core/src/auth/authentication/login.controller.ts
+++ b/packages/core/src/auth/authentication/login.controller.ts
@@ -13,6 +13,7 @@ import {
   Post,
   ServiceManager
 } from '../../core';
+import { logIn, logOut } from '../utils';
 import { IAuthenticator } from './authenticator.interface';
 
 export interface Strategy {
@@ -36,7 +37,7 @@ export abstract class LoginController {
 
   @Get('/logout')
   logout(ctx: Context) {
-    delete ctx.request.session.authentication;
+    logOut(ctx);
     if (this.redirect && this.redirect.logout) {
       return new HttpResponseRedirect(this.redirect.logout);
     }
@@ -66,10 +67,7 @@ export abstract class LoginController {
       return redirectPath ? new HttpResponseRedirect(redirectPath) : new HttpResponseUnauthorized();
     }
 
-    ctx.request.session.authentication = {
-      ...ctx.request.session.authentication,
-      userId: user.id
-    };
+    logIn(ctx, user);
 
     const redirectPath = this.redirect && this.redirect.success;
     return redirectPath ? new HttpResponseRedirect(redirectPath) : new HttpResponseNoContent();

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -1,3 +1,4 @@
 export * from './authentication';
 export * from './authorization';
 export * from './entities';
+export * from './utils';

--- a/packages/core/src/auth/utils/index.ts
+++ b/packages/core/src/auth/utils/index.ts
@@ -1,0 +1,2 @@
+export { logIn } from './log-in.util';
+export { logOut } from './log-out.util';

--- a/packages/core/src/auth/utils/log-in.util.spec.ts
+++ b/packages/core/src/auth/utils/log-in.util.spec.ts
@@ -1,0 +1,31 @@
+// std
+import { deepStrictEqual } from 'assert';
+
+// FoalTS
+import { Context } from '../../core';
+import { AbstractUser } from '../entities';
+import { logIn } from './log-in.util';
+
+describe('logIn', () => {
+
+  it('should create or update ctx.session.authentication to include the userId.', async () => {
+    const ctx = new Context({ session: {} });
+    const user = { id: 1 } as AbstractUser;
+
+    logIn(ctx, user);
+
+    deepStrictEqual(ctx.request.session.authentication, {
+      userId: 1
+    });
+
+    ctx.request.session.authentication.foo = 'bar';
+
+    logIn(ctx, user);
+
+    deepStrictEqual(ctx.request.session.authentication, {
+      foo: 'bar',
+      userId: 1
+    });
+  });
+
+});

--- a/packages/core/src/auth/utils/log-in.util.ts
+++ b/packages/core/src/auth/utils/log-in.util.ts
@@ -1,0 +1,9 @@
+import { Context } from '../../core';
+import { AbstractUser } from '../entities';
+
+export function logIn(ctx: Context, user: AbstractUser) {
+  ctx.request.session.authentication = {
+    ...ctx.request.session.authentication,
+    userId: user.id
+  };
+}

--- a/packages/core/src/auth/utils/log-out.util.spec.ts
+++ b/packages/core/src/auth/utils/log-out.util.spec.ts
@@ -1,0 +1,30 @@
+// std
+import { deepStrictEqual } from 'assert';
+
+// FoalTS
+import { Context } from '../../core';
+import { logOut } from './log-out.util';
+
+describe('logOut', () => {
+
+  it('should delete ctx.session.authentication if it exists.', async () => {
+    const ctx = new Context({});
+    ctx.request.session = {
+      authentication: {
+        userId: 1
+      }
+    };
+
+    logOut(ctx);
+
+    deepStrictEqual(ctx.request.session, {});
+  });
+
+  it('should not throw an error if ctx.session.authentication is undefined.', async () => {
+    const ctx = new Context({});
+    ctx.request.session = {};
+
+    logOut(ctx);
+  });
+
+});

--- a/packages/core/src/auth/utils/log-out.util.ts
+++ b/packages/core/src/auth/utils/log-out.util.ts
@@ -1,0 +1,5 @@
+import { Context } from '../../core';
+
+export function logOut(ctx: Context) {
+  delete ctx.request.session.authentication;
+}


### PR DESCRIPTION
# Issue

Log users in or out without the `LoginController` is hard.

# Solution and steps

Add two utilities `logIn` and `logIn` to attach/detach a user to/from a session.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.