### PR TITLE
Add OPTIONS and HEAD http methods.

### DIFF
--- a/docs/architecture/controllers.md
+++ b/docs/architecture/controllers.md
@@ -25,7 +25,7 @@ Controllers are the front door of your application. They catch all the incoming 
 
 ### Creating a controller
 
-Formally a controller is a single class that is instantiated as a singleton. The methods that handle the requests take also a decorator: `Get`, `Post`, `Patch`, `Put` or `Delete`. Each method with one of theses decorators is responsible for one route.
+Formally a controller is a single class that is instantiated as a singleton. The methods that handle the requests take also a decorator: `Get`, `Post`, `Patch`, `Put`, `Delete`, `Head` or `Options`. Each method with one of theses decorators is responsible for one route.
 
 ```typescript
 import { Context, Get, HttpResponseOK } from '@foal/core';
@@ -143,7 +143,7 @@ class ChildController extends ParentController {
 }
 ```
 
-You can also override `foo`. If you don't add a `Get`, `Post`, `Patch`, `Put` or `Delete` decorator then the parent path and HTTP method are used. If you don't add a hook, then the parent hooks are used. Otherwise they are all discarded.
+You can also override `foo`. If you don't add a `Get`, `Post`, `Patch`, `Put`, `Delete`, `Head` or `Options` decorator then the parent path and HTTP method are used. If you don't add a hook, then the parent hooks are used. Otherwise they are all discarded.
 
 ## Using sub-controllers
 

--- a/packages/core/src/core/http/http-methods.spec.ts
+++ b/packages/core/src/core/http/http-methods.spec.ts
@@ -5,7 +5,55 @@ import { strictEqual } from 'assert';
 import 'reflect-metadata';
 
 // FoalTS
-import { Delete, Get, Patch, Post, Put } from './http-methods';
+import { Delete, Get, Head, Options, Patch, Post, Put } from './http-methods';
+
+describe('Head', () => {
+
+  it('should define the metadata httpMethod="HEAD" on the method class.', () => {
+    class Foobar {
+      @Head()
+      barfoo() {}
+    }
+
+    const actual = Reflect.getOwnMetadata('httpMethod', Foobar.prototype, 'barfoo');
+    strictEqual(actual, 'HEAD');
+  });
+
+  it('should define the metadata path=${path} on the method class.', () => {
+    class Foobar {
+      @Head('/foo')
+      barfoo() {}
+    }
+
+    const actual = Reflect.getOwnMetadata('path', Foobar.prototype, 'barfoo');
+    strictEqual(actual, '/foo');
+  });
+
+});
+
+describe('Options', () => {
+
+  it('should define the metadata httpMethod="OPTIONS" on the method class.', () => {
+    class Foobar {
+      @Options()
+      barfoo() {}
+    }
+
+    const actual = Reflect.getOwnMetadata('httpMethod', Foobar.prototype, 'barfoo');
+    strictEqual(actual, 'OPTIONS');
+  });
+
+  it('should define the metadata path=${path} on the method class.', () => {
+    class Foobar {
+      @Options('/foo')
+      barfoo() {}
+    }
+
+    const actual = Reflect.getOwnMetadata('path', Foobar.prototype, 'barfoo');
+    strictEqual(actual, '/foo');
+  });
+
+});
 
 describe('Get', () => {
 

--- a/packages/core/src/core/http/http-methods.ts
+++ b/packages/core/src/core/http/http-methods.ts
@@ -1,7 +1,21 @@
 // 3p
 import 'reflect-metadata';
 
-export type HttpMethod = 'POST' | 'GET' | 'PUT' | 'PATCH' | 'DELETE';
+export type HttpMethod = 'POST' | 'GET' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
+
+export function Head(path?: string) {
+  return (target: any, propertyKey: string) => {
+    Reflect.defineMetadata('httpMethod', 'HEAD', target, propertyKey);
+    Reflect.defineMetadata('path', path, target, propertyKey);
+  };
+}
+
+export function Options(path?: string) {
+  return (target: any, propertyKey: string) => {
+    Reflect.defineMetadata('httpMethod', 'OPTIONS', target, propertyKey);
+    Reflect.defineMetadata('path', path, target, propertyKey);
+  };
+}
 
 export function Get(path?: string) {
   return (target: any, propertyKey: string) => {

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -7,7 +7,7 @@ import { MemoryStore } from 'express-session';
 import * as request from 'supertest';
 
 // FoalTS
-import { Context, Delete, Get, HttpResponseOK, Patch, Post, Put } from '../core';
+import { Context, Delete, Get, Head, HttpResponseOK, Options, Patch, Post, Put } from '../core';
 import { createApp } from './create-app';
 
 describe('createApp', () => {
@@ -34,10 +34,12 @@ describe('createApp', () => {
       request(app).patch('/foo').expect(404),
       request(app).put('/foo').expect(404),
       request(app).delete('/foo').expect(404),
+      request(app).head('/foo').expect(404),
+      request(app).options('/foo').expect(404),
     ]);
   });
 
-  it('should respond on DELETE, GET, PATCH, POST and PUT requests if a handler exists.', () => {
+  it('should respond on DELETE, GET, PATCH, POST, PUT, HEAD and OPTIONS requests if a handler exists.', () => {
     class MyController {
       @Get('/foo')
       get() {
@@ -59,6 +61,15 @@ describe('createApp', () => {
       delete() {
         return new HttpResponseOK('delete');
       }
+      @Head('/foo')
+      head() {
+        // A HEAD response does not have a body.
+        return new HttpResponseOK();
+      }
+      @Options('/foo')
+      options() {
+        return new HttpResponseOK('options');
+      }
     }
     const app = createApp(MyController);
     return Promise.all([
@@ -67,6 +78,8 @@ describe('createApp', () => {
       request(app).patch('/foo').expect('patch'),
       request(app).put('/foo').expect('put'),
       request(app).delete('/foo').expect('delete'),
+      request(app).head('/foo').expect(200),
+      request(app).options('/foo').expect('options'),
     ]);
   });
 

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -73,6 +73,12 @@ export function createApp(rootControllerClass: Class, options: CreateAppOptions 
       case 'PUT':
         app.put(route.path, createMiddleware(route, services));
         break;
+      case 'HEAD':
+        app.head(route.path, createMiddleware(route, services));
+        break;
+      case 'OPTIONS':
+        app.options(route.path, createMiddleware(route, services));
+        break;
     }
   }
   app.use(notFound());


### PR DESCRIPTION
# Issue

The HTTP methods `OPTIONS` and `HEAD` are currently not supported. This causes trouble especially when it deals to create a public API (see https://github.com/FoalTS/foal/issues/259).

# Solution and steps

- [x] Add the decorators `Options` and `Head`.
- [x] Add the support of these methods in `createApp`.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.