### PR TITLE
Be able to customize the logger outputs

### DIFF
--- a/docs/utilities/logging-and-debugging.md
+++ b/docs/utilities/logging-and-debugging.md
@@ -1,5 +1,18 @@
 # Logging & Debugging
 
+## HTTP Request Logging
+
+FoalTS uses [morgan](https://www.npmjs.com/package/morgan) to log the HTTP requests. You can specify the output format using the environment variable `SETTINGS_LOGGER_FORMAT` or the `config/settings.json` file:
+
+```json
+{
+  ...
+  "loggerFormat": "tiny"
+}
+```
+
+## Custom Logging
+
 FoalTS provides a convenient hook for logging debug messages: `Log(message: string, options: LogOptions = {})`.
 
 ```typescript

--- a/packages/cli/src/generate/specs/app/config/settings.development.json
+++ b/packages/cli/src/generate/specs/app/config/settings.development.json
@@ -1,3 +1,4 @@
 {
-  "debug": true
+  "debug": true,
+  "loggerFormat": "dev"
 }

--- a/packages/cli/src/generate/specs/app/config/settings.json
+++ b/packages/cli/src/generate/specs/app/config/settings.json
@@ -2,6 +2,7 @@
   "csrf": true,
   "debug": false,
   "port": 3000,
+  "loggerFormat": "tiny",
   "staticUrl": "public/",
   "sessionResave": false,
   "sessionSaveUninitialized": false,

--- a/packages/cli/src/generate/templates/app/config/settings.development.json
+++ b/packages/cli/src/generate/templates/app/config/settings.development.json
@@ -1,3 +1,4 @@
 {
-  "debug": true
+  "debug": true,
+  "loggerFormat": "dev"
 }

--- a/packages/cli/src/generate/templates/app/config/settings.json
+++ b/packages/cli/src/generate/templates/app/config/settings.json
@@ -2,6 +2,7 @@
   "csrf": true,
   "debug": false,
   "port": 3000,
+  "loggerFormat": "tiny",
   "staticUrl": "public/",
   "sessionResave": false,
   "sessionSaveUninitialized": false,

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -32,7 +32,12 @@ export interface CreateAppOptions {
 export function createApp(rootControllerClass: Class, options: CreateAppOptions = {}, expressInstance?) {
   const app = expressInstance || express();
 
-  app.use(logger('[:date] ":method :url HTTP/:http-version" :status - :response-time ms'));
+  const loggerFormat = Config.get(
+    'settings', 'loggerFormat',
+    '[:date] ":method :url HTTP/:http-version" :status - :response-time ms'
+  );
+
+  app.use(logger(loggerFormat));
   app.use(express.static(path.join(process.cwd(), Config.get('settings', 'staticUrl', '/public') as string)));
   app.use(helmet());
   app.use(express.json());


### PR DESCRIPTION
# Issue

FoalTS displays logs upon requests. It would be nice to be able to customize them.

# Solution and steps

Add an option in the `Config` to the specify the string format (see https://www.npmjs.com/package/morgan)

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
