### PR TITLE
[@foal/core] Add empty csrfToken function when csrf=false

### DIFF
--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -27,6 +27,22 @@ describe('createApp', () => {
     return promise;
   });
 
+  it('should define the function req.csrfToken even if csrf is set to false in Config.', () => {
+    process.env.SETTINGS_CSRF = 'false';
+    class AppController {
+      @Post('/')
+      index(ctx: Context) {
+        return new HttpResponseOK(ctx.request.csrfToken());
+      }
+    }
+    const app = createApp(AppController);
+    const promise = Promise.all([
+      request(app).post('/').expect(200).expect('CSRF protection disabled.'),
+    ]);
+    process.env.SETTINGS_CSRF = 'false'; // Not great: assumption about the default param here.
+    return promise;
+  });
+
   it('should return 404 "Not Found" on requests that have no handlers.', () => {
     const app = createApp(class {});
     return Promise.all([

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -54,6 +54,11 @@ export function createApp(rootControllerClass: Class, options: CreateAppOptions 
 
   if (Config.get('settings', 'csrf', false) as boolean) {
     app.use(csurf());
+  } else {
+    app.use((req, res, next) => {
+      req.csrfToken = () => 'CSRF protection disabled.';
+      next();
+    });
   }
   app.use((err, req, res, next) => {
     if (err.code === 'EBADCSRFTOKEN') {


### PR DESCRIPTION
# Issue

See #283 

# Solution and steps

Add a custom express middleware in `createApp` when `csrf` is false.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
