### PR TITLE
[@foal/cli] Remove the prompts from "foal g controller|service"

### DIFF
--- a/docs/architecture/services.md
+++ b/docs/architecture/services.md
@@ -2,7 +2,6 @@
 
 ```sh
 foal generate service my-service
-> Empty
 ```
 
 ```typescript

--- a/docs/development-environment/code-generation.md
+++ b/docs/development-environment/code-generation.md
@@ -12,9 +12,6 @@ Create a new directory with all the required files to get started.
 
 ```shell
 foal g controller foobar
-> Empty
-> REST
-> Login
 ```
 
 Create a new controller in `./src/app/controllers`, in `./controllers` or in the current directory depending on which folders are found.
@@ -53,13 +50,6 @@ Create a new sub-app with all its files in `./src/app/sub-apps`, in `./sub-apps`
 
 ```shell
 foal g service foobar
-> Empty
-  ──────────────
-> ResourceCollection
-> EntityResourceCollection
-  ──────────────
-> Authenticator
-> EmailAuthenticator
 ```
 
 Create a new service in `./src/app/services`, in `./services` or in the current directory depending on which folders are found.

--- a/docs/tutorials/multi-user-todo-list/5-auth-controllers-and-hooks.md
+++ b/docs/tutorials/multi-user-todo-list/5-auth-controllers-and-hooks.md
@@ -60,7 +60,6 @@ The next step is to create a controller that logs the users in or out and redire
 
 ```
 foal generate controller auth --register
-> Empty
 ```
 
 Open the new file `auth.controller.ts` and replace its content.

--- a/docs/tutorials/multi-user-todo-list/7-the-signup-page.md
+++ b/docs/tutorials/multi-user-todo-list/7-the-signup-page.md
@@ -6,7 +6,6 @@ Create a new controller to handle this route.
 
 ```
 foal generate controller signup --register
-> Empty
 ```
 
 Open the new file and replace its content.

--- a/docs/tutorials/simple-todo-list/5-the-rest-api.md
+++ b/docs/tutorials/simple-todo-list/5-the-rest-api.md
@@ -8,7 +8,6 @@ Create a new controller.
 
 ```sh
 foal generate controller api --register
-> Empty
 ```
 
 Open the new generated file `api.controller.ts` in the `src/app/controllers/` directory and replace its content.

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -5,9 +5,11 @@ cd e2e-test-temp
 foal createapp my-app
 cd my-app
 
-# Test the generators that do not require user interaction
+# Test the generators
 foal g entity flight
 foal g hook foo-bar
+foal g service foo
+foal g controller bar --register
 foal g sub-app bar-foo
 foal g script bar-script
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,8 +50,7 @@
   "dependencies": {
     "ajv": "^6.5.0",
     "colors": "^1.3.2",
-    "commander": "^2.15.1",
-    "inquirer": "^6.0.0"
+    "commander": "^2.15.1"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,11 +7,9 @@
 
 // 3p
 import * as program from 'commander';
-import { prompt, Separator } from 'inquirer';
 
 // FoalTS
 import {
-  ControllerType,
   createApp,
   createController,
   createEntity,
@@ -20,7 +18,6 @@ import {
   createService,
   createSubApp,
   createVSCodeConfig,
-  ServiceType
 } from './generate';
 import { runScript } from './run-script';
 
@@ -53,11 +50,7 @@ program
     name = name || 'no-name';
     switch (type) {
       case 'controller':
-        const controllerChoices: ControllerType[] = [ 'Empty', 'REST'/*, 'GraphQL'*/, 'Login' ];
-        const controllerAnswers = await prompt([
-          { choices: controllerChoices, name: 'type', type: 'list', message: 'Type' }
-        ]);
-        createController({ name, type: controllerAnswers.type, register: options.register || false  });
+        createController({ name, type: 'Empty', register: options.register || false  });
         break;
       case 'entity':
         createEntity({ name });
@@ -72,22 +65,7 @@ program
         createScript({ name });
         break;
       case 'service':
-        const serviceChoices: ServiceType[] = [
-          'Empty',
-          new Separator(),
-          'ResourceCollection',
-          'EntityResourceCollection',
-          // new Separator(),
-          // 'GraphQLResolver',
-          new Separator(),
-          'Authenticator',
-          'EmailAuthenticator',
-          new Separator(),
-        ];
-        const serviceAnswers = await prompt([
-          { choices: serviceChoices, name: 'type', type: 'list', message: 'Type', pageSize: 10 }
-        ]);
-        createService({ name, type: serviceAnswers.type});
+        createService({ name, type: 'Empty' });
         break;
       case 'vscode-config':
         createVSCodeConfig();


### PR DESCRIPTION
# Issue

See #288.

# Solution and steps

Remove the prompts of the commands `foal g controller` and `foal g service` to prevent the user from generating deprecated files.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
