### PR TITLE
Rename Authenticate to AuthenticateWithSessionAndCookie

### DIFF
--- a/docs/authentication-and-access-control/usage-in-web-requests.md
+++ b/docs/authentication-and-access-control/usage-in-web-requests.md
@@ -1,13 +1,13 @@
 # Usage in Web Requests
 
-FoalTS uses sessions and the `Authenticate` hook to authenticate users accross several requests.
+FoalTS uses sessions and the `AuthenticateWithSessionAndCookie` hook to authenticate users accross several requests.
 
-## The `Authenticate` Hook
+## The `AuthenticateWithSessionAndCookie` Hook
 
 It should decorate the `AppController`. If the user has already logged in in a previous request, then it will be available in the `context` with which the controller methods are called.
 
 ```ts
-@Authenticate(User)
+@AuthenticateWithSessionAndCookie(User)
 export class AppController {
   @Get('/foo')
   foo(ctx: Context) {

--- a/docs/tutorials/multi-user-todo-list/6-todos-and-ownership.md
+++ b/docs/tutorials/multi-user-todo-list/6-todos-and-ownership.md
@@ -17,7 +17,7 @@ Go back to the `ApiController` and update the `getTodos` route.
 > - an empty object called `state` that you can use to forward information between hooks, 
 > - and the `user` object that is defined if a user logged in.
 >
-> *Note:* To make the `user` available you need to use the `Authenticate` hook somewhere. Generally it decorates the `AppController`.
+> *Note:* To make the `user` available you need to use the `AuthenticateWithSessionAndCookie` hook somewhere. Generally it decorates the `AppController`.
 
 Refresh the todo-list page. You should only see the todos of the user with whom you logged in.
 

--- a/docs/tutorials/simple-todo-list/5-the-rest-api.md
+++ b/docs/tutorials/simple-todo-list/5-the-rest-api.md
@@ -100,12 +100,12 @@ The last thing to know is how the `ApiController` is bound to the request handle
 Open the file `app.controller.ts` in `src/app`.
 
 ```typescript
-import { Authenticate, controller } from '@foal/core';
+import { AuthenticateWithSessionAndCookie, controller } from '@foal/core';
 
 import { ApiController, ViewController } from './controllers';
 import { User } from './entities';
 
-@Authenticate(User)
+@AuthenticateWithSessionAndCookie(User)
 export class AppController {
   subControllers = [
     controller('/', ViewController),
@@ -118,4 +118,4 @@ This controller is the main controller of the application. It is directly called
 
 In that case, the `--register` flag directly added a new line to declare the `ApiController` as a sub-controller of `AppController`. The `ViewController` is in charge of rendering the `index.html` template.
 
-> The `Authenticate` decorator is useless here as you will not use authentication in this tutorial. You can remove it if you want.
+> The `AuthenticateWithSessionAndCookie` decorator is useless here as you will not use authentication in this tutorial. You can remove it if you want.

--- a/packages/cli/src/generate/specs/app/src/app/app.controller.ts
+++ b/packages/cli/src/generate/specs/app/src/app/app.controller.ts
@@ -1,9 +1,9 @@
-import { Authenticate, controller } from '@foal/core';
+import { AuthenticateWithSessionAndCookie, controller } from '@foal/core';
 
 import { ViewController } from './controllers';
 import { User } from './entities';
 
-@Authenticate(User)
+@AuthenticateWithSessionAndCookie(User)
 export class AppController {
   subControllers = [
     controller('/', ViewController),

--- a/packages/cli/src/generate/templates/app/src/app/app.controller.ts
+++ b/packages/cli/src/generate/templates/app/src/app/app.controller.ts
@@ -1,9 +1,9 @@
-import { Authenticate, controller } from '@foal/core';
+import { AuthenticateWithSessionAndCookie, controller } from '@foal/core';
 
 import { ViewController } from './controllers';
 import { User } from './entities';
 
-@Authenticate(User)
+@AuthenticateWithSessionAndCookie(User)
 export class AppController {
   subControllers = [
     controller('/', ViewController),

--- a/packages/core/e2e/auth.spec.ts
+++ b/packages/core/e2e/auth.spec.ts
@@ -8,7 +8,7 @@ import { Column, createConnection, Entity, getConnection, getRepository } from '
 // FoalTS
 import {
   AbstractUser,
-  Authenticate,
+  AuthenticateWithSessionAndCookie,
   createApp,
   EmailAuthenticator,
   emailSchema,
@@ -57,7 +57,7 @@ it('Authentication and authorization', async () => {
     ];
   }
 
-  @Authenticate(User)
+  @AuthenticateWithSessionAndCookie(User)
   class AppController {
     subControllers = [
       MyController,

--- a/packages/core/e2e/rest.spec.ts
+++ b/packages/core/e2e/rest.spec.ts
@@ -17,7 +17,7 @@ import {
 // FoalTS
 import {
   AbstractUser,
-  Authenticate,
+  AuthenticateWithSessionAndCookie,
   controller,
   createApp,
   dependency,
@@ -137,7 +137,7 @@ xit('REST API with RestController and EntityResourceCollection', async () => {
     ];
   }
 
-  @Authenticate(User)
+  @AuthenticateWithSessionAndCookie(User)
   class AppController {
     subControllers = [
       controller('/users', UserController),

--- a/packages/core/src/auth/authentication/authenticate.hook.spec.ts
+++ b/packages/core/src/auth/authentication/authenticate.hook.spec.ts
@@ -11,9 +11,9 @@ import {
   ServiceManager,
 } from '../../core';
 import { AbstractUser, Group, Permission } from '../entities';
-import { Authenticate } from './authenticate.hook';
+import { AuthenticateWithSessionAndCookie } from './authenticate.hook';
 
-describe('Authenticate', () => {
+describe('AuthenticateWithSessionAndCookie', () => {
 
   @Entity()
   class User extends AbstractUser {
@@ -57,16 +57,16 @@ describe('Authenticate', () => {
   afterEach(() => getConnection().close());
 
   it('should throw an Error if there is no session.', () => {
-    const preHook = getHookFunction(Authenticate(User));
+    const preHook = getHookFunction(AuthenticateWithSessionAndCookie(User));
     const ctx = new Context({});
 
     return (preHook(ctx, new ServiceManager()) as Promise<any>)
       .then(() => fail('The promise should be rejected'))
-      .catch(err => strictEqual(err.message, 'Authenticate hook requires session management.'));
+      .catch(err => strictEqual(err.message, 'AuthenticateWithSessionAndCookie hook requires session management.'));
   });
 
   it('should not throw an Error if the session does not have an `authentication.userId` property.', async () => {
-    const preHook = getHookFunction(Authenticate(User));
+    const preHook = getHookFunction(AuthenticateWithSessionAndCookie(User));
     const ctx = new Context({});
 
     ctx.request.session = {};
@@ -77,7 +77,7 @@ describe('Authenticate', () => {
   });
 
   it('should set ctx.user to undefined if no user is found in the database matching the given id.', async () => {
-    const hook = getHookFunction(Authenticate(User));
+    const hook = getHookFunction(AuthenticateWithSessionAndCookie(User));
     const ctx = new Context({});
 
     ctx.request.session = {
@@ -92,7 +92,7 @@ describe('Authenticate', () => {
 
   it('should add a user property (with all its groups and permissions) if a user matches'
       + ' the given id in the database.', async () => {
-    const hook = getHookFunction(Authenticate(User));
+    const hook = getHookFunction(AuthenticateWithSessionAndCookie(User));
     const ctx = new Context({});
 
     ctx.request.session = {

--- a/packages/core/src/auth/authentication/authenticate.hook.ts
+++ b/packages/core/src/auth/authentication/authenticate.hook.ts
@@ -3,10 +3,10 @@ import { getManager } from 'typeorm';
 import { Class, Hook, HookDecorator } from '../../core';
 import { AbstractUser } from '../entities';
 
-export function Authenticate(UserEntity: Class<AbstractUser>): HookDecorator {
+export function AuthenticateWithSessionAndCookie(UserEntity: Class<AbstractUser>): HookDecorator {
   return Hook(async ctx => {
     if (!ctx.request.session) {
-      throw new Error('Authenticate hook requires session management.');
+      throw new Error('AuthenticateWithSessionAndCookie hook requires session management.');
     }
     if (!ctx.request.session.authentication || !ctx.request.session.authentication.hasOwnProperty('userId')) {
       return;

--- a/packages/examples/src/app/app.controller.ts
+++ b/packages/examples/src/app/app.controller.ts
@@ -1,12 +1,12 @@
 import {
-  Authenticate,
+  AuthenticateWithSessionAndCookie,
   controller,
 } from '@foal/core';
 
 import { AuthController, ViewController } from './controllers';
 import { User } from './entities';
 
-@Authenticate(User)
+@AuthenticateWithSessionAndCookie(User)
 export class AppController {
   subControllers = [
     controller('', AuthController),


### PR DESCRIPTION
# Issue

The name `Authenticate` is not very clear as it does not give information on how the user is authenticated. Future versions of FoalTS will include other ways to authenticate a user (JWT, see https://github.com/FoalTS/foal/issues/254). It would be great to clearly differentiate these methods.

# Solution and steps

Rename the hook `Authenticate` to `AuthenticateWithSessionAndCookie`.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.