### PR TITLE
[@foal/core] Add "post function" feature in hooks

### DIFF
--- a/docs/architecture/hooks.md
+++ b/docs/architecture/hooks.md
@@ -4,13 +4,26 @@
 foal generate hook my-hook
 ```
 
-Hooks are an elegant way to deal with access control, input validation or sanitization. A hook is made of small function, synchronous or asynchronous, that aims to be executed before a controller method.
+Hooks are decorators that execute extra logic before and/or after the method execution.
+
+They are particulary useful in these scenarios:
+- authentication & access control
+- request validation & sanitization
+- logging
+
+They improve code readability and make unit testing easier.
+
+## Structure
+
+A hook is made of small function, synchronous or asynchronous, that is executed before the controller method.
 
 This function takes two parameters:
-- The `Context` object which provides some information on the http request as well as the session object and the authenticated user if they exist.
+- The `Context` object which provides some information on the http request as well as the authenticated user if it exists.
 - The service manager that lets access other services within the hook.
 
-If an `HttpResponse` is returned (or resolved) in a hook then the processing of the request is stopped for the hooks and controller method and the server responds with the `statusCode` and optional `body` of the returned object.
+It may return an `HttpResponse` object. If so, the remaining hooks and the controller method are not executed, and the server responds with this response.
+
+It may also return an `HookPostFunction` that will be executed after the method execution. This takes three parameters: the context, the service manager and the response returned by the controller method.
 
 <!--
 // TODO: Write this.
@@ -43,6 +56,17 @@ export function HelloWorld(smiley: string){
   return Hook((ctx: Context, services: ServiceManager) => {
     console.log('Hello world ' + smiley);
   });
+}
+
+export function LogExecutionTime() {
+  return Hook(() => {
+    const NS_PER_SEC = 1e9;
+    const time = process.hrtime(); 
+    return () => {
+      const diff = process.hrtime(time);
+      console.log(`Benchmark took ${diff[0] * NS_PER_SEC + diff[1]} nanoseconds`);
+    };
+  })
 }
 
 ```

--- a/packages/core/src/auth/authentication/authenticate.hook.spec.ts
+++ b/packages/core/src/auth/authentication/authenticate.hook.spec.ts
@@ -60,7 +60,7 @@ describe('Authenticate', () => {
     const preHook = getHookFunction(Authenticate(User));
     const ctx = new Context({});
 
-    return preHook(ctx, new ServiceManager())
+    return (preHook(ctx, new ServiceManager()) as Promise<any>)
       .then(() => fail('The promise should be rejected'))
       .catch(err => strictEqual(err.message, 'Authenticate hook requires session management.'));
   });

--- a/packages/core/src/core/hooks.spec.ts
+++ b/packages/core/src/core/hooks.spec.ts
@@ -9,8 +9,8 @@ import { getHookFunction, Hook, HookFunction } from './hooks';
 
 describe('Hook', () => {
 
-  const hook1: HookFunction = () => {};
-  const hook2: HookFunction = () => {};
+  const hook1: HookFunction = () => { return; };
+  const hook2: HookFunction = () => undefined;
 
   it('should add the hook to the metadata hooks on the method class.', () => {
     class Foobar {

--- a/packages/core/src/core/hooks.ts
+++ b/packages/core/src/core/hooks.ts
@@ -5,7 +5,7 @@ import 'reflect-metadata';
 import { Context, HttpResponse } from './http';
 import { ServiceManager } from './service-manager';
 
-export type HookPostFunction = (ctx: Context, services: ServiceManager, response: HttpResponse) => void;
+export type HookPostFunction = (ctx: Context, services: ServiceManager, response: HttpResponse) => void | Promise<void>;
 export type HookFunction = (ctx: Context, services: ServiceManager) =>
   void | HttpResponse | HookPostFunction | Promise <void | HttpResponse | HookPostFunction>;
 export type HookDecorator = (target: any, propertyKey?: string) => any;

--- a/packages/core/src/core/hooks.ts
+++ b/packages/core/src/core/hooks.ts
@@ -2,11 +2,12 @@
 import 'reflect-metadata';
 
 // FoalTS
-import { Context } from './http';
+import { Context, HttpResponse } from './http';
 import { ServiceManager } from './service-manager';
 
-// not void. HttpResponse or HttpResponse | void (same with promises)
-export type HookFunction = (ctx: Context, services: ServiceManager) => any;
+export type HookPostFunction = (ctx: Context, services: ServiceManager, response: HttpResponse) => void;
+export type HookFunction = (ctx: Context, services: ServiceManager) =>
+  void | HttpResponse | HookPostFunction | Promise <void | HttpResponse | HookPostFunction>;
 export type HookDecorator = (target: any, propertyKey?: string) => any;
 
 export function Hook(hookFunction: HookFunction): HookDecorator {


### PR DESCRIPTION
# Issue

Sometimes we want to execute functions after the execution of the controller method. See https://github.com/FoalTS/foal/issues/163.

# Solution and steps

Let the hooks return a `HookPostFunction` that will be executed after the method execution.

```typescript
type HookPostFunction = (ctx: Context, services: ServiceManager, response: HttpResponse) => void | Promise<void>;
```

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.