### PR TITLE
[@foal/cli] Make the createapp command not fail when Git is not installed

### DIFF
--- a/packages/cli/src/generate/utils/init-git-repo.ts
+++ b/packages/cli/src/generate/utils/init-git-repo.ts
@@ -7,13 +7,14 @@ export async function initGitRepo(root: string) {
 
   function execute(args: string[]) {
     return new Promise<void>((resolve, reject) => {
-      spawn('git', args, { cwd: root })
+      spawn('git', args, { cwd: root, shell: true })
         .on('close', (code: number) => code === 0 ? resolve() : reject(code));
     });
   }
 
   const hasCommand = await execute(['--version']).then(() => true, () => false);
   if (!hasCommand) {
+    console.log('Git not installed. Skipping initialization of git.');
     return;
   }
 


### PR DESCRIPTION
# Issue

See #319 

# Solution and steps

Change the `spawn` options.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [ ] ~~Add/update/check tests~~.
- [x] Update/check the cli generators.
