### PR TITLE
Support cookies and headers in the `HttpResponse` objects

### DIFF
--- a/docs/architecture/controllers.md
+++ b/docs/architecture/controllers.md
@@ -62,7 +62,7 @@ export class AppController {
 ## Accessing request data, session or current user
 
 Each decorated method of a controller takes a `Context` as parameter. This object has three properties:
-- the express `request` which has information on the request as well as the session object and the `csrfToken` method,
+- the express [request object](http://expressjs.com/en/4x/api.html#req) which has information on the request as well as the session object and the `csrfToken` method,
 - the `user` property which is undefined or not depedending on if a user was authenticated,
 - and a `state` object which is a mere object to forward information between [hooks](./hooks.md).
 
@@ -206,3 +206,22 @@ Controller methods should return an `HttpResponse`. Here are the available optio
 - `class HttpResponseNotImplemented` (501)
 
 The `HttpResponseSuccess`, `HttpResponseClientError` and `HttpResponseServerError` can take an optional argument `body` which is used as the body of the reponse. Ex: `new HttpResponseBadRequest({ message: 'The foo field is missing.' })`
+
+The `HttpResponse` has also 7 methods to set and get cookies and headers:
+```typescript
+({
+  setHeader(name: string, value: string);
+
+  getHeader(name: string): string|undefined;
+
+  getHeaders(): { [key: string]: string };
+
+  setCookie(name: string, value: string, options: CookieOptions = {}): void;
+
+  getCookie(name: string): { value: string|undefined, options: CookieOptions };
+
+  getCookies(): { [key: string]: { value: string|undefined, options: CookieOptions } };
+})
+```
+
+To check if an object is an instance of `HttpResponse` you can use the `isHttpResponse(obj): boolean`. An analog function exists for each sub-class of `HttpResponse` (`isHttpResponseNotFound`, etc).

--- a/docs/architecture/controllers.md
+++ b/docs/architecture/controllers.md
@@ -205,4 +205,4 @@ Controller methods should return an `HttpResponse`. Here are the available optio
 - `class HttpResponseInternalServerError` (500)
 - `class HttpResponseNotImplemented` (501)
 
-The `HttpResponseSuccess`, `HttpResponseClientError` and `HttpResponseServerError` can take an optional argument `content` which is used in the body of the reponse. Ex: `new HttpResponseBadRequest({ message: 'The foo field is missing.' })`
+The `HttpResponseSuccess`, `HttpResponseClientError` and `HttpResponseServerError` can take an optional argument `body` which is used as the body of the reponse. Ex: `new HttpResponseBadRequest({ message: 'The foo field is missing.' })`

--- a/docs/architecture/hooks.md
+++ b/docs/architecture/hooks.md
@@ -10,7 +10,7 @@ This function takes two parameters:
 - The `Context` object which provides some information on the http request as well as the session object and the authenticated user if they exist.
 - The service manager that lets access other services within the hook.
 
-If an `HttpResponse` is returned (or resolved) in a hook then the processing of the request is stopped for the hooks and controller method and the server responds with the `statusCode` and optional `content` of the returned object.
+If an `HttpResponse` is returned (or resolved) in a hook then the processing of the request is stopped for the hooks and controller method and the server responds with the `statusCode` and optional `body` of the returned object.
 
 <!--
 // TODO: Write this.

--- a/docs/cookbook/template-engine.md
+++ b/docs/cookbook/template-engine.md
@@ -4,7 +4,7 @@ FoalTS comes up with several tools to render templates.
 
 ## `render(templatePath: string, locals: object, dirname: string): HttpResponseOK`
 
-Renders the template with the given locals and then returns an `HttpResponeOK` whose content is the rendered template.
+Renders the template with the given locals and then returns an `HttpResponeOK` whose body is the rendered template.
 
 Example:
 ```typescript

--- a/docs/cookbook/validation.md
+++ b/docs/cookbook/validation.md
@@ -40,7 +40,7 @@ validate(schema, data);
 
 ## The `ValidateBody`, `ValidateHeaders`, `ValidateParams` and `ValidateQuery` hooks
 
-`ValidateBody`, `ValidateHeaders`, `ValidateParams` and `ValidateQuery` are hooks to control the body, headers, route params and the query of the requests received by the server. They validate the `context.request.{body|headers|params|query}` with the given schema. If the validation fails then an `HttpResponseBadRequest` is returned with the validation errors as `content`.
+`ValidateBody`, `ValidateHeaders`, `ValidateParams` and `ValidateQuery` are hooks to control the body, headers, route params and the query of the requests received by the server. They validate the `context.request.{body|headers|params|query}` with the given schema. If the validation fails then an `HttpResponseBadRequest` is returned with the validation errors as `body`.
 
 *Example*:
 ```typescript

--- a/docs/tutorials/simple-todo-list/7-unit-testing.md
+++ b/docs/tutorials/simple-todo-list/7-unit-testing.md
@@ -73,11 +73,11 @@ describe('ApiController', () => {
       const response = await controller.getTodos();
       ok(isHttpResponseOK(response), 'response should be an instance of HttpResponseOK.');
 
-      const content = (response as HttpResponseOK).content;
+      const body = (response as HttpResponseOK).body;
 
-      ok(Array.isArray(content), 'The content of the response should be an array.');
-      strictEqual(content[0].text, 'Todo 1');
-      strictEqual(content[1].text, 'Todo 2');
+      ok(Array.isArray(body), 'The body of the response should be an array.');
+      strictEqual(body[0].text, 'Todo 1');
+      strictEqual(body[1].text, 'Todo 2');
     });
 
   });

--- a/packages/core/src/auth/authentication/login.controller.spec.ts
+++ b/packages/core/src/auth/authentication/login.controller.spec.ts
@@ -157,7 +157,7 @@ describe('LoginController', () => {
       const response = await controller.login(ctx);
 
       ok(response instanceof HttpResponseBadRequest);
-      deepStrictEqual(response.content, [
+      deepStrictEqual(response.body, [
         {
           dataPath: '.email',
           keyword: 'type',

--- a/packages/core/src/common/controllers/rest.controller.spec.ts
+++ b/packages/core/src/common/controllers/rest.controller.spec.ts
@@ -103,7 +103,7 @@ describe('RestController', () => {
 
         const actual = await controller.deleteById(ctx);
         ok(actual instanceof HttpResponseOK);
-        strictEqual(actual.content, objects);
+        strictEqual(actual.body, objects);
         strictEqual(deleteByIdUser, ctx.user);
         strictEqual(deleteByIdId, ctx.request.params.id);
         deepStrictEqual(deleteByIdParams, {});
@@ -133,7 +133,7 @@ describe('RestController', () => {
 
           const actual = await controller.deleteById(ctx);
           ok(actual instanceof httpResponseClass);
-          strictEqual(actual.content, content);
+          strictEqual(actual.body, content);
         });
       }
 
@@ -228,7 +228,7 @@ describe('RestController', () => {
 
         const actual = await controller.get(ctx);
         ok(actual instanceof HttpResponseOK);
-        strictEqual(actual.content, objects);
+        strictEqual(actual.body, objects);
         strictEqual(getQueryCtx, ctx);
         strictEqual(findQuery, query);
         strictEqual(findUser, ctx.user);
@@ -258,7 +258,7 @@ describe('RestController', () => {
 
           const actual = await controller.get(ctx);
           ok(actual instanceof httpResponseClass);
-          strictEqual(actual.content, content);
+          strictEqual(actual.body, content);
         });
       }
 
@@ -351,7 +351,7 @@ describe('RestController', () => {
 
         const actual = await controller.getById(ctx);
         ok(actual instanceof HttpResponseOK);
-        strictEqual(actual.content, objects);
+        strictEqual(actual.body, objects);
         strictEqual(findByIdUser, ctx.user);
         strictEqual(findByIdId, ctx.request.params.id);
         deepStrictEqual(findByIdParams, {});
@@ -381,7 +381,7 @@ describe('RestController', () => {
 
           const actual = await controller.getById(ctx);
           ok(actual instanceof httpResponseClass);
-          strictEqual(actual.content, content);
+          strictEqual(actual.body, content);
         });
       }
 
@@ -494,7 +494,7 @@ describe('RestController', () => {
 
         const actual = await controller.patchById(ctx);
         ok(actual instanceof HttpResponseOK);
-        strictEqual(actual.content, objects);
+        strictEqual(actual.body, objects);
         strictEqual(modifyByIdUser, ctx.user);
         strictEqual(modifyByIdId, ctx.request.params.id);
         strictEqual(modifyByIdData, ctx.request.body);
@@ -525,7 +525,7 @@ describe('RestController', () => {
 
           const actual = await controller.patchById(ctx);
           ok(actual instanceof httpResponseClass);
-          strictEqual(actual.content, content);
+          strictEqual(actual.body, content);
         });
       }
 
@@ -619,7 +619,7 @@ describe('RestController', () => {
 
         const actual = await controller.post(ctx);
         ok(actual instanceof HttpResponseCreated);
-        strictEqual(actual.content, objects);
+        strictEqual(actual.body, objects);
         strictEqual(createUser, ctx.user);
         strictEqual(createData, ctx.request.body);
         deepStrictEqual(createParams, {});
@@ -649,7 +649,7 @@ describe('RestController', () => {
 
           const actual = await controller.post(ctx);
           ok(actual instanceof httpResponseClass);
-          strictEqual(actual.content, content);
+          strictEqual(actual.body, content);
         });
       }
 
@@ -775,7 +775,7 @@ describe('RestController', () => {
 
         const actual = await controller.putById(ctx);
         ok(actual instanceof HttpResponseOK);
-        strictEqual(actual.content, objects);
+        strictEqual(actual.body, objects);
         strictEqual(updateByIdUser, ctx.user);
         strictEqual(updateByIdId, ctx.request.params.id);
         strictEqual(updateByIdData, ctx.request.body);
@@ -806,7 +806,7 @@ describe('RestController', () => {
 
           const actual = await controller.putById(ctx);
           ok(actual instanceof httpResponseClass);
-          strictEqual(actual.content, content);
+          strictEqual(actual.body, content);
         });
       }
 

--- a/packages/core/src/common/hooks/validate-body.hook.spec.ts
+++ b/packages/core/src/common/hooks/validate-body.hook.spec.ts
@@ -49,7 +49,7 @@ describe('ValidateBody', () => {
     ok(hook(context({ foo: 'a' }), new ServiceManager()) instanceof HttpResponseBadRequest);
   });
 
-  it('should return an HttpResponseBadRequest with a defined `content` property if '
+  it('should return an HttpResponseBadRequest with a defined `body` property if '
       + 'ctx.request.body is not validated by ajv.', () => {
     const schema = {
       properties: {
@@ -62,7 +62,7 @@ describe('ValidateBody', () => {
 
     const actual = hook(ctx, new ServiceManager());
     ok(actual instanceof HttpResponseBadRequest);
-    notStrictEqual((actual as HttpResponseBadRequest).content, undefined);
+    notStrictEqual((actual as HttpResponseBadRequest).body, undefined);
   });
 
 });

--- a/packages/core/src/common/hooks/validate-headers.hook.spec.ts
+++ b/packages/core/src/common/hooks/validate-headers.hook.spec.ts
@@ -49,7 +49,7 @@ describe('ValidateHeaders', () => {
     ok(hook(context({ foo: 'a' }), new ServiceManager()) instanceof HttpResponseBadRequest);
   });
 
-  it('should return an HttpResponseBadRequest with a defined `content` property if '
+  it('should return an HttpResponseBadRequest with a defined `body` property if '
       + 'ctx.request.headers is not validated by ajv.', () => {
     const schema = {
       properties: {
@@ -62,7 +62,7 @@ describe('ValidateHeaders', () => {
 
     const actual = hook(ctx, new ServiceManager());
     ok(actual instanceof HttpResponseBadRequest);
-    notStrictEqual((actual as HttpResponseBadRequest).content, undefined);
+    notStrictEqual((actual as HttpResponseBadRequest).body, undefined);
   });
 
 });

--- a/packages/core/src/common/hooks/validate-params.hook.spec.ts
+++ b/packages/core/src/common/hooks/validate-params.hook.spec.ts
@@ -49,7 +49,7 @@ describe('ValidateParams', () => {
     ok(hook(context({ foo: 'a' }), new ServiceManager()) instanceof HttpResponseBadRequest);
   });
 
-  it('should return an HttpResponseBadRequest with a defined `content` property if '
+  it('should return an HttpResponseBadRequest with a defined `body` property if '
       + 'ctx.request.params is not validated by ajv.', () => {
     const schema = {
       properties: {
@@ -62,7 +62,7 @@ describe('ValidateParams', () => {
 
     const actual = hook(ctx, new ServiceManager());
     ok(actual instanceof HttpResponseBadRequest);
-    notStrictEqual((actual as HttpResponseBadRequest).content, undefined);
+    notStrictEqual((actual as HttpResponseBadRequest).body, undefined);
   });
 
 });

--- a/packages/core/src/common/hooks/validate-query.hook.spec.ts
+++ b/packages/core/src/common/hooks/validate-query.hook.spec.ts
@@ -49,7 +49,7 @@ describe('ValidateQuery', () => {
     ok(hook(context({ foo: 'a' }), new ServiceManager()) instanceof HttpResponseBadRequest);
   });
 
-  it('should return an HttpResponseBadRequest with a defined `content` property if '
+  it('should return an HttpResponseBadRequest with a defined `body` property if '
       + 'ctx.request.query is not validated by ajv.', () => {
     const schema = {
       properties: {
@@ -62,7 +62,7 @@ describe('ValidateQuery', () => {
 
     const actual = hook(ctx, new ServiceManager());
     ok(actual instanceof HttpResponseBadRequest);
-    notStrictEqual((actual as HttpResponseBadRequest).content, undefined);
+    notStrictEqual((actual as HttpResponseBadRequest).body, undefined);
   });
 
 });

--- a/packages/core/src/common/utils/render.util.spec.ts
+++ b/packages/core/src/common/utils/render.util.spec.ts
@@ -34,7 +34,7 @@ describe('render', () => {
     const expected = `Hello ${name}! How are you?`;
     const actual = render('./templates/template.html', { name }, __dirname);
     ok(actual instanceof HttpResponseOK);
-    strictEqual(actual.content, expected);
+    strictEqual(actual.body, expected);
   });
 
   it('should throw an Error if the template and/or locals are incorrect.', () => {

--- a/packages/core/src/core/http/http-responses.spec.ts
+++ b/packages/core/src/core/http/http-responses.spec.ts
@@ -162,13 +162,13 @@ describe('HttpResponseOK', () => {
     strictEqual(httpResponse.statusMessage, 'OK');
   });
 
-  it('should accept an optional content.', () => {
+  it('should accept an optional body.', () => {
     let httpResponse = new HttpResponseOK();
-    strictEqual(httpResponse.content, undefined);
+    strictEqual(httpResponse.body, undefined);
 
-    const content = { foo: 'bar' };
-    httpResponse = new HttpResponseOK(content);
-    strictEqual(httpResponse.content, content);
+    const body = { foo: 'bar' };
+    httpResponse = new HttpResponseOK(body);
+    strictEqual(httpResponse.body, body);
   });
 
 });
@@ -209,13 +209,13 @@ describe('HttpResponseCreated', () => {
     strictEqual(httpResponse.statusMessage, 'CREATED');
   });
 
-  it('should accept an optional content.', () => {
+  it('should accept an optional body.', () => {
     let httpResponse = new HttpResponseCreated();
-    strictEqual(httpResponse.content, undefined);
+    strictEqual(httpResponse.body, undefined);
 
-    const content = { foo: 'bar' };
-    httpResponse = new HttpResponseCreated(content);
-    strictEqual(httpResponse.content, content);
+    const body = { foo: 'bar' };
+    httpResponse = new HttpResponseCreated(body);
+    strictEqual(httpResponse.body, body);
   });
 
 });
@@ -316,14 +316,14 @@ describe('HttpResponseRedirect', () => {
     strictEqual(httpResponse.statusMessage, 'FOUND');
   });
 
-  it('should accept a mandatory path and an optional content.', () => {
+  it('should accept a mandatory path and an optional body.', () => {
     let httpResponse = new HttpResponseRedirect('/foo');
     strictEqual(httpResponse.path, '/foo');
-    strictEqual(httpResponse.content, undefined);
+    strictEqual(httpResponse.body, undefined);
 
-    const content = { foo: 'bar' };
-    httpResponse = new HttpResponseRedirect('/foo', content);
-    strictEqual(httpResponse.content, content);
+    const body = { foo: 'bar' };
+    httpResponse = new HttpResponseRedirect('/foo', body);
+    strictEqual(httpResponse.body, body);
   });
 
 });
@@ -386,13 +386,13 @@ describe('HttpResponseBadRequest', () => {
     strictEqual(httpResponse.statusMessage, 'BAD REQUEST');
   });
 
-  it('should accept an optional content.', () => {
+  it('should accept an optional body.', () => {
     let httpResponse = new HttpResponseBadRequest();
-    strictEqual(httpResponse.content, undefined);
+    strictEqual(httpResponse.body, undefined);
 
-    const content = { foo: 'bar' };
-    httpResponse = new HttpResponseBadRequest(content);
-    strictEqual(httpResponse.content, content);
+    const body = { foo: 'bar' };
+    httpResponse = new HttpResponseBadRequest(body);
+    strictEqual(httpResponse.body, body);
   });
 
 });
@@ -433,13 +433,13 @@ describe('HttpResponseUnauthorized', () => {
     strictEqual(httpResponse.statusMessage, 'UNAUTHORIZED');
   });
 
-  it('should accept an optional content.', () => {
+  it('should accept an optional body.', () => {
     let httpResponse = new HttpResponseUnauthorized();
-    strictEqual(httpResponse.content, undefined);
+    strictEqual(httpResponse.body, undefined);
 
-    const content = { foo: 'bar' };
-    httpResponse = new HttpResponseUnauthorized(content);
-    strictEqual(httpResponse.content, content);
+    const body = { foo: 'bar' };
+    httpResponse = new HttpResponseUnauthorized(body);
+    strictEqual(httpResponse.body, body);
   });
 
 });
@@ -480,13 +480,13 @@ describe('HttpResponseForbidden', () => {
     strictEqual(httpResponse.statusMessage, 'FORBIDDEN');
   });
 
-  it('should accept an optional content.', () => {
+  it('should accept an optional body.', () => {
     let httpResponse = new HttpResponseForbidden();
-    strictEqual(httpResponse.content, undefined);
+    strictEqual(httpResponse.body, undefined);
 
-    const content = { foo: 'bar' };
-    httpResponse = new HttpResponseForbidden(content);
-    strictEqual(httpResponse.content, content);
+    const body = { foo: 'bar' };
+    httpResponse = new HttpResponseForbidden(body);
+    strictEqual(httpResponse.body, body);
   });
 
 });
@@ -527,13 +527,13 @@ describe('HttpResponseNotFound', () => {
     strictEqual(httpResponse.statusMessage, 'NOT FOUND');
   });
 
-  it('should accept an optional content.', () => {
+  it('should accept an optional body.', () => {
     let httpResponse = new HttpResponseNotFound();
-    strictEqual(httpResponse.content, undefined);
+    strictEqual(httpResponse.body, undefined);
 
-    const content = { foo: 'bar' };
-    httpResponse = new HttpResponseNotFound(content);
-    strictEqual(httpResponse.content, content);
+    const body = { foo: 'bar' };
+    httpResponse = new HttpResponseNotFound(body);
+    strictEqual(httpResponse.body, body);
   });
 
 });
@@ -574,13 +574,13 @@ describe('HttpResponseMethodNotAllowed', () => {
     strictEqual(httpResponse.statusMessage, 'METHOD NOT ALLOWED');
   });
 
-  it('should accept an optional content.', () => {
+  it('should accept an optional body.', () => {
     let httpResponse = new HttpResponseMethodNotAllowed();
-    strictEqual(httpResponse.content, undefined);
+    strictEqual(httpResponse.body, undefined);
 
-    const content = { foo: 'bar' };
-    httpResponse = new HttpResponseMethodNotAllowed(content);
-    strictEqual(httpResponse.content, content);
+    const body = { foo: 'bar' };
+    httpResponse = new HttpResponseMethodNotAllowed(body);
+    strictEqual(httpResponse.body, body);
   });
 
 });
@@ -621,13 +621,13 @@ describe('HttpResponseConflict', () => {
     strictEqual(httpResponse.statusMessage, 'CONFLICT');
   });
 
-  it('should accept an optional content.', () => {
+  it('should accept an optional body.', () => {
     let httpResponse = new HttpResponseConflict();
-    strictEqual(httpResponse.content, undefined);
+    strictEqual(httpResponse.body, undefined);
 
-    const content = { foo: 'bar' };
-    httpResponse = new HttpResponseConflict(content);
-    strictEqual(httpResponse.content, content);
+    const body = { foo: 'bar' };
+    httpResponse = new HttpResponseConflict(body);
+    strictEqual(httpResponse.body, body);
   });
 
 });
@@ -690,13 +690,13 @@ describe('HttpResponseInternalServerError', () => {
     strictEqual(httpResponse.statusMessage, 'INTERNAL SERVER ERROR');
   });
 
-  it('should accept an optional content.', () => {
+  it('should accept an optional body.', () => {
     let httpResponse = new HttpResponseInternalServerError();
-    strictEqual(httpResponse.content, undefined);
+    strictEqual(httpResponse.body, undefined);
 
-    const content = { foo: 'bar' };
-    httpResponse = new HttpResponseInternalServerError(content);
-    strictEqual(httpResponse.content, content);
+    const body = { foo: 'bar' };
+    httpResponse = new HttpResponseInternalServerError(body);
+    strictEqual(httpResponse.body, body);
   });
 
 });
@@ -737,13 +737,13 @@ describe('HttpResponseNotImplemented', () => {
     strictEqual(httpResponse.statusMessage, 'NOT IMPLEMENTED');
   });
 
-  it('should accept an optional content.', () => {
+  it('should accept an optional body.', () => {
     let httpResponse = new HttpResponseNotImplemented();
-    strictEqual(httpResponse.content, undefined);
+    strictEqual(httpResponse.body, undefined);
 
-    const content = { foo: 'bar' };
-    httpResponse = new HttpResponseNotImplemented(content);
-    strictEqual(httpResponse.content, content);
+    const body = { foo: 'bar' };
+    httpResponse = new HttpResponseNotImplemented(body);
+    strictEqual(httpResponse.body, body);
   });
 
 });

--- a/packages/core/src/core/http/http-responses.spec.ts
+++ b/packages/core/src/core/http/http-responses.spec.ts
@@ -1,5 +1,5 @@
 // std
-import { deepStrictEqual, ok, strictEqual } from 'assert';
+import { deepStrictEqual, notStrictEqual, ok, strictEqual } from 'assert';
 
 // FoalTS
 import {
@@ -41,13 +41,65 @@ import {
 
 describe('HttpResponse', () => {
 
-  it('should have a headers properties.', () => {
-    class ConcreteClass extends HttpResponse {
-      statusMessage = 'foo';
-      statusCode = 0;
-    }
-    const response = new ConcreteClass();
-    deepStrictEqual(response.headers, {});
+  class ConcreteClass extends HttpResponse {
+    statusMessage = 'foo';
+    statusCode = 0;
+  }
+  let response: ConcreteClass;
+
+  beforeEach(() => response = new ConcreteClass());
+
+  it('when setHeader and getHeader are called should set and get custom headers.', () => {
+    response.setHeader('my_header', 'header_value');
+    strictEqual(response.getHeader('my_header'), 'header_value');
+    strictEqual(response.getHeader('my_header2'), undefined);
+  });
+
+  it('when getHeaders is called should return a copy of the headers.', () => {
+    response.setHeader('my_header1', 'header_value1');
+    response.setHeader('my_header2', 'header_value2');
+    const actual1 = response.getHeaders();
+    const actual2 = response.getHeaders();
+    deepStrictEqual(actual1, {
+      my_header1: 'header_value1',
+      my_header2: 'header_value2'
+    });
+    notStrictEqual(actual1, actual2);
+  });
+
+  it('when setCookie and getCookie are called should set and get custom cookies.', () => {
+    response.setCookie('my_cookie', 'cookie_value');
+    const options = { domain: 'foalts.org' };
+    response.setCookie('my_cookie2', 'cookie_value2', options);
+
+    const cookie = response.getCookie('my_cookie');
+    strictEqual(cookie.value, 'cookie_value');
+    deepStrictEqual(cookie.options, {});
+
+    const cookie2  = response.getCookie('my_cookie2');
+    strictEqual(cookie2.value, 'cookie_value2');
+    deepStrictEqual(cookie2.options, options);
+    notStrictEqual(cookie2.options, options);
+
+    const cookie3  = response.getCookie('my_cookie3');
+    strictEqual(cookie3.value, undefined);
+    deepStrictEqual(cookie3.options, {});
+  });
+
+  it('when getCookies is called should return a deep copy of the cookies.', () => {
+    response.setCookie('my_cookie1', 'cookie_value1');
+    const options = { domain: 'foalts.org' };
+    response.setCookie('my_cookie2', 'cookie_value2', options);
+
+    const actual1 = response.getCookies();
+    const actual2 = response.getCookies();
+    deepStrictEqual(actual1, {
+      my_cookie1: { value: 'cookie_value1', options: {} },
+      my_cookie2: { value: 'cookie_value2', options }
+    });
+    notStrictEqual(actual1, actual2);
+    notStrictEqual(actual1.my_cookie1, actual2.my_cookie1);
+    notStrictEqual(actual1.my_cookie2.options, actual2.my_cookie2.options);
   });
 
 });

--- a/packages/core/src/core/http/http-responses.ts
+++ b/packages/core/src/core/http/http-responses.ts
@@ -17,7 +17,7 @@ export abstract class HttpResponse {
   private cookies: { [key: string]: { value: string|undefined, options: CookieOptions } } = {};
   private headers: { [key: string]: string } = {};
 
-  constructor(public content?: any) {}
+  constructor(public body?: any) {}
 
   setHeader(name: string, value: string): void {
     this.headers[name] = value;
@@ -63,8 +63,8 @@ export function isHttpResponse(obj: any): obj is HttpResponse {
 
 export abstract class HttpResponseSuccess extends HttpResponse {
   readonly isHttpResponseSuccess = true;
-  constructor(content?: any) {
-    super(content);
+  constructor(body?: any) {
+    super(body);
   }
 }
 
@@ -77,8 +77,8 @@ export class HttpResponseOK extends HttpResponseSuccess {
   readonly isHttpResponseOK = true;
   statusCode = 200;
   statusMessage = 'OK';
-  constructor(content?: any) {
-    super(content);
+  constructor(body?: any) {
+    super(body);
   }
 }
 
@@ -91,8 +91,8 @@ export class HttpResponseCreated extends HttpResponseSuccess {
   readonly isHttpResponseCreated = true;
   statusCode = 201;
   statusMessage = 'CREATED';
-  constructor(content?: any) {
-    super(content);
+  constructor(body?: any) {
+    super(body);
   }
 }
 
@@ -119,8 +119,8 @@ export function isHttpResponseNoContent(obj: any): obj is HttpResponseNoContent 
 
 export abstract class HttpResponseRedirection extends HttpResponse {
   readonly isHttpResponseRedirection = true;
-  constructor(content?: any) {
-    super(content);
+  constructor(body?: any) {
+    super(body);
   }
 }
 
@@ -133,8 +133,8 @@ export class HttpResponseRedirect extends HttpResponseRedirection {
   readonly isHttpResponseRedirect = true;
   statusCode = 302;
   statusMessage = 'FOUND';
-  constructor(public path: string, content?: any) {
-    super(content);
+  constructor(public path: string, body?: any) {
+    super(body);
   }
 }
 
@@ -147,8 +147,8 @@ export function isHttpResponseRedirect(obj: any): obj is HttpResponseRedirect {
 
 export abstract class HttpResponseClientError extends HttpResponse {
   readonly isHttpResponseClientError = true;
-  constructor(content?: any) {
-    super(content);
+  constructor(body?: any) {
+    super(body);
   }
 }
 
@@ -161,8 +161,8 @@ export class HttpResponseBadRequest extends HttpResponseClientError {
   readonly isHttpResponseBadRequest = true;
   statusCode = 400;
   statusMessage = 'BAD REQUEST';
-  constructor(content?: any) {
-    super(content);
+  constructor(body?: any) {
+    super(body);
   }
 }
 
@@ -175,8 +175,8 @@ export class HttpResponseUnauthorized extends HttpResponseClientError {
   readonly isHttpResponseUnauthorized = true;
   statusCode = 401;
   statusMessage = 'UNAUTHORIZED';
-  constructor(content?: any) {
-    super(content);
+  constructor(body?: any) {
+    super(body);
     this.setHeader('WWW-Authenticate', '');
   }
 }
@@ -190,8 +190,8 @@ export class HttpResponseForbidden extends HttpResponseClientError {
   readonly isHttpResponseForbidden = true;
   statusCode = 403;
   statusMessage = 'FORBIDDEN';
-  constructor(content?: any) {
-    super(content);
+  constructor(body?: any) {
+    super(body);
   }
 }
 
@@ -204,8 +204,8 @@ export class HttpResponseNotFound extends HttpResponseClientError {
   readonly isHttpResponseNotFound = true;
   statusCode = 404;
   statusMessage = 'NOT FOUND';
-  constructor(content?: any) {
-    super(content);
+  constructor(body?: any) {
+    super(body);
   }
 }
 
@@ -218,8 +218,8 @@ export class HttpResponseMethodNotAllowed extends HttpResponseClientError {
   readonly isHttpResponseMethodNotAllowed = true;
   statusCode = 405;
   statusMessage = 'METHOD NOT ALLOWED';
-  constructor(content?: any) {
-    super(content);
+  constructor(body?: any) {
+    super(body);
   }
 }
 
@@ -232,8 +232,8 @@ export class HttpResponseConflict extends HttpResponseClientError {
   readonly isHttpResponseConflict = true;
   statusCode = 409;
   statusMessage = 'CONFLICT';
-  constructor(content?: any) {
-    super(content);
+  constructor(body?: any) {
+    super(body);
   }
 }
 
@@ -246,8 +246,8 @@ export function isHttpResponseConflict(obj: any): obj is HttpResponseConflict {
 
 export abstract class HttpResponseServerError extends HttpResponse {
   readonly isHttpResponseServerError = true;
-  constructor(content?: any) {
-    super(content);
+  constructor(body?: any) {
+    super(body);
   }
 }
 
@@ -260,8 +260,8 @@ export class HttpResponseInternalServerError extends HttpResponseServerError {
   readonly isHttpResponseInternalServerError = true;
   statusCode = 500;
   statusMessage = 'INTERNAL SERVER ERROR';
-  constructor(content?: any) {
-    super(content);
+  constructor(body?: any) {
+    super(body);
   }
 }
 
@@ -274,8 +274,8 @@ export class HttpResponseNotImplemented extends HttpResponseServerError {
   readonly isHttpResponseNotImplemented = true;
   statusCode = 501;
   statusMessage = 'NOT IMPLEMENTED';
-  constructor(content?: any) {
-    super(content);
+  constructor(body?: any) {
+    super(body);
   }
 }
 

--- a/packages/core/src/express/create-middleware.spec.ts
+++ b/packages/core/src/express/create-middleware.spec.ts
@@ -158,11 +158,11 @@ describe('createMiddleware', () => {
         it('should send a response with the suitable headers.', () => {
           const app = express();
           const successResponse = new HttpResponseCreated();
-          successResponse.headers = { 'X-CSRF-Token': 'aaa' };
+          successResponse.setHeader('X-CSRF-Token', 'aaa');
           const clientErrorResponse = new HttpResponseBadRequest();
-          clientErrorResponse.headers = { 'X-CSRF-Token': 'bbb' };
+          clientErrorResponse.setHeader('X-CSRF-Token', 'bbb');
           const serverErrorResponse = new HttpResponseInternalServerError();
-          serverErrorResponse.headers = { 'X-CSRF-Token': 'ccc' };
+          serverErrorResponse.setHeader('X-CSRF-Token', 'ccc');
 
           app.get('/success', createMiddleware(
             route(() => successResponse),
@@ -190,6 +190,44 @@ describe('createMiddleware', () => {
           ]);
         });
 
+        it('should send a response with the suitable cookies.', () => {
+          const app = express();
+          const successResponse = new HttpResponseCreated();
+          successResponse.setCookie('cookie1', 'cookie1_value_a');
+          successResponse.setCookie('cookie2', 'cookie2_value_a', { httpOnly: true });
+          const clientErrorResponse = new HttpResponseBadRequest();
+          clientErrorResponse.setCookie('cookie1', 'cookie1_value_b');
+          clientErrorResponse.setCookie('cookie2', 'cookie2_value_b', { httpOnly: true });
+          const serverErrorResponse = new HttpResponseInternalServerError();
+          serverErrorResponse.setCookie('cookie1', 'cookie1_value_c');
+          serverErrorResponse.setCookie('cookie2', 'cookie2_value_c', { httpOnly: true });
+
+          app.get('/success', createMiddleware(
+            route(() => successResponse),
+            new ServiceManager()
+          ));
+          app.get('/client-error', createMiddleware(
+            route(async () => clientErrorResponse),
+            new ServiceManager()
+          ));
+          app.get('/server-error', createMiddleware(
+            route(() => serverErrorResponse),
+            new ServiceManager()
+          ));
+
+          return Promise.all([
+            request(app)
+              .get('/success')
+              .expect('Set-Cookie', 'cookie1=cookie1_value_a; Path=/,cookie2=cookie2_value_a; Path=/; HttpOnly'),
+            request(app)
+              .get('/client-error')
+              .expect('Set-Cookie', 'cookie1=cookie1_value_b; Path=/,cookie2=cookie2_value_b; Path=/; HttpOnly'),
+            request(app)
+              .get('/server-error')
+              .expect('Set-Cookie', 'cookie1=cookie1_value_c; Path=/,cookie2=cookie2_value_c; Path=/; HttpOnly'),
+          ]);
+        });
+
     });
 
     describe('when the controller method returns or resolves an instance of HttpResponseRedirection', () => {
@@ -208,7 +246,7 @@ describe('createMiddleware', () => {
       it('should redirect the page with the suitable headers.', () => {
         const app = express();
         const response = new HttpResponseRedirect('/b');
-        response.headers = { 'X-CSRF-Token': 'aaa' };
+        response.setHeader('X-CSRF-Token', 'aaa');
         app.get('/a', createMiddleware(route(() => response), new ServiceManager()));
         app.get('/b', (req, res) => res.send('foo'));
 

--- a/packages/core/src/express/create-middleware.spec.ts
+++ b/packages/core/src/express/create-middleware.spec.ts
@@ -117,7 +117,7 @@ describe('createMiddleware', () => {
           ]);
         });
 
-        it('should send a response with a suitable body depending on response.content.', () => {
+        it('should send a response with a suitable body depending on response.body.', () => {
           const app = express();
 
           app.get('/a', createMiddleware(

--- a/packages/core/src/express/create-middleware.ts
+++ b/packages/core/src/express/create-middleware.ts
@@ -25,8 +25,13 @@ export function createMiddleware(route: Route, services: ServiceManager): (...ar
         throw new Error(`The controller method "${route.propertyKey}" should return an HttpResponse.`);
       }
 
-      res.set(response.headers);
       res.status(response.statusCode);
+      res.set(response.getHeaders());
+      const cookies = response.getCookies();
+      // tslint:disable-next-line:forin
+      for (const cookieName in cookies) {
+        res.cookie(cookieName, cookies[cookieName].value, cookies[cookieName].options);
+      }
 
       if (isHttpResponseRedirect(response)) {
         res.redirect(response.path);

--- a/packages/core/src/express/create-middleware.ts
+++ b/packages/core/src/express/create-middleware.ts
@@ -38,10 +38,10 @@ export function createMiddleware(route: Route, services: ServiceManager): (...ar
         return;
       }
 
-      if (typeof response.content === 'number') {
-        response.content = response.content.toString();
+      if (typeof response.body === 'number') {
+        response.body = response.body.toString();
       }
-      res.send(response.content);
+      res.send(response.body);
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
# Issue

The developer should be able to send cookies in their http responses.

# Solution and steps

- [x] Add the methods `setCookie`, `getCookie` and `getCookies`.
- [x] Add the methods `setHeader`, `getHeader` and `getHeaders` make the properties `headers` to be consistent with the cookies.
- [x] Make `create-middleware` use the `getCookies` method.

# Breaking change

The property `headers` of `HttpResponse` is now private. You need to use the `setHeader`, `getHeader` and `getHeaders` methods instead.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.