### PR TITLE
v0.6.1

### DIFF
--- a/packages/cli/src/generate/specs/controller/test-foo-bar.controller.spec.empty.ts
+++ b/packages/cli/src/generate/specs/controller/test-foo-bar.controller.spec.empty.ts
@@ -2,7 +2,7 @@
 import { ok, strictEqual } from 'assert';
 
 // 3p
-import { createController, getHttpMethod, getPath, isHttpResponseOK } from '@foal/core';
+import { Context, createController, getHttpMethod, getPath, isHttpResponseOK } from '@foal/core';
 
 // App
 import { TestFooBarController } from './test-foo-bar.controller';
@@ -21,7 +21,8 @@ describe('TestFooBarController', () => {
     });
 
     it('should return an HttpResponseOK.', () => {
-      ok(isHttpResponseOK(controller.foo()));
+      const ctx = new Context({});
+      ok(isHttpResponseOK(controller.foo(ctx)));
     });
 
   });

--- a/packages/cli/src/generate/templates/controller/controller.spec.empty.ts
+++ b/packages/cli/src/generate/templates/controller/controller.spec.empty.ts
@@ -2,7 +2,7 @@
 import { ok, strictEqual } from 'assert';
 
 // 3p
-import { createController, getHttpMethod, getPath, isHttpResponseOK } from '@foal/core';
+import { Context, createController, getHttpMethod, getPath, isHttpResponseOK } from '@foal/core';
 
 // App
 import { /* upperFirstCamelName */Controller } from './/* kebabName */.controller';
@@ -21,7 +21,8 @@ describe('/* upperFirstCamelName */Controller', () => {
     });
 
     it('should return an HttpResponseOK.', () => {
-      ok(isHttpResponseOK(controller.foo()));
+      const ctx = new Context({});
+      ok(isHttpResponseOK(controller.foo(ctx)));
     });
 
   });


### PR DESCRIPTION
- [x] [@foal/cli] Fix a typo in the generated controller spec (issue: https://github.com/FoalTS/foal/issues/239) (PR: https://github.com/FoalTS/foal/pull/267)