### PR TITLE
[@foal/cli] Add `foal run` as alias of `foal run-script`

### DIFF
--- a/docs/authentication-and-access-control/groups-and-permissions.md
+++ b/docs/authentication-and-access-control/groups-and-permissions.md
@@ -49,7 +49,7 @@ async function main() {
 
 ```sh
 npm run build:scripts
-foal run-script create-perm name="Permission to access the secret" codeName="access-secret"
+foal run create-perm name="Permission to access the secret" codeName="access-secret"
 ```
 
 ## Groups
@@ -104,8 +104,8 @@ async function main() {
 
 ```sh
 npm run build:scripts
-foal run-script create-perm name="Permission to delete users" codeName="delete-users"
-foal run-script create-group name="Administrators" codeName="admin" permissions='[ "delete-users" ]'
+foal run create-perm name="Permission to delete users" codeName="delete-users"
+foal run create-group name="Administrators" codeName="admin" permissions='[ "delete-users" ]'
 ```
 
 ## Users
@@ -142,7 +142,7 @@ The `hasPerm(permissionCodeName: string)` method of the `UserWithPermissions` cl
 
 ```sh
 npm run build:scripts
-foal run-script create-user userPermissions='[ "my-first-perm" ]' groups='[ "my-group" ]'
+foal run create-user userPermissions='[ "my-first-perm" ]' groups='[ "my-group" ]'
 ```
 
 ## Fetching a User with their Permissions

--- a/docs/authentication-and-access-control/user-class.md
+++ b/docs/authentication-and-access-control/user-class.md
@@ -54,7 +54,7 @@ You can use the `create-user` shell script (located in `src/scripts`) to create 
 
 ```sh
 npm run build:scripts
-foal run-script create-user
+foal run create-user
 ```
 
 ## Example (email and password)
@@ -106,7 +106,7 @@ You can now create a new user with these commands:
 
 ```sh
 npm run build:scripts
-foal run-script create-user email=mary@foalts.org password=mary_password
+foal run create-user email=mary@foalts.org password=mary_password
 ```
 
 ## Using another ORM/ODM

--- a/docs/development-environment/create-and-run-scripts.md
+++ b/docs/development-environment/create-and-run-scripts.md
@@ -44,7 +44,7 @@ npm run build:scripts
 Then you can execute it with this command:
 
 ```sh
-foal run-script my-script
+foal run my-script # or foal run-script my-script
 ```
 
-> You can also provide additionnal arguments to your script (for example: `foal run-script my-script foo=1 bar='[ 3, 4 ]'`). The default template in the generated scripts shows you how to handle such behavior.
+> You can also provide additionnal arguments to your script (for example: `foal run my-script foo=1 bar='[ 3, 4 ]'`). The default template in the generated scripts shows you how to handle such behavior.

--- a/docs/tutorials/mongodb-todo-list/2-with-typeorm.md
+++ b/docs/tutorials/mongodb-todo-list/2-with-typeorm.md
@@ -45,9 +45,9 @@ Create new todos with the shell scripts and then run the application.
 
 ```
 npm run build:scripts
-foal run-script create-todo text="Read the docs"
-foal run-script create-todo text="Create my first application"
-foal run-script create-todo text="Write tests"
+foal run create-todo text="Read the docs"
+foal run create-todo text="Create my first application"
+foal run create-todo text="Write tests"
 ```
 
 ```

--- a/docs/tutorials/multi-user-todo-list/3-the-shell-scripts.md
+++ b/docs/tutorials/multi-user-todo-list/3-the-shell-scripts.md
@@ -72,8 +72,8 @@ npm run build:scripts
 Create two new users.
 
 ```
-foal run-script create-user email="john@foalts.org" password="john_password"
-foal run-script create-user email="mary@foalts.org" password="mary_password"
+foal run create-user email="john@foalts.org" password="john_password"
+foal run create-user email="mary@foalts.org" password="mary_password"
 ```
 
 > If you try to re-run one of these commands, you'll get the error below as the email key is unique.
@@ -137,8 +137,8 @@ npm run build:scripts
 Create new todos for each user.
 
 ```
-foal run-script create-todo owner="john@foalts.org" text="John task 1"
-foal run-script create-todo owner="john@foalts.org" text="John task 2"
-foal run-script create-todo owner="mary@foalts.org" text="Mary task 1"
-foal run-script create-todo owner="mary@foalts.org" text="Mary task 2"
+foal run create-todo owner="john@foalts.org" text="John task 1"
+foal run create-todo owner="john@foalts.org" text="John task 2"
+foal run create-todo owner="mary@foalts.org" text="Mary task 1"
+foal run create-todo owner="mary@foalts.org" text="Mary task 2"
 ```

--- a/docs/tutorials/simple-todo-list/4-the-shell-script-create-todo.md
+++ b/docs/tutorials/simple-todo-list/4-the-shell-script-create-todo.md
@@ -60,9 +60,9 @@ npm run build:scripts
 Then run the script to create tasks in the database.
 
 ```sh
-foal run-script create-todo text="Read the docs"
-foal run-script create-todo text="Create my first application"
-foal run-script create-todo text="Write tests"
+foal run create-todo text="Read the docs"
+foal run create-todo text="Create my first application"
+foal run create-todo text="Write tests"
 ```
 
 > Note that if you try to create a new to-do without specifying the text argument, you'll get the error below.

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -116,4 +116,4 @@ npm run build:scripts
 # foal run-script create-group name="My group2" codeName="my-group2"
 
 # foal run-script create-user userPermissions='[ "my-first-perm" ]' groups='[ "my-group" ]'
-foal run-script create-user
+foal run create-user

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -42,7 +42,8 @@ program
   });
 
 program
-  .command('run-script <name>')
+  .command('run <name>')
+  .alias('run-script')
   .description('Runs the given script.')
   .action((name: string) => {
     runScript({ name }, process.argv);


### PR DESCRIPTION
# Issue

The command `foal run-script <name>` is too long.

# Solution and steps

Add the alias `foal run <name>`.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
