### PR TITLE
Let createApp accept a custom express instance as base

### DIFF
--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -3,6 +3,7 @@ import { strictEqual } from 'assert';
 import { promisify } from 'util';
 
 // 3p
+import * as express from 'express';
 import { MemoryStore } from 'express-session';
 import * as request from 'supertest';
 
@@ -141,6 +142,14 @@ describe('createApp', () => {
     sessions = await promisify(store.all.bind(store))();
     strictEqual(Object.keys(sessions).length, 1);
   });
+
+  it('should use the optional express instance if one is given.', () => {
+    const expected = express();
+    const actual = createApp(class {}, {}, expected);
+
+    strictEqual(actual, expected);
+  });
+
 });
 
 // function httpMethodTest(httpMethod: HttpMethod) {

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -23,6 +23,12 @@ export interface CreateAppOptions {
   store?(session): any;
 }
 
+/**
+ * Main function to create a node.js (express) application from the root controller.
+ * @param rootControllerClass The root controller, usually called `AppController`
+ * @param options Optional options to specify the session store (default is MemoryStore)
+ * @param expressInstance Optional express instance to be used as base.
+ */
 export function createApp(rootControllerClass: Class, options: CreateAppOptions = {}, expressInstance?) {
   const app = expressInstance || express();
 

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -1,11 +1,14 @@
+// std
 import * as path from 'path';
 
+// 3p
 import * as csurf from 'csurf';
 import * as express from 'express';
 import * as session from 'express-session';
 import * as helmet from 'helmet';
 import * as logger from 'morgan';
 
+// FoalTS
 import {
   Class,
   Config,
@@ -20,8 +23,8 @@ export interface CreateAppOptions {
   store?(session): any;
 }
 
-export function createApp(rootControllerClass: Class, options: CreateAppOptions = {}) {
-  const app = express();
+export function createApp(rootControllerClass: Class, options: CreateAppOptions = {}, expressInstance?) {
+  const app = expressInstance || express();
 
   app.use(logger('[:date] ":method :url HTTP/:http-version" :status - :response-time ms'));
   app.use(express.static(path.join(process.cwd(), Config.get('settings', 'staticUrl', '/public') as string)));


### PR DESCRIPTION
# Issue

All the features of FoalTS have not been implemented yet. By then, it would be useful to be able to use app-level express middlewares (like `cors`). It is a bit hacky but it will let us fully use the framework.

Related issues: https://github.com/FoalTS/foal/issues/259, https://github.com/FoalTS/foal/issues/259.

# Solution and steps

Add an optional parameter `expressInstance` to `createApp`.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.