### PR TITLE
[@foal/cli] Register the controllers with their kebab name.

### DIFF
--- a/docs/authentication-and-access-control/usage-in-web-requests.md
+++ b/docs/authentication-and-access-control/usage-in-web-requests.md
@@ -130,7 +130,7 @@ Create a file named `login.html` inside `controllers/templates` with the followi
 <html>
   <head></head>
   <body>
-    <form action="/login-with-email" method="POST">
+    <form action="/auth/login-with-email" method="POST">
       <input style="display: none" name="_csrf" value="<%= csrfToken %>">
       <input type="email" name="email">
       <input type="password" name="password">

--- a/docs/tutorials/multi-user-todo-list/5-auth-controllers-and-hooks.md
+++ b/docs/tutorials/multi-user-todo-list/5-auth-controllers-and-hooks.md
@@ -88,25 +88,6 @@ export class AuthController extends LoginController {
 
 ```
 
-You also need to update the `app.controller.ts` file to add the `/auth` path.
-
-```typescript
-import { Authenticate, controller } from '@foal/core';
-
-import { ApiController, AuthController, ViewController } from './controllers';
-import { User } from './entities';
-
-@Authenticate(User)
-export class AppController {
-  subControllers = [
-    controller('/', ViewController),
-    controller('/', ApiController),
-    controller('/auth', AuthController),
-  ];
-}
-
-```
-
 The `LoginController` is based on the [strategy pattern](https://en.wikipedia.org/wiki/Strategy_pattern).
 
 An application may have several ways to authenticate a user. It can be with an email and a password as it the case here. But it also could be by using a google or twitter account.

--- a/docs/tutorials/multi-user-todo-list/6-todos-and-ownership.md
+++ b/docs/tutorials/multi-user-todo-list/6-todos-and-ownership.md
@@ -5,7 +5,7 @@ Currently the API returns everyone's todos to each user. This is not the expecte
 Go back to the `ApiController` and update the `getTodos` route.
 
 ```typescript
-  @Get('/api/todos')
+  @Get('/todos')
   async getTodos(ctx: Context) {
     const todos = await getRepository(Todo).find({ owner: ctx.user });
     return new HttpResponseOK(todos);
@@ -28,7 +28,7 @@ As for the delete feature, you also need to restrict its access. Users should on
 Update the api controller.
 
 ```typescript
-  @Post('/api/todos')
+  @Post('/todos')
   @ValidateBody({
     ...
   })
@@ -43,7 +43,7 @@ Update the api controller.
     return new HttpResponseCreated(todo);
   }
 
-  @Delete('/api/todos/:id')
+  @Delete('/todos/:id')
   @ValidateParams({
     ...
   })

--- a/docs/tutorials/multi-user-todo-list/7-the-signup-page.md
+++ b/docs/tutorials/multi-user-todo-list/7-the-signup-page.md
@@ -5,7 +5,7 @@ The sign up page, that is served in the view controller, makes a request `POST /
 Create a new controller to handle this route.
 
 ```
-foal generate controller sign-up --register
+foal generate controller signup --register
 ```
 
 Open the new file and replace its content.
@@ -19,9 +19,9 @@ import { getRepository } from 'typeorm';
 // App
 import { User } from '../entities';
 
-export class SignUpController {
+export class SignupController {
 
-  @Post('/signup')
+  @Post()
   @ValidateBody(emailSchema)
   async signup(ctx: Context) {
     // Check that the password is not too common.

--- a/docs/tutorials/simple-todo-list/5-the-rest-api.md
+++ b/docs/tutorials/simple-todo-list/5-the-rest-api.md
@@ -18,7 +18,7 @@ import { Get, HttpResponseOK } from '@foal/core';
 
 export class ApiController {
 
-  @Get('/api/todos')
+  @Get('/todos')
   getTodos() {
     const todos = [
       { id: 1, text: 'My task 1' },
@@ -46,7 +46,7 @@ import { Todo } from '../entities';
 
 export class ApiController {
 
-  @Get('/api/todos')
+  @Get('/todos')
   async getTodos() {
     const todos = await getRepository(Todo).find();
     return new HttpResponseOK(todos);
@@ -60,7 +60,7 @@ If you refresh your browser, you should now see the tasks that we created throug
 Add the create and delete features.
 
 ```typescript
-  @Post('/api/todos')
+  @Post('/todos')
   async postTodo(ctx: Context) {
     // Create a new todo with the body of the HTTP request.
     const todo = new Todo();
@@ -73,7 +73,7 @@ Add the create and delete features.
     return new HttpResponseCreated(todo);
   }
 
-  @Delete('/api/todos/:id')
+  @Delete('/todos/:id')
   async deleteTodo(ctx: Context) {
     // Get the todo with the id given in the URL if it exists.
     const todo = await getRepository(Todo).findOne({ id: ctx.request.params.id });
@@ -109,7 +109,7 @@ import { User } from './entities';
 export class AppController {
   subControllers = [
     controller('/', ViewController),
-    controller('/', ApiController)
+    controller('/api', ApiController)
   ];
 }
 ```

--- a/docs/tutorials/simple-todo-list/6-validation-and-sanitization.md
+++ b/docs/tutorials/simple-todo-list/6-validation-and-sanitization.md
@@ -13,7 +13,7 @@ The `ValidateBody` and `ValidateParams` check respectively the `body` and `param
 Let's add validation and sanitization to your application. In fact, you have already defined the todo schema in the `create-todo` script earlier.
 
 ```typescript
-  @Post('/api/todos')
+  @Post('/todos')
   @ValidateBody({
     // The body request should be an object once parsed by the framework.
     type: 'object',
@@ -36,7 +36,7 @@ Let's add validation and sanitization to your application. In fact, you have alr
     return new HttpResponseCreated(todo);
   }
 
-  @Delete('/api/todos/:id')
+  @Delete('/todos/:id')
   @ValidateParams({
     properties: {
       // The id should be a number. If it is not (the request.params object

--- a/docs/tutorials/simple-todo-list/7-unit-testing.md
+++ b/docs/tutorials/simple-todo-list/7-unit-testing.md
@@ -54,8 +54,8 @@ describe('ApiController', () => {
     it('should handle requests at GET /.', () => {
       // Throw an error and make the test fail if the http method of `getTodos` is not GET.
       strictEqual(getHttpMethod(ApiController, 'getTodos'), 'GET');
-      // Throw an error and make the test fail if the path of `getTodos` is not /api/todos.
-      strictEqual(getPath(ApiController, 'getTodos'), '/api/todos');
+      // Throw an error and make the test fail if the path of `getTodos` is not /todos.
+      strictEqual(getPath(ApiController, 'getTodos'), '/todos');
     });
 
     // Define a unit test.

--- a/packages/cli/src/generate/generators/controller/create-controller.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.ts
@@ -29,7 +29,7 @@ export function createController({ name, type, register }: { name: string, type:
     });
 
   if (register) {
-    const path = type === 'REST' ? `/${names.kebabName}s` : '/';
+    const path = `/${names.kebabName}${type === 'REST' ? 's' : ''}`;
     generator
       .updateFile('../app.controller.ts', content => {
         return registerController(content, `${names.upperFirstCamelName}Controller`, path);

--- a/packages/cli/src/generate/specs/controller/app.controller.empty-property.ts
+++ b/packages/cli/src/generate/specs/controller/app.controller.empty-property.ts
@@ -4,6 +4,6 @@ import { TestFooBarController } from './controllers';
 
 export class MyController {
   subControllers = [
-    controller('/', TestFooBarController)
+    controller('/test-foo-bar', TestFooBarController)
   ];
 }

--- a/packages/cli/src/generate/specs/controller/app.controller.empty-spaced-property.ts
+++ b/packages/cli/src/generate/specs/controller/app.controller.empty-spaced-property.ts
@@ -4,6 +4,6 @@ import { TestFooBarController } from './controllers';
 
 export class MyController {
   subControllers = [
-    controller('/', TestFooBarController)
+    controller('/test-foo-bar', TestFooBarController)
   ];
 }

--- a/packages/cli/src/generate/specs/controller/app.controller.no-empty-property.ts
+++ b/packages/cli/src/generate/specs/controller/app.controller.no-empty-property.ts
@@ -6,6 +6,6 @@ export class MyController {
   subControllers = [
     controller('/', MyController),
     controller('/', MyController2),
-    controller('/', TestFooBarController)
+    controller('/test-foo-bar', TestFooBarController)
   ];
 }


### PR DESCRIPTION
# Issue

When using the option `--register` with the command `foal generate controller`, the controllers are registered with the default path `/`.

This is annoying for two reasons.
- Usually when creating an `ApiController`, we'd like to bind the controller to the route `/api`.
- Having the same path `/` for each controller may lead to tricky bugs when two controllers have a method with another same path (they handle the same route).

# Solution and steps

Register the controllers with their kebab name by default.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.