### PR TITLE
[@foal/cli] Fix controller spec typo (add a context object)

### DIFF
--- a/packages/cli/src/generate/specs/controller/test-foo-bar.controller.spec.empty.ts
+++ b/packages/cli/src/generate/specs/controller/test-foo-bar.controller.spec.empty.ts
@@ -2,7 +2,7 @@
 import { ok, strictEqual } from 'assert';
 
 // 3p
-import { createController, getHttpMethod, getPath, isHttpResponseOK } from '@foal/core';
+import { Context, createController, getHttpMethod, getPath, isHttpResponseOK } from '@foal/core';
 
 // App
 import { TestFooBarController } from './test-foo-bar.controller';
@@ -21,7 +21,8 @@ describe('TestFooBarController', () => {
     });
 
     it('should return an HttpResponseOK.', () => {
-      ok(isHttpResponseOK(controller.foo()));
+      const ctx = new Context({});
+      ok(isHttpResponseOK(controller.foo(ctx)));
     });
 
   });

--- a/packages/cli/src/generate/templates/controller/controller.spec.empty.ts
+++ b/packages/cli/src/generate/templates/controller/controller.spec.empty.ts
@@ -2,7 +2,7 @@
 import { ok, strictEqual } from 'assert';
 
 // 3p
-import { createController, getHttpMethod, getPath, isHttpResponseOK } from '@foal/core';
+import { Context, createController, getHttpMethod, getPath, isHttpResponseOK } from '@foal/core';
 
 // App
 import { /* upperFirstCamelName */Controller } from './/* kebabName */.controller';
@@ -21,7 +21,8 @@ describe('/* upperFirstCamelName */Controller', () => {
     });
 
     it('should return an HttpResponseOK.', () => {
-      ok(isHttpResponseOK(controller.foo()));
+      const ctx = new Context({});
+      ok(isHttpResponseOK(controller.foo(ctx)));
     });
 
   });


### PR DESCRIPTION
# Issue

Fix https://github.com/FoalTS/foal/issues/239.

# Solution and steps

Create a `Context` object in the controller spec.

# Checklist

- [x] Add/update/check docs.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.