### PR TITLE
v.0.6.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ First install [Node.Js and npm](https://nodejs.org/en/download/).
 
 ### Create a new app
 
-```shell
+```
 $ npm install -g @foal/cli
 $ foal createapp my-app
 $ cd my-app && npm install

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -3,7 +3,7 @@
 * [index.ts][SourceFile-0]
     * Functions
         * [parsePassword][FunctionDeclaration-0]
-        * [Authenticate][FunctionDeclaration-1]
+        * [AuthenticateWithSessionAndCookie][FunctionDeclaration-1]
         * [strategy][FunctionDeclaration-2]
         * [PermissionRequired][FunctionDeclaration-3]
         * [LoginRequired][FunctionDeclaration-4]
@@ -24,37 +24,39 @@
         * [getAjvInstance][FunctionDeclaration-19]
         * [render][FunctionDeclaration-20]
         * [validate][FunctionDeclaration-21]
-        * [Get][FunctionDeclaration-22]
-        * [Post][FunctionDeclaration-23]
-        * [Put][FunctionDeclaration-24]
-        * [Patch][FunctionDeclaration-25]
-        * [Delete][FunctionDeclaration-26]
-        * [isHttpResponse][FunctionDeclaration-27]
-        * [isHttpResponseSuccess][FunctionDeclaration-28]
-        * [isHttpResponseOK][FunctionDeclaration-29]
-        * [isHttpResponseCreated][FunctionDeclaration-30]
-        * [isHttpResponseNoContent][FunctionDeclaration-31]
-        * [isHttpResponseRedirection][FunctionDeclaration-32]
-        * [isHttpResponseRedirect][FunctionDeclaration-33]
-        * [isHttpResponseClientError][FunctionDeclaration-34]
-        * [isHttpResponseBadRequest][FunctionDeclaration-35]
-        * [isHttpResponseUnauthorized][FunctionDeclaration-36]
-        * [isHttpResponseForbidden][FunctionDeclaration-37]
-        * [isHttpResponseNotFound][FunctionDeclaration-38]
-        * [isHttpResponseMethodNotAllowed][FunctionDeclaration-39]
-        * [isHttpResponseConflict][FunctionDeclaration-40]
-        * [isHttpResponseServerError][FunctionDeclaration-41]
-        * [isHttpResponseInternalServerError][FunctionDeclaration-42]
-        * [isHttpResponseNotImplemented][FunctionDeclaration-43]
-        * [Hook][FunctionDeclaration-44]
-        * [getHookFunction][FunctionDeclaration-45]
-        * [makeControllerRoutes][FunctionDeclaration-46]
-        * [getPath][FunctionDeclaration-47]
-        * [getHttpMethod][FunctionDeclaration-48]
-        * [createController][FunctionDeclaration-49]
-        * [createService][FunctionDeclaration-50]
-        * [dependency][FunctionDeclaration-51]
-        * [createApp][FunctionDeclaration-52]
+        * [Head][FunctionDeclaration-22]
+        * [Options][FunctionDeclaration-23]
+        * [Get][FunctionDeclaration-24]
+        * [Post][FunctionDeclaration-25]
+        * [Put][FunctionDeclaration-26]
+        * [Patch][FunctionDeclaration-27]
+        * [Delete][FunctionDeclaration-28]
+        * [isHttpResponse][FunctionDeclaration-29]
+        * [isHttpResponseSuccess][FunctionDeclaration-30]
+        * [isHttpResponseOK][FunctionDeclaration-31]
+        * [isHttpResponseCreated][FunctionDeclaration-32]
+        * [isHttpResponseNoContent][FunctionDeclaration-33]
+        * [isHttpResponseRedirection][FunctionDeclaration-34]
+        * [isHttpResponseRedirect][FunctionDeclaration-35]
+        * [isHttpResponseClientError][FunctionDeclaration-36]
+        * [isHttpResponseBadRequest][FunctionDeclaration-37]
+        * [isHttpResponseUnauthorized][FunctionDeclaration-38]
+        * [isHttpResponseForbidden][FunctionDeclaration-39]
+        * [isHttpResponseNotFound][FunctionDeclaration-40]
+        * [isHttpResponseMethodNotAllowed][FunctionDeclaration-41]
+        * [isHttpResponseConflict][FunctionDeclaration-42]
+        * [isHttpResponseServerError][FunctionDeclaration-43]
+        * [isHttpResponseInternalServerError][FunctionDeclaration-44]
+        * [isHttpResponseNotImplemented][FunctionDeclaration-45]
+        * [Hook][FunctionDeclaration-46]
+        * [getHookFunction][FunctionDeclaration-47]
+        * [makeControllerRoutes][FunctionDeclaration-48]
+        * [getPath][FunctionDeclaration-49]
+        * [getHttpMethod][FunctionDeclaration-50]
+        * [createController][FunctionDeclaration-51]
+        * [createService][FunctionDeclaration-52]
+        * [dependency][FunctionDeclaration-53]
+        * [createApp][FunctionDeclaration-54]
     * Interfaces
         * [EmailUser][InterfaceDeclaration-0]
         * [IAuthenticator][InterfaceDeclaration-2]
@@ -70,6 +72,7 @@
         * [Middleware][TypeAliasDeclaration-1]
         * [RelationLoader][TypeAliasDeclaration-2]
         * [HttpMethod][TypeAliasDeclaration-3]
+        * [HookPostFunction][TypeAliasDeclaration-5]
         * [HookFunction][TypeAliasDeclaration-4]
         * [HookDecorator][TypeAliasDeclaration-0]
     * Variables
@@ -97,10 +100,10 @@ Promise<string>
 
 ----------
 
-### Authenticate
+### AuthenticateWithSessionAndCookie
 
 ```typescript
-function Authenticate(UserEntity: Class<AbstractUser>): HookDecorator;
+function AuthenticateWithSessionAndCookie(UserEntity: Class<AbstractUser>): HookDecorator;
 ```
 
 **Parameters**
@@ -487,6 +490,42 @@ function validate(schema: object, data: any): void;
 **Return type**
 
 void
+
+----------
+
+### Head
+
+```typescript
+function Head(path?: string | undefined): (target: any, propertyKey: string) => void;
+```
+
+**Parameters**
+
+| Name | Type                    |
+| ---- | ----------------------- |
+| path | string &#124; undefined |
+
+**Return type**
+
+(target: any, propertyKey: string) => void
+
+----------
+
+### Options
+
+```typescript
+function Options(path?: string | undefined): (target: any, propertyKey: string) => void;
+```
+
+**Parameters**
+
+| Name | Type                    |
+| ---- | ----------------------- |
+| path | string &#124; undefined |
+
+**Return type**
+
+(target: any, propertyKey: string) => void
 
 ----------
 
@@ -1056,16 +1095,19 @@ void
 
 ### createApp
 
+Main function to create a node.js (express) application from the root controller.
+
 ```typescript
-function createApp(rootControllerClass: Class<any>, options: CreateAppOptions = {}): any;
+function createApp(rootControllerClass: Class<any>, options: CreateAppOptions = {}, expressInstance?: any): any;
 ```
 
 **Parameters**
 
-| Name                | Type                                       | Default value |
-| ------------------- | ------------------------------------------ | ------------- |
-| rootControllerClass | [Class][InterfaceDeclaration-1]<any>       |               |
-| options             | [CreateAppOptions][InterfaceDeclaration-9] | {}            |
+| Name                | Type                                       | Default value | Description                                                            |
+| ------------------- | ------------------------------------------ | ------------- | ---------------------------------------------------------------------- |
+| rootControllerClass | [Class][InterfaceDeclaration-1]<any>       |               | The root controller, usually called `AppController`                    |
+| options             | [CreateAppOptions][InterfaceDeclaration-9] | {}            | Optional options to specify the session store (default is MemoryStore) |
+| expressInstance     | any                                        |               | Optional express instance to be used as base.                          |
 
 **Return type**
 
@@ -1442,24 +1484,36 @@ type RelationLoader = (user: AbstractUser | undefined, params: CollectionParams)
 ### HttpMethod
 
 ```typescript
-type HttpMethod = "POST" | "GET" | "PUT" | "PATCH" | "DELETE";
+type HttpMethod = "POST" | "GET" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
 ```
 
 **Type**
 
-"POST" | "GET" | "PUT" | "PATCH" | "DELETE"
+"POST" | "GET" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS"
+
+----------
+
+### HookPostFunction
+
+```typescript
+type HookPostFunction = (ctx: Context<AbstractUser>, services: ServiceManager, response: HttpResponse) => void | Promise<void>;
+```
+
+**Type**
+
+(ctx: Context<AbstractUser>, services: ServiceManager, response: HttpResponse) => void | Promise<void>
 
 ----------
 
 ### HookFunction
 
 ```typescript
-type HookFunction = (ctx: Context<AbstractUser>, services: ServiceManager) => any;
+type HookFunction = (ctx: Context<AbstractUser>, services: ServiceManager) => void | HttpResponse | HookPostFunction | Promise<void | HttpResponse | HookPostFunction>;
 ```
 
 **Type**
 
-(ctx: Context<AbstractUser>, services: ServiceManager) => any
+(ctx: Context<AbstractUser>, services: ServiceManager) => void | [HttpResponse][ClassDeclaration-9] | [HookPostFunction][TypeAliasDeclaration-5] | Promise<void | [HttpResponse][ClassDeclaration-9] | [HookPostFunction][TypeAliasDeclaration-5]>
 
 ----------
 
@@ -1644,7 +1698,7 @@ const emailSchema: { additionalProperties: boolean; properties: { email: { type:
 
 [SourceFile-0]: index.md#indexts
 [FunctionDeclaration-0]: index.md#parsepassword
-[FunctionDeclaration-1]: index.md#authenticate
+[FunctionDeclaration-1]: index.md#authenticatewithsessionandcookie
 [ClassDeclaration-1]: index/abstractuser.md#abstractuser
 [InterfaceDeclaration-1]: index.md#class
 [TypeAliasDeclaration-0]: index.md#hookdecorator
@@ -1694,68 +1748,70 @@ const emailSchema: { additionalProperties: boolean; properties: { email: { type:
 [FunctionDeclaration-20]: index.md#render
 [ClassDeclaration-20]: index/httpresponseok.md#httpresponseok
 [FunctionDeclaration-21]: index.md#validate
-[FunctionDeclaration-22]: index.md#get
-[FunctionDeclaration-23]: index.md#post
-[FunctionDeclaration-24]: index.md#put
-[FunctionDeclaration-25]: index.md#patch
-[FunctionDeclaration-26]: index.md#delete
-[FunctionDeclaration-27]: index.md#ishttpresponse
+[FunctionDeclaration-22]: index.md#head
+[FunctionDeclaration-23]: index.md#options
+[FunctionDeclaration-24]: index.md#get
+[FunctionDeclaration-25]: index.md#post
+[FunctionDeclaration-26]: index.md#put
+[FunctionDeclaration-27]: index.md#patch
+[FunctionDeclaration-28]: index.md#delete
+[FunctionDeclaration-29]: index.md#ishttpresponse
 [ClassDeclaration-9]: index/httpresponse.md#httpresponse
-[FunctionDeclaration-28]: index.md#ishttpresponsesuccess
+[FunctionDeclaration-30]: index.md#ishttpresponsesuccess
 [ClassDeclaration-11]: index/httpresponsesuccess.md#httpresponsesuccess
-[FunctionDeclaration-29]: index.md#ishttpresponseok
+[FunctionDeclaration-31]: index.md#ishttpresponseok
 [ClassDeclaration-20]: index/httpresponseok.md#httpresponseok
-[FunctionDeclaration-30]: index.md#ishttpresponsecreated
+[FunctionDeclaration-32]: index.md#ishttpresponsecreated
 [ClassDeclaration-22]: index/httpresponsecreated.md#httpresponsecreated
-[FunctionDeclaration-31]: index.md#ishttpresponsenocontent
+[FunctionDeclaration-33]: index.md#ishttpresponsenocontent
 [ClassDeclaration-10]: index/httpresponsenocontent.md#httpresponsenocontent
-[FunctionDeclaration-32]: index.md#ishttpresponseredirection
+[FunctionDeclaration-34]: index.md#ishttpresponseredirection
 [ClassDeclaration-8]: index/httpresponseredirection.md#httpresponseredirection
-[FunctionDeclaration-33]: index.md#ishttpresponseredirect
+[FunctionDeclaration-35]: index.md#ishttpresponseredirect
 [ClassDeclaration-7]: index/httpresponseredirect.md#httpresponseredirect
-[FunctionDeclaration-34]: index.md#ishttpresponseclienterror
+[FunctionDeclaration-36]: index.md#ishttpresponseclienterror
 [ClassDeclaration-13]: index/httpresponseclienterror.md#httpresponseclienterror
-[FunctionDeclaration-35]: index.md#ishttpresponsebadrequest
+[FunctionDeclaration-37]: index.md#ishttpresponsebadrequest
 [ClassDeclaration-14]: index/httpresponsebadrequest.md#httpresponsebadrequest
-[FunctionDeclaration-36]: index.md#ishttpresponseunauthorized
+[FunctionDeclaration-38]: index.md#ishttpresponseunauthorized
 [ClassDeclaration-15]: index/httpresponseunauthorized.md#httpresponseunauthorized
-[FunctionDeclaration-37]: index.md#ishttpresponseforbidden
+[FunctionDeclaration-39]: index.md#ishttpresponseforbidden
 [ClassDeclaration-21]: index/httpresponseforbidden.md#httpresponseforbidden
-[FunctionDeclaration-38]: index.md#ishttpresponsenotfound
+[FunctionDeclaration-40]: index.md#ishttpresponsenotfound
 [ClassDeclaration-12]: index/httpresponsenotfound.md#httpresponsenotfound
-[FunctionDeclaration-39]: index.md#ishttpresponsemethodnotallowed
+[FunctionDeclaration-41]: index.md#ishttpresponsemethodnotallowed
 [ClassDeclaration-17]: index/httpresponsemethodnotallowed.md#httpresponsemethodnotallowed
-[FunctionDeclaration-40]: index.md#ishttpresponseconflict
+[FunctionDeclaration-42]: index.md#ishttpresponseconflict
 [ClassDeclaration-27]: index/httpresponseconflict.md#httpresponseconflict
-[FunctionDeclaration-41]: index.md#ishttpresponseservererror
+[FunctionDeclaration-43]: index.md#ishttpresponseservererror
 [ClassDeclaration-19]: index/httpresponseservererror.md#httpresponseservererror
-[FunctionDeclaration-42]: index.md#ishttpresponseinternalservererror
+[FunctionDeclaration-44]: index.md#ishttpresponseinternalservererror
 [ClassDeclaration-28]: index/httpresponseinternalservererror.md#httpresponseinternalservererror
-[FunctionDeclaration-43]: index.md#ishttpresponsenotimplemented
+[FunctionDeclaration-45]: index.md#ishttpresponsenotimplemented
 [ClassDeclaration-18]: index/httpresponsenotimplemented.md#httpresponsenotimplemented
-[FunctionDeclaration-44]: index.md#hook
+[FunctionDeclaration-46]: index.md#hook
 [TypeAliasDeclaration-4]: index.md#hookfunction
 [TypeAliasDeclaration-0]: index.md#hookdecorator
-[FunctionDeclaration-45]: index.md#gethookfunction
+[FunctionDeclaration-47]: index.md#gethookfunction
 [TypeAliasDeclaration-0]: index.md#hookdecorator
 [TypeAliasDeclaration-4]: index.md#hookfunction
-[FunctionDeclaration-46]: index.md#makecontrollerroutes
+[FunctionDeclaration-48]: index.md#makecontrollerroutes
 [TypeAliasDeclaration-4]: index.md#hookfunction
 [InterfaceDeclaration-1]: index.md#class
 [ClassDeclaration-5]: index/servicemanager.md#servicemanager
 [InterfaceDeclaration-8]: index.md#route
-[FunctionDeclaration-47]: index.md#getpath
+[FunctionDeclaration-49]: index.md#getpath
 [InterfaceDeclaration-1]: index.md#class
-[FunctionDeclaration-48]: index.md#gethttpmethod
+[FunctionDeclaration-50]: index.md#gethttpmethod
 [InterfaceDeclaration-1]: index.md#class
-[FunctionDeclaration-49]: index.md#createcontroller
-[InterfaceDeclaration-1]: index.md#class
-[ClassDeclaration-5]: index/servicemanager.md#servicemanager
-[FunctionDeclaration-50]: index.md#createservice
+[FunctionDeclaration-51]: index.md#createcontroller
 [InterfaceDeclaration-1]: index.md#class
 [ClassDeclaration-5]: index/servicemanager.md#servicemanager
-[FunctionDeclaration-51]: index.md#dependency
-[FunctionDeclaration-52]: index.md#createapp
+[FunctionDeclaration-52]: index.md#createservice
+[InterfaceDeclaration-1]: index.md#class
+[ClassDeclaration-5]: index/servicemanager.md#servicemanager
+[FunctionDeclaration-53]: index.md#dependency
+[FunctionDeclaration-54]: index.md#createapp
 [InterfaceDeclaration-1]: index.md#class
 [InterfaceDeclaration-9]: index.md#createappoptions
 [InterfaceDeclaration-0]: index.md#emailuser
@@ -1785,7 +1841,12 @@ const emailSchema: { additionalProperties: boolean; properties: { email: { type:
 [TypeAliasDeclaration-1]: index.md#middleware
 [TypeAliasDeclaration-2]: index.md#relationloader
 [TypeAliasDeclaration-3]: index.md#httpmethod
+[TypeAliasDeclaration-5]: index.md#hookpostfunction
 [TypeAliasDeclaration-4]: index.md#hookfunction
+[ClassDeclaration-9]: index/httpresponse.md#httpresponse
+[TypeAliasDeclaration-5]: index.md#hookpostfunction
+[ClassDeclaration-9]: index/httpresponse.md#httpresponse
+[TypeAliasDeclaration-5]: index.md#hookpostfunction
 [TypeAliasDeclaration-0]: index.md#hookdecorator
 [ClassDeclaration-0]: index/emailauthenticator.md#emailauthenticator
 [ClassDeclaration-4]: index/logincontroller.md#logincontroller

--- a/docs/architecture/controllers.md
+++ b/docs/architecture/controllers.md
@@ -25,7 +25,7 @@ Controllers are the front door of your application. They catch all the incoming 
 
 ### Creating a controller
 
-Formally a controller is a single class that is instantiated as a singleton. The methods that handle the requests take also a decorator: `Get`, `Post`, `Patch`, `Put` or `Delete`. Each method with one of theses decorators is responsible for one route.
+Formally a controller is a single class that is instantiated as a singleton. The methods that handle the requests take also a decorator: `Get`, `Post`, `Patch`, `Put`, `Delete`, `Head` or `Options`. Each method with one of theses decorators is responsible for one route.
 
 ```typescript
 import { Context, Get, HttpResponseOK } from '@foal/core';
@@ -143,7 +143,7 @@ class ChildController extends ParentController {
 }
 ```
 
-You can also override `foo`. If you don't add a `Get`, `Post`, `Patch`, `Put` or `Delete` decorator then the parent path and HTTP method are used. If you don't add a hook, then the parent hooks are used. Otherwise they are all discarded.
+You can also override `foo`. If you don't add a `Get`, `Post`, `Patch`, `Put`, `Delete`, `Head` or `Options` decorator then the parent path and HTTP method are used. If you don't add a hook, then the parent hooks are used. Otherwise they are all discarded.
 
 ## Using sub-controllers
 

--- a/docs/architecture/hooks.md
+++ b/docs/architecture/hooks.md
@@ -4,13 +4,26 @@
 foal generate hook my-hook
 ```
 
-Hooks are an elegant way to deal with access control, input validation or sanitization. A hook is made of small function, synchronous or asynchronous, that aims to be executed before a controller method.
+Hooks are decorators that execute extra logic before and/or after the method execution.
+
+They are particulary useful in these scenarios:
+- authentication & access control
+- request validation & sanitization
+- logging
+
+They improve code readability and make unit testing easier.
+
+## Structure
+
+A hook is made of small function, synchronous or asynchronous, that is executed before the controller method.
 
 This function takes two parameters:
-- The `Context` object which provides some information on the http request as well as the session object and the authenticated user if they exist.
+- The `Context` object which provides some information on the http request as well as the authenticated user if it exists.
 - The service manager that lets access other services within the hook.
 
-If an `HttpResponse` is returned (or resolved) in a hook then the processing of the request is stopped for the hooks and controller method and the server responds with the `statusCode` and optional `body` of the returned object.
+It may return an `HttpResponse` object. If so, the remaining hooks and the controller method are not executed, and the server responds with this response.
+
+It may also return an `HookPostFunction` that will be executed after the method execution. This takes three parameters: the context, the service manager and the response returned by the controller method.
 
 <!--
 // TODO: Write this.
@@ -43,6 +56,17 @@ export function HelloWorld(smiley: string){
   return Hook((ctx: Context, services: ServiceManager) => {
     console.log('Hello world ' + smiley);
   });
+}
+
+export function LogExecutionTime() {
+  return Hook(() => {
+    const NS_PER_SEC = 1e9;
+    const time = process.hrtime(); 
+    return () => {
+      const diff = process.hrtime(time);
+      console.log(`Benchmark took ${diff[0] * NS_PER_SEC + diff[1]} nanoseconds`);
+    };
+  })
 }
 
 ```

--- a/docs/authentication-and-access-control/usage-in-web-requests.md
+++ b/docs/authentication-and-access-control/usage-in-web-requests.md
@@ -1,13 +1,13 @@
 # Usage in Web Requests
 
-FoalTS uses sessions and the `Authenticate` hook to authenticate users accross several requests.
+FoalTS uses sessions and the `AuthenticateWithSessionAndCookie` hook to authenticate users accross several requests.
 
-## The `Authenticate` Hook
+## The `AuthenticateWithSessionAndCookie` Hook
 
 It should decorate the `AppController`. If the user has already logged in in a previous request, then it will be available in the `context` with which the controller methods are called.
 
 ```ts
-@Authenticate(User)
+@AuthenticateWithSessionAndCookie(User)
 export class AppController {
   @Get('/foo')
   foo(ctx: Context) {

--- a/docs/tutorials/multi-user-todo-list/6-todos-and-ownership.md
+++ b/docs/tutorials/multi-user-todo-list/6-todos-and-ownership.md
@@ -17,7 +17,7 @@ Go back to the `ApiController` and update the `getTodos` route.
 > - an empty object called `state` that you can use to forward information between hooks, 
 > - and the `user` object that is defined if a user logged in.
 >
-> *Note:* To make the `user` available you need to use the `Authenticate` hook somewhere. Generally it decorates the `AppController`.
+> *Note:* To make the `user` available you need to use the `AuthenticateWithSessionAndCookie` hook somewhere. Generally it decorates the `AppController`.
 
 Refresh the todo-list page. You should only see the todos of the user with whom you logged in.
 

--- a/docs/tutorials/simple-todo-list/5-the-rest-api.md
+++ b/docs/tutorials/simple-todo-list/5-the-rest-api.md
@@ -100,12 +100,12 @@ The last thing to know is how the `ApiController` is bound to the request handle
 Open the file `app.controller.ts` in `src/app`.
 
 ```typescript
-import { Authenticate, controller } from '@foal/core';
+import { AuthenticateWithSessionAndCookie, controller } from '@foal/core';
 
 import { ApiController, ViewController } from './controllers';
 import { User } from './entities';
 
-@Authenticate(User)
+@AuthenticateWithSessionAndCookie(User)
 export class AppController {
   subControllers = [
     controller('/', ViewController),
@@ -118,4 +118,4 @@ This controller is the main controller of the application. It is directly called
 
 In that case, the `--register` flag directly added a new line to declare the `ApiController` as a sub-controller of `AppController`. The `ViewController` is in charge of rendering the `index.html` template.
 
-> The `Authenticate` decorator is useless here as you will not use authentication in this tutorial. You can remove it if you want.
+> The `AuthenticateWithSessionAndCookie` decorator is useless here as you will not use authentication in this tutorial. You can remove it if you want.

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.6.0-beta.6"
+  "version": "0.6.0"
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,6 +40,29 @@ Documentation: [https://foalts.gitbook.io/docs/](https://foalts.gitbook.io/docs/
 
 ## Description
 
+FoalTS is a high-level Node.JS framework to quickly build complete web apps in TypeScript. Thanks to its architecture, packages and tools FoalTS lets you bootstrap and develop entreprise-grade applications.
+
+
+## Get started
+
+First install [Node.Js and npm](https://nodejs.org/en/download/).
+
+### Create a new app
+
+```
+$ npm install -g @foal/cli
+$ foal createapp my-app
+$ cd my-app && npm install
+$ npm run develop
+```
+
+The development server is started! Go to `http://localhost:3000` and find our welcoming page!
+
+[=> Continue with the tutorial](https://foalts.gitbook.io/docs/content/)
+
+
+## Why?
+
 In recent years Node.js has become one of the most popular servers on the web. And for good reason, it is fast, simple while being powerful and flexible. Creating a server with only a few lines of code has never been easier. 
 
 But when it comes to setting up a complete and scalable project, things get harder. You have to put everything in place. The authorization system, database migrations, development tools or even encryption of passwords are just the tip of the iceberg. Working on this is time consuming and may slow down the release frequency or even lead to undesired bugs. As the codebase grows up and the complexity increases, it becomes harder and harder to develop new features and maintain the app.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,10 +6,10 @@
   "types": "./lib/index.d.ts",
   "scripts": {
     "test": "npm run test:generators && npm run test:run-script",
-    "test:generators": "NODE_ENV=test mocha --require ts-node/register \"./src/generate/generators/**/*.spec.ts\"",
-    "dev:test:generators": "NODE_ENV=test mocha --require ts-node/register --watch --watch-extensions ts \"./src/generate/generators/**/*.spec.ts\"",
-    "test:run-script": "NODE_ENV=test mocha --require ts-node/register \"./src/run-script/**/*.spec.ts\"",
-    "dev:test:run-script": "NODE_ENV=test mocha --require ts-node/register --watch --watch-extensions ts \"./src/run-script/**/*.spec.ts\"",
+    "test:generators": "mocha --file \"./src/test.ts\" --require ts-node/register \"./src/generate/generators/**/*.spec.ts\"",
+    "dev:test:generators": "mocha --file \"./src/test.ts\" --require ts-node/register --watch --watch-extensions ts \"./src/generate/generators/**/*.spec.ts\"",
+    "test:run-script": "mocha --file \"./src/test.ts\" --require ts-node/register \"./src/run-script/**/*.spec.ts\"",
+    "dev:test:run-script": "mocha --file \"./src/test.ts\" --require ts-node/register --watch --watch-extensions ts \"./src/run-script/**/*.spec.ts\"",
     "build": "rimraf lib && tsc -p tsconfig-build.json && copyfiles -u 3 \"src/generate/templates/**/*\" lib/generate/templates",
     "prepublish": "npm run build"
   },
@@ -57,7 +57,7 @@
     "@types/mocha": "^5.2.0",
     "@types/node": "^10.1.2",
     "copyfiles": "^2.0.0",
-    "mocha": "^3.5.3",
+    "mocha": "^5.2.0",
     "rimraf": "^2.6.2",
     "ts-node": "^3.3.0",
     "typescript": "^2.5.2"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foal/cli",
-  "version": "0.6.0-beta.6",
+  "version": "0.6.0",
   "description": "CLI tool for FoalTS",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -35,8 +35,8 @@
     "node": ">=8"
   },
   "dependencies": {
-    "@foal/core": "0.6.0-beta.6",
-    "@foal/ejs": "0.6.0-beta.5",
+    "@foal/core": "~0.6.0",
+    "@foal/ejs": "~0.6.0",
     "source-map-support": "^0.5.1",
     "sqlite3": "^4.0.0",
     "connect-sqlite3": "^0.9.11",

--- a/packages/cli/src/generate/specs/app/src/app/app.controller.ts
+++ b/packages/cli/src/generate/specs/app/src/app/app.controller.ts
@@ -1,9 +1,9 @@
-import { Authenticate, controller } from '@foal/core';
+import { AuthenticateWithSessionAndCookie, controller } from '@foal/core';
 
 import { ViewController } from './controllers';
 import { User } from './entities';
 
-@Authenticate(User)
+@AuthenticateWithSessionAndCookie(User)
 export class AppController {
   subControllers = [
     controller('/', ViewController),

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -35,8 +35,8 @@
     "node": ">=8"
   },
   "dependencies": {
-    "@foal/core": "0.6.0-beta.6",
-    "@foal/ejs": "0.6.0-beta.5",
+    "@foal/core": "~0.6.0",
+    "@foal/ejs": "~0.6.0",
     "source-map-support": "^0.5.1",
     "sqlite3": "^4.0.0",
     "connect-sqlite3": "^0.9.11",

--- a/packages/cli/src/generate/templates/app/src/app/app.controller.ts
+++ b/packages/cli/src/generate/templates/app/src/app/app.controller.ts
@@ -1,9 +1,9 @@
-import { Authenticate, controller } from '@foal/core';
+import { AuthenticateWithSessionAndCookie, controller } from '@foal/core';
 
 import { ViewController } from './controllers';
 import { User } from './entities';
 
-@Authenticate(User)
+@AuthenticateWithSessionAndCookie(User)
 export class AppController {
   subControllers = [
     controller('/', ViewController),

--- a/packages/cli/src/generate/utils/test-environment.ts
+++ b/packages/cli/src/generate/utils/test-environment.ts
@@ -48,7 +48,7 @@ export class TestEnvironment {
       join(this.root, filePath),
       'utf8'
     );
-    strictEqual(actual, spec);
+    strictEqual(actual.replace(/\r\n/g, '\n'), spec.replace(/\r\n/g, '\n'));
     return this;
   }
 

--- a/packages/cli/src/test.ts
+++ b/packages/cli/src/test.ts
@@ -1,0 +1,1 @@
+process.env.NODE_ENV = 'test';

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -43,6 +43,29 @@ Documentation: [https://foalts.gitbook.io/docs/](https://foalts.gitbook.io/docs/
 
 ## Description
 
+FoalTS is a high-level Node.JS framework to quickly build complete web apps in TypeScript. Thanks to its architecture, packages and tools FoalTS lets you bootstrap and develop entreprise-grade applications.
+
+
+## Get started
+
+First install [Node.Js and npm](https://nodejs.org/en/download/).
+
+### Create a new app
+
+```
+$ npm install -g @foal/cli
+$ foal createapp my-app
+$ cd my-app && npm install
+$ npm run develop
+```
+
+The development server is started! Go to `http://localhost:3000` and find our welcoming page!
+
+[=> Continue with the tutorial](https://foalts.gitbook.io/docs/content/)
+
+
+## Why?
+
 In recent years Node.js has become one of the most popular servers on the web. And for good reason, it is fast, simple while being powerful and flexible. Creating a server with only a few lines of code has never been easier. 
 
 But when it comes to setting up a complete and scalable project, things get harder. You have to put everything in place. The authorization system, database migrations, development tools or even encryption of passwords are just the tip of the iceberg. Working on this is time consuming and may slow down the release frequency or even lead to undesired bugs. As the codebase grows up and the complexity increases, it becomes harder and harder to develop new features and maintain the app.

--- a/packages/core/e2e/auth.spec.ts
+++ b/packages/core/e2e/auth.spec.ts
@@ -8,7 +8,7 @@ import { Column, createConnection, Entity, getConnection, getRepository } from '
 // FoalTS
 import {
   AbstractUser,
-  Authenticate,
+  AuthenticateWithSessionAndCookie,
   createApp,
   EmailAuthenticator,
   emailSchema,
@@ -57,7 +57,7 @@ it('Authentication and authorization', async () => {
     ];
   }
 
-  @Authenticate(User)
+  @AuthenticateWithSessionAndCookie(User)
   class AppController {
     subControllers = [
       MyController,

--- a/packages/core/e2e/rest.spec.ts
+++ b/packages/core/e2e/rest.spec.ts
@@ -17,7 +17,7 @@ import {
 // FoalTS
 import {
   AbstractUser,
-  Authenticate,
+  AuthenticateWithSessionAndCookie,
   controller,
   createApp,
   dependency,
@@ -137,7 +137,7 @@ xit('REST API with RestController and EntityResourceCollection', async () => {
     ];
   }
 
-  @Authenticate(User)
+  @AuthenticateWithSessionAndCookie(User)
   class AppController {
     subControllers = [
       controller('/users', UserController),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -92,7 +92,7 @@
     "@types/mocha": "^2.2.43",
     "@types/node": "^10.1.2",
     "@types/supertest": "^2.0.5",
-    "mocha": "^3.5.3",
+    "mocha": "^5.2.0",
     "mysql": "^2.15.0",
     "node-mocks-http": "^1.7.0",
     "nyc": "^12.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foal/core",
-  "version": "0.6.0-beta.6",
+  "version": "0.6.0",
   "description": "High level web framework to create enterprise-grade Node.JS applications.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -88,7 +88,7 @@
     "typeorm": "^0.2.6"
   },
   "devDependencies": {
-    "@foal/ejs": "^0.6.0-beta.5",
+    "@foal/ejs": "^0.6.0",
     "@types/mocha": "^2.2.43",
     "@types/node": "^10.1.2",
     "@types/supertest": "^2.0.5",

--- a/packages/core/src/auth/authentication/authenticate.hook.spec.ts
+++ b/packages/core/src/auth/authentication/authenticate.hook.spec.ts
@@ -60,7 +60,7 @@ describe('Authenticate', () => {
     const preHook = getHookFunction(Authenticate(User));
     const ctx = new Context({});
 
-    return preHook(ctx, new ServiceManager())
+    return (preHook(ctx, new ServiceManager()) as Promise<any>)
       .then(() => fail('The promise should be rejected'))
       .catch(err => strictEqual(err.message, 'Authenticate hook requires session management.'));
   });

--- a/packages/core/src/auth/authentication/authenticate.hook.spec.ts
+++ b/packages/core/src/auth/authentication/authenticate.hook.spec.ts
@@ -11,9 +11,9 @@ import {
   ServiceManager,
 } from '../../core';
 import { AbstractUser, Group, Permission } from '../entities';
-import { Authenticate } from './authenticate.hook';
+import { AuthenticateWithSessionAndCookie } from './authenticate.hook';
 
-describe('Authenticate', () => {
+describe('AuthenticateWithSessionAndCookie', () => {
 
   @Entity()
   class User extends AbstractUser {
@@ -57,16 +57,16 @@ describe('Authenticate', () => {
   afterEach(() => getConnection().close());
 
   it('should throw an Error if there is no session.', () => {
-    const preHook = getHookFunction(Authenticate(User));
+    const preHook = getHookFunction(AuthenticateWithSessionAndCookie(User));
     const ctx = new Context({});
 
     return (preHook(ctx, new ServiceManager()) as Promise<any>)
       .then(() => fail('The promise should be rejected'))
-      .catch(err => strictEqual(err.message, 'Authenticate hook requires session management.'));
+      .catch(err => strictEqual(err.message, 'AuthenticateWithSessionAndCookie hook requires session management.'));
   });
 
   it('should not throw an Error if the session does not have an `authentication.userId` property.', async () => {
-    const preHook = getHookFunction(Authenticate(User));
+    const preHook = getHookFunction(AuthenticateWithSessionAndCookie(User));
     const ctx = new Context({});
 
     ctx.request.session = {};
@@ -77,7 +77,7 @@ describe('Authenticate', () => {
   });
 
   it('should set ctx.user to undefined if no user is found in the database matching the given id.', async () => {
-    const hook = getHookFunction(Authenticate(User));
+    const hook = getHookFunction(AuthenticateWithSessionAndCookie(User));
     const ctx = new Context({});
 
     ctx.request.session = {
@@ -92,7 +92,7 @@ describe('Authenticate', () => {
 
   it('should add a user property (with all its groups and permissions) if a user matches'
       + ' the given id in the database.', async () => {
-    const hook = getHookFunction(Authenticate(User));
+    const hook = getHookFunction(AuthenticateWithSessionAndCookie(User));
     const ctx = new Context({});
 
     ctx.request.session = {

--- a/packages/core/src/auth/authentication/authenticate.hook.ts
+++ b/packages/core/src/auth/authentication/authenticate.hook.ts
@@ -3,10 +3,10 @@ import { getManager } from 'typeorm';
 import { Class, Hook, HookDecorator } from '../../core';
 import { AbstractUser } from '../entities';
 
-export function Authenticate(UserEntity: Class<AbstractUser>): HookDecorator {
+export function AuthenticateWithSessionAndCookie(UserEntity: Class<AbstractUser>): HookDecorator {
   return Hook(async ctx => {
     if (!ctx.request.session) {
-      throw new Error('Authenticate hook requires session management.');
+      throw new Error('AuthenticateWithSessionAndCookie hook requires session management.');
     }
     if (!ctx.request.session.authentication || !ctx.request.session.authentication.hasOwnProperty('userId')) {
       return;

--- a/packages/core/src/core/hooks.spec.ts
+++ b/packages/core/src/core/hooks.spec.ts
@@ -9,8 +9,8 @@ import { getHookFunction, Hook, HookFunction } from './hooks';
 
 describe('Hook', () => {
 
-  const hook1: HookFunction = () => {};
-  const hook2: HookFunction = () => {};
+  const hook1: HookFunction = () => { return; };
+  const hook2: HookFunction = () => undefined;
 
   it('should add the hook to the metadata hooks on the method class.', () => {
     class Foobar {

--- a/packages/core/src/core/hooks.ts
+++ b/packages/core/src/core/hooks.ts
@@ -2,11 +2,12 @@
 import 'reflect-metadata';
 
 // FoalTS
-import { Context } from './http';
+import { Context, HttpResponse } from './http';
 import { ServiceManager } from './service-manager';
 
-// not void. HttpResponse or HttpResponse | void (same with promises)
-export type HookFunction = (ctx: Context, services: ServiceManager) => any;
+export type HookPostFunction = (ctx: Context, services: ServiceManager, response: HttpResponse) => void | Promise<void>;
+export type HookFunction = (ctx: Context, services: ServiceManager) =>
+  void | HttpResponse | HookPostFunction | Promise <void | HttpResponse | HookPostFunction>;
 export type HookDecorator = (target: any, propertyKey?: string) => any;
 
 export function Hook(hookFunction: HookFunction): HookDecorator {

--- a/packages/core/src/core/http/http-methods.spec.ts
+++ b/packages/core/src/core/http/http-methods.spec.ts
@@ -5,7 +5,55 @@ import { strictEqual } from 'assert';
 import 'reflect-metadata';
 
 // FoalTS
-import { Delete, Get, Patch, Post, Put } from './http-methods';
+import { Delete, Get, Head, Options, Patch, Post, Put } from './http-methods';
+
+describe('Head', () => {
+
+  it('should define the metadata httpMethod="HEAD" on the method class.', () => {
+    class Foobar {
+      @Head()
+      barfoo() {}
+    }
+
+    const actual = Reflect.getOwnMetadata('httpMethod', Foobar.prototype, 'barfoo');
+    strictEqual(actual, 'HEAD');
+  });
+
+  it('should define the metadata path=${path} on the method class.', () => {
+    class Foobar {
+      @Head('/foo')
+      barfoo() {}
+    }
+
+    const actual = Reflect.getOwnMetadata('path', Foobar.prototype, 'barfoo');
+    strictEqual(actual, '/foo');
+  });
+
+});
+
+describe('Options', () => {
+
+  it('should define the metadata httpMethod="OPTIONS" on the method class.', () => {
+    class Foobar {
+      @Options()
+      barfoo() {}
+    }
+
+    const actual = Reflect.getOwnMetadata('httpMethod', Foobar.prototype, 'barfoo');
+    strictEqual(actual, 'OPTIONS');
+  });
+
+  it('should define the metadata path=${path} on the method class.', () => {
+    class Foobar {
+      @Options('/foo')
+      barfoo() {}
+    }
+
+    const actual = Reflect.getOwnMetadata('path', Foobar.prototype, 'barfoo');
+    strictEqual(actual, '/foo');
+  });
+
+});
 
 describe('Get', () => {
 

--- a/packages/core/src/core/http/http-methods.ts
+++ b/packages/core/src/core/http/http-methods.ts
@@ -1,7 +1,21 @@
 // 3p
 import 'reflect-metadata';
 
-export type HttpMethod = 'POST' | 'GET' | 'PUT' | 'PATCH' | 'DELETE';
+export type HttpMethod = 'POST' | 'GET' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
+
+export function Head(path?: string) {
+  return (target: any, propertyKey: string) => {
+    Reflect.defineMetadata('httpMethod', 'HEAD', target, propertyKey);
+    Reflect.defineMetadata('path', path, target, propertyKey);
+  };
+}
+
+export function Options(path?: string) {
+  return (target: any, propertyKey: string) => {
+    Reflect.defineMetadata('httpMethod', 'OPTIONS', target, propertyKey);
+    Reflect.defineMetadata('path', path, target, propertyKey);
+  };
+}
 
 export function Get(path?: string) {
   return (target: any, propertyKey: string) => {

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -7,7 +7,7 @@ import { MemoryStore } from 'express-session';
 import * as request from 'supertest';
 
 // FoalTS
-import { Context, Delete, Get, HttpResponseOK, Patch, Post, Put } from '../core';
+import { Context, Delete, Get, Head, HttpResponseOK, Options, Patch, Post, Put } from '../core';
 import { createApp } from './create-app';
 
 describe('createApp', () => {
@@ -34,10 +34,12 @@ describe('createApp', () => {
       request(app).patch('/foo').expect(404),
       request(app).put('/foo').expect(404),
       request(app).delete('/foo').expect(404),
+      request(app).head('/foo').expect(404),
+      request(app).options('/foo').expect(404),
     ]);
   });
 
-  it('should respond on DELETE, GET, PATCH, POST and PUT requests if a handler exists.', () => {
+  it('should respond on DELETE, GET, PATCH, POST, PUT, HEAD and OPTIONS requests if a handler exists.', () => {
     class MyController {
       @Get('/foo')
       get() {
@@ -59,6 +61,15 @@ describe('createApp', () => {
       delete() {
         return new HttpResponseOK('delete');
       }
+      @Head('/foo')
+      head() {
+        // A HEAD response does not have a body.
+        return new HttpResponseOK();
+      }
+      @Options('/foo')
+      options() {
+        return new HttpResponseOK('options');
+      }
     }
     const app = createApp(MyController);
     return Promise.all([
@@ -67,6 +78,8 @@ describe('createApp', () => {
       request(app).patch('/foo').expect('patch'),
       request(app).put('/foo').expect('put'),
       request(app).delete('/foo').expect('delete'),
+      request(app).head('/foo').expect(200),
+      request(app).options('/foo').expect('options'),
     ]);
   });
 

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -3,6 +3,7 @@ import { strictEqual } from 'assert';
 import { promisify } from 'util';
 
 // 3p
+import * as express from 'express';
 import { MemoryStore } from 'express-session';
 import * as request from 'supertest';
 
@@ -141,6 +142,14 @@ describe('createApp', () => {
     sessions = await promisify(store.all.bind(store))();
     strictEqual(Object.keys(sessions).length, 1);
   });
+
+  it('should use the optional express instance if one is given.', () => {
+    const expected = express();
+    const actual = createApp(class {}, {}, expected);
+
+    strictEqual(actual, expected);
+  });
+
 });
 
 // function httpMethodTest(httpMethod: HttpMethod) {

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -73,6 +73,12 @@ export function createApp(rootControllerClass: Class, options: CreateAppOptions 
       case 'PUT':
         app.put(route.path, createMiddleware(route, services));
         break;
+      case 'HEAD':
+        app.head(route.path, createMiddleware(route, services));
+        break;
+      case 'OPTIONS':
+        app.options(route.path, createMiddleware(route, services));
+        break;
     }
   }
   app.use(notFound());

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -1,11 +1,14 @@
+// std
 import * as path from 'path';
 
+// 3p
 import * as csurf from 'csurf';
 import * as express from 'express';
 import * as session from 'express-session';
 import * as helmet from 'helmet';
 import * as logger from 'morgan';
 
+// FoalTS
 import {
   Class,
   Config,
@@ -20,8 +23,14 @@ export interface CreateAppOptions {
   store?(session): any;
 }
 
-export function createApp(rootControllerClass: Class, options: CreateAppOptions = {}) {
-  const app = express();
+/**
+ * Main function to create a node.js (express) application from the root controller.
+ * @param rootControllerClass The root controller, usually called `AppController`
+ * @param options Optional options to specify the session store (default is MemoryStore)
+ * @param expressInstance Optional express instance to be used as base.
+ */
+export function createApp(rootControllerClass: Class, options: CreateAppOptions = {}, expressInstance?) {
+  const app = expressInstance || express();
 
   app.use(logger('[:date] ":method :url HTTP/:http-version" :status - :response-time ms'));
   app.use(express.static(path.join(process.cwd(), Config.get('settings', 'staticUrl', '/public') as string)));

--- a/packages/ejs/README.md
+++ b/packages/ejs/README.md
@@ -43,6 +43,29 @@ Documentation: [https://foalts.gitbook.io/docs/](https://foalts.gitbook.io/docs/
 
 ## Description
 
+FoalTS is a high-level Node.JS framework to quickly build complete web apps in TypeScript. Thanks to its architecture, packages and tools FoalTS lets you bootstrap and develop entreprise-grade applications.
+
+
+## Get started
+
+First install [Node.Js and npm](https://nodejs.org/en/download/).
+
+### Create a new app
+
+```
+$ npm install -g @foal/cli
+$ foal createapp my-app
+$ cd my-app && npm install
+$ npm run develop
+```
+
+The development server is started! Go to `http://localhost:3000` and find our welcoming page!
+
+[=> Continue with the tutorial](https://foalts.gitbook.io/docs/content/)
+
+
+## Why?
+
 In recent years Node.js has become one of the most popular servers on the web. And for good reason, it is fast, simple while being powerful and flexible. Creating a server with only a few lines of code has never been easier. 
 
 But when it comes to setting up a complete and scalable project, things get harder. You have to put everything in place. The authorization system, database migrations, development tools or even encryption of passwords are just the tip of the iceberg. Working on this is time consuming and may slow down the release frequency or even lead to undesired bugs. As the codebase grows up and the complexity increases, it becomes harder and harder to develop new features and maintain the app.

--- a/packages/ejs/package.json
+++ b/packages/ejs/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@types/mocha": "^2.2.43",
     "@types/node": "^10.5.6",
-    "mocha": "^3.5.3",
+    "mocha": "^5.2.0",
     "rimraf": "^2.6.2",
     "ts-node": "^3.3.0",
     "typescript": "^2.5.2"

--- a/packages/ejs/package.json
+++ b/packages/ejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foal/ejs",
-  "version": "0.6.0-beta.5",
+  "version": "0.6.0",
   "description": "EJS template package for FoalTS",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -4,7 +4,6 @@
 ![node version](https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg)
 [![npm version](https://badge.fury.io/js/%40foal%2Fexamples.svg)](https://badge.fury.io/js/%40foal%2Fexamples)
 [![Build Status](https://travis-ci.org/FoalTS/foal.svg?branch=add-travis)](https://travis-ci.org/FoalTS/foal)
-[![Known Vulnerabilities](https://snyk.io/test/github/foalts/foal/badge.svg?targetFile=packages%2Fexamples%2Fpackage.json)](https://snyk.io/test/github/foalts/foal?targetFile=packages%2Fexamples%2Fpackage.json)
 
 Web framework to create enterprise-grade Node.JS applications .
 

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -54,7 +54,7 @@
     "@types/node": "^10.1.1",
     "concurrently": "^3.5.1",
     "copy": "^0.3.2",
-    "mocha": "^4.0.1",
+    "mocha": "^5.2.0",
     "supervisor": "^0.12.0",
     "typescript": "^2.5.3"
   }

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foal/examples",
-  "version": "0.6.0-beta.6",
+  "version": "0.6.0",
   "description": "FoalTs examples",
   "scripts": {
     "build": "tsc && copy-cli \"src/**/*.html\" lib",
@@ -40,8 +40,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@foal/core": "^0.6.0-beta.6",
-    "@foal/ejs": "^0.6.0-beta.5",
+    "@foal/core": "^0.6.0",
+    "@foal/ejs": "^0.6.0",
     "bootstrap": "^4.0.0",
     "connect-sqlite3": "^0.9.11",
     "source-map-support": "^0.5.6",
@@ -49,7 +49,7 @@
     "typeorm": "^0.2.6"
   },
   "devDependencies": {
-    "@foal/cli": "^0.6.0-beta.6",
+    "@foal/cli": "^0.6.0",
     "@types/mocha": "^2.2.43",
     "@types/node": "^10.1.1",
     "concurrently": "^3.5.1",

--- a/packages/examples/src/app/app.controller.ts
+++ b/packages/examples/src/app/app.controller.ts
@@ -1,12 +1,12 @@
 import {
-  Authenticate,
+  AuthenticateWithSessionAndCookie,
   controller,
 } from '@foal/core';
 
 import { AuthController, ViewController } from './controllers';
 import { User } from './entities';
 
-@Authenticate(User)
+@AuthenticateWithSessionAndCookie(User)
 export class AppController {
   subControllers = [
     controller('', AuthController),

--- a/packages/password/README.md
+++ b/packages/password/README.md
@@ -43,6 +43,29 @@ Documentation: [https://foalts.gitbook.io/docs/](https://foalts.gitbook.io/docs/
 
 ## Description
 
+FoalTS is a high-level Node.JS framework to quickly build complete web apps in TypeScript. Thanks to its architecture, packages and tools FoalTS lets you bootstrap and develop entreprise-grade applications.
+
+
+## Get started
+
+First install [Node.Js and npm](https://nodejs.org/en/download/).
+
+### Create a new app
+
+```
+$ npm install -g @foal/cli
+$ foal createapp my-app
+$ cd my-app && npm install
+$ npm run develop
+```
+
+The development server is started! Go to `http://localhost:3000` and find our welcoming page!
+
+[=> Continue with the tutorial](https://foalts.gitbook.io/docs/content/)
+
+
+## Why?
+
 In recent years Node.js has become one of the most popular servers on the web. And for good reason, it is fast, simple while being powerful and flexible. Creating a server with only a few lines of code has never been easier. 
 
 But when it comes to setting up a complete and scalable project, things get harder. You have to put everything in place. The authorization system, database migrations, development tools or even encryption of passwords are just the tip of the iceberg. Working on this is time consuming and may slow down the release frequency or even lead to undesired bugs. As the codebase grows up and the complexity increases, it becomes harder and harder to develop new features and maintain the app.

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -40,7 +40,7 @@
     "@types/mocha": "^2.2.43",
     "@types/node": "^10.5.6",
     "copy": "^0.3.2",
-    "mocha": "^3.5.3",
+    "mocha": "^5.2.0",
     "rimraf": "^2.6.2",
     "ts-node": "^3.3.0",
     "typescript": "^2.5.2"

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foal/password",
-  "version": "0.6.0-beta.5",
+  "version": "0.6.0",
   "description": "Password utilities for FoalTS",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
# Features

- [x] Let hooks execute functions after the method execution (https://github.com/FoalTS/foal/pull/253).
- [x] Let createApp accept a custom express instance as base (https://github.com/FoalTS/foal/pull/264).
- [x] Support the missing HTTP methods `HEAD` and `OPTIONS` (https://github.com/FoalTS/foal/pull/262).
- [x] [Internal] Make the CLI unit tests work on Windows (issue: https://github.com/FoalTS/foal/issues/207) (https://github.com/FoalTS/foal/pull/260, https://github.com/FoalTS/foal/pull/261).
- [x] Rename the hook `Authenticate` to `AuthenticateWithSessionAndCookie` (https://github.com/FoalTS/foal/pull/263).

# Breaking changes

- The returned type of a hook function is now `void | HttpResponse | HookPostFunction | Promise <void | HttpResponse | HookPostFunction>` and not `any` anymore.
 This means that if you have a hook defined like `@Hook(ctx => ctx.state.foo = 2)`, you to have update its definition as follows: `@Hook(ctx => { ctx.state.foo = 2; })`
- The hook `Authenticate` is now named `AuthenticateWithSessionAndCookie`.

# Contributors

@LoicPoullain 
@Jrfidellis 