### PR TITLE
[@foal/cli] Auto install dependencies upon project creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ First install [Node.Js and npm](https://nodejs.org/en/download/).
 ```
 $ npm install -g @foal/cli
 $ foal createapp my-app
-$ cd my-app && npm install
+$ cd my-app
 $ npm run develop
 ```
 

--- a/docs/tutorials/simple-todo-list/1-installation.md
+++ b/docs/tutorials/simple-todo-list/1-installation.md
@@ -56,7 +56,7 @@ The outer `my-app` root directory is just a container for your project.
 
 # Start The Server
 
-Let's verify that the FoalTS project works. Run the following command:
+Let's verify that the FoalTS project works. Run the following commands:
 
 ```
 cd my-app

--- a/docs/tutorials/simple-todo-list/1-installation.md
+++ b/docs/tutorials/simple-todo-list/1-installation.md
@@ -20,11 +20,12 @@ Then create a new application.
 foal createapp my-app
 ```
 
-This command generates a new directory with the basic structure of the new application. Let's look at what `createapp` created:
+This command generates a new directory with the basic structure of the new application. It also installs all the dependencies. Let's look at what `createapp` created:
 
 ```shell
 my-app/
   config/
+  node_modules/
   public/
   src/
     app/
@@ -38,6 +39,7 @@ my-app/
 
 The outer `my-app` root directory is just a container for your project.
 - The `config/` directory contains configuration files for your different environments (production, test, development, e2e, etc).
+- The `node_modules/` directory contains all the prod and dev dependencies of your project.
 - The static files are located in the `public/` directory. They are usually images, CSS and client JavaScript files and are served directly when the server is running.
 - The `src/` directory contains all the source code of the application (TypeScript files and HTML templates).
   - The inner `app/` directory includes the components of your server (controllers, templates, services, hooks, sub-apps).
@@ -52,20 +54,12 @@ The outer `my-app` root directory is just a container for your project.
 >
 > The language used to develop a FoalTS application is [TypeScript](https://www.typescriptlang.org/). It is a typed superset of JavaScript that compiles to plain JavaScript. The benefits of using TypeScript are many, but in summary, the language provides great tools and the future features of JavaScript.
 
-Change into the `my-app` directory and install the dependencies.
-
-```sh
-cd my-app
-npm install
-```
-
-A new folder `node_modules/` should appear in your root directory. It contains all the prod and dev dependencies of your project.
-
 # Start The Server
 
 Let's verify that the FoalTS project works. Run the following command:
 
 ```
+cd my-app
 npm run develop
 ```
 

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -4,7 +4,6 @@ cd e2e-test-temp
 # Test app creation
 foal createapp my-app
 cd my-app
-npm install
 
 # Test the generators that do not require user interaction
 foal g entity flight

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -51,7 +51,7 @@ First install [Node.Js and npm](https://nodejs.org/en/download/).
 ```
 $ npm install -g @foal/cli
 $ foal createapp my-app
-$ cd my-app && npm install
+$ cd my-app
 $ npm run develop
 ```
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,7 +34,7 @@ program
   .command('createapp <name>')
   .description('Creates a new directory with a new FoalTS app.')
   .action((name: string) => {
-    createApp({ name });
+    createApp({ name, autoInstall: true });
   });
 
 program

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -54,7 +54,7 @@ First install [Node.Js and npm](https://nodejs.org/en/download/).
 ```
 $ npm install -g @foal/cli
 $ foal createapp my-app
-$ cd my-app && npm install
+$ cd my-app
 $ npm run develop
 ```
 

--- a/packages/ejs/README.md
+++ b/packages/ejs/README.md
@@ -54,7 +54,7 @@ First install [Node.Js and npm](https://nodejs.org/en/download/).
 ```
 $ npm install -g @foal/cli
 $ foal createapp my-app
-$ cd my-app && npm install
+$ cd my-app
 $ npm run develop
 ```
 

--- a/packages/password/README.md
+++ b/packages/password/README.md
@@ -54,7 +54,7 @@ First install [Node.Js and npm](https://nodejs.org/en/download/).
 ```
 $ npm install -g @foal/cli
 $ foal createapp my-app
-$ cd my-app && npm install
+$ cd my-app
 $ npm run develop
 ```
 


### PR DESCRIPTION
# Issue

When creating a new project, the dependencies are not automatically installed. The user has "too many" commands to enter to create and start the app.

# Solution and steps

Auto install the dependencies  with npm  upon creation (or with yarn if it is installed).

# Checklist

- [x] Add/update/check docs.
- [ ] Add/update/check tests.
- [x] Update/check the cli generators.