### PR TITLE
Validates random commands and shows up help if none supplied

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 // 3p
+import chalk from 'chalk';
 import * as program from 'commander';
 
 // FoalTS
@@ -79,4 +80,18 @@ program
     }
   });
 
+// Validation for random commands
+program
+  .arguments('<command>')
+  .action(cmd => {
+    program.outputHelp();
+    console.log(`  ` + chalk.red(`\n  Unknown command ${chalk.yellow(cmd)}.`));
+    console.log();
+  });
+
 program.parse(process.argv);
+
+// Shows help if no arguments are provided
+if (!program.args.length) {
+  program.outputHelp();
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 // 3p
-import chalk from 'chalk';
+import { red, yellow } from 'colors/safe';
 import * as program from 'commander';
 
 // FoalTS
@@ -85,7 +85,7 @@ program
   .arguments('<command>')
   .action(cmd => {
     program.outputHelp();
-    console.log(`  ` + chalk.red(`\n  Unknown command ${chalk.yellow(cmd)}.`));
+    console.log(`  ` + red(`\n  Unknown command ${yellow(cmd)}.`));
     console.log();
   });
 


### PR DESCRIPTION
Closes #308 

## Present issue

- If the user fires in `foal` nothing shows up. 
- User can fire in any command without any sort of warnings

## Proposed solution

- Shows up help if no arguments are supplied
- Warns the user on firing in random commands with `foal` 