### PR TITLE
[@foal/cli] `foal createapp`: prettify the outputs and auto initialize git repo.

### DIFF
--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -33,7 +33,7 @@ export async function createApp({ name, sessionSecret, autoInstall, initRepo }:
   { name: string, sessionSecret?: string, autoInstall?: boolean, initRepo?: boolean }) {
   const names = getNames(name);
   if (process.env.NODE_ENV !== 'test') {
-    console.log(blue(
+    console.log(cyan(
 `====================================================================
 
      _______   ________   ____        ___     _________   _______
@@ -56,7 +56,8 @@ export async function createApp({ name, sessionSecret, autoInstall, initRepo }:
 
   mkdirIfDoesNotExist(names.kebabName);
 
-  new Generator('app', names.kebabName)
+  log('  📂 Creating files...');
+  new Generator('app', names.kebabName, { noLogs: true })
     .copyFileFromTemplates('gitignore', '.gitignore')
     .copyFileFromTemplates('ormconfig.json')
     .renderTemplate('package.json', locals)
@@ -133,7 +134,7 @@ export async function createApp({ name, sessionSecret, autoInstall, initRepo }:
     });
   }
 
-  log('  📔 Initializing the git repository...');
+  log('  📔 Initializing git repository...');
   if (initRepo) {
     await initGitRepo(join(process.cwd(), names.kebabName));
   }

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -1,14 +1,16 @@
 // std
 import { execSync, spawn, SpawnOptions } from 'child_process';
 import * as crypto from 'crypto';
+import { join } from 'path';
 
 // 3p
-import { blue, red, underline } from 'colors/safe';
+import { blue, cyan, red } from 'colors/safe';
 
 // FoalTS
 import {
   Generator,
   getNames,
+  initGitRepo,
   mkdirIfDoesNotExist,
 } from '../../utils';
 
@@ -21,8 +23,14 @@ function isYarnInstalled() {
   }
 }
 
-export async function createApp({ name, sessionSecret, autoInstall }:
-  { name: string, sessionSecret?: string, autoInstall?: boolean }) {
+function log(msg: string) {
+  if (process.env.NODE_ENV !== 'test') {
+    console.log(msg);
+  }
+}
+
+export async function createApp({ name, sessionSecret, autoInstall, initRepo }:
+  { name: string, sessionSecret?: string, autoInstall?: boolean, initRepo?: boolean }) {
   const names = getNames(name);
   if (process.env.NODE_ENV !== 'test') {
     console.log(blue(
@@ -103,6 +111,8 @@ export async function createApp({ name, sessionSecret, autoInstall }:
         .copyFileFromTemplates('src/scripts/create-perm.ts')
         .copyFileFromTemplates('src/scripts/create-user.ts');
 
+  log('');
+  log('  📦 Installing the dependencies...');
   if (autoInstall) {
     const packageManager = isYarnInstalled() ? 'yarn' : 'npm';
     const args = [ 'install' ];
@@ -116,20 +126,23 @@ export async function createApp({ name, sessionSecret, autoInstall }:
       spawn(packageManager, args, options)
         .on('close', (code: number) => {
           if (code !== 0) {
-            console.log(red('A problem occurred when installing the dependencies. See above.'));
+            log(red('A problem occurred when installing the dependencies. See above.'));
           }
           resolve();
         });
     });
   }
 
-  if (process.env.NODE_ENV !== 'test') {
-    console.log(
-      `
-${underline('Run the app:')}
-$ cd ${names.kebabName}
-$ npm run develop
-`
-    );
+  log('  📔 Initializing the git repository...');
+  if (initRepo) {
+    await initGitRepo(join(process.cwd(), names.kebabName));
   }
+
+  log(`
+  👉 Run the following commands to get started:
+
+    $ ${cyan(`cd ${names.kebabName}`)}
+    $ ${cyan('npm run develop')}
+`
+  );
 }

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -4,7 +4,7 @@ import * as crypto from 'crypto';
 import { join } from 'path';
 
 // 3p
-import { blue, cyan, red } from 'colors/safe';
+import { cyan, red } from 'colors/safe';
 
 // FoalTS
 import {

--- a/packages/cli/src/generate/utils/generator.ts
+++ b/packages/cli/src/generate/utils/generator.ts
@@ -9,7 +9,13 @@ import { cyan, green } from 'colors/safe';
 import { mkdirIfDoesNotExist } from './mkdir-if-does-not-exist';
 
 export class Generator {
-  constructor(private name: string, private root: string) {}
+  constructor(
+    private name: string,
+    private root: string,
+    private options: {
+      noLogs?: boolean
+    } = {}
+  ) {}
 
   /* Create architecture */
 
@@ -68,7 +74,7 @@ export class Generator {
     if (this.root) {
       path = join(this.root, path);
     }
-    if (process.env.NODE_ENV !== 'test') {
+    if (process.env.NODE_ENV !== 'test' && !this.options.noLogs) {
       console.log(`${green('CREATE')} ${path}`);
     }
   }
@@ -77,7 +83,7 @@ export class Generator {
     if (this.root) {
       path = join(this.root, path);
     }
-    if (process.env.NODE_ENV !== 'test') {
+    if (process.env.NODE_ENV !== 'test' && !this.options.noLogs) {
       console.log(`${cyan('UPDATE')} ${path}`);
     }
   }

--- a/packages/cli/src/generate/utils/index.ts
+++ b/packages/cli/src/generate/utils/index.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 
 // FoalTS
 export { Generator } from './generator';
+export { initGitRepo } from './init-git-repo';
 export { mkdirIfDoesNotExist } from './mkdir-if-does-not-exist';
 export { TestEnvironment } from './test-environment';
 export { getNames } from './get-names';

--- a/packages/cli/src/generate/utils/init-git-repo.ts
+++ b/packages/cli/src/generate/utils/init-git-repo.ts
@@ -1,0 +1,35 @@
+import { spawn } from 'child_process';
+
+// This file is inspired by the Angular CLI (MIT License: https://angular.io/license).
+// See https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/schematics/tasks/repo-init/executor.ts
+
+export async function initGitRepo(root: string) {
+
+  function execute(args: string[]) {
+    return new Promise<void>((resolve, reject) => {
+      spawn('git', args, { cwd: root })
+        .on('close', (code: number) => code === 0 ? resolve() : reject(code));
+    });
+  }
+
+  const hasCommand = await execute(['--version']).then(() => true, () => false);
+  if (!hasCommand) {
+    return;
+  }
+
+  const insideRepo = await execute(['rev-parse', '--is-inside-work-tree'])
+    .then(() => true, () => false);
+  if (insideRepo) {
+    console.log('Directory is already under version control. Skipping initialization of git.');
+    return;
+  }
+
+  try {
+    await execute(['init']);
+    await execute(['add', '.']);
+    await execute(['commit', '-m "Initial commit"']);
+  } catch {
+    console.log('Initialization of git failed.');
+  }
+
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,7 +38,7 @@ program
       console.log(red('\n Kindly provide only one argument as the project name'));
       return;
     }
-    createApp({ name, autoInstall: true });
+    createApp({ name, autoInstall: true, initRepo: true });
   });
 
 program


### PR DESCRIPTION
# Issue

- Almost every project uses Git. It is tedious to have to run `git init`, `git add .` and `git commit` after the project creation.
- When creating a new project the banner goes away because the paths of the generated files are printed (see #314).

# Solution and steps

- Auto init a git repo on every new project. If the project is already in a git repo then skip.
- Improve the console UI.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [ ] ~~Add/update/check tests~~.
- [x] Update/check the cli generators.
