### PR TITLE
Fix type error in JWTOptional and JWTRequired

### DIFF
--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -5,6 +5,12 @@ cd e2e-test-temp
 foal createapp my-app
 cd my-app
 
+# Check some compilation errors
+if grep -Ril "../../Users/loicp" .; then
+    echo "Compilation error: \"../../Users/loicp\" has been found in one of the builds."
+    exit 1
+fi
+
 # Test the generators
 foal g entity flight
 foal g hook foo-bar

--- a/packages/jwt/src/jwt-optional.hook.ts
+++ b/packages/jwt/src/jwt-optional.hook.ts
@@ -1,8 +1,8 @@
 // 3p
+import { HookDecorator } from '@foal/core';
 import { VerifyOptions } from 'jsonwebtoken';
 
 // FoalTS
-import { HookDecorator } from '@foal/core';
 import { JWT, JWTOptions } from './jwt.hook';
 
 export function JWTOptional(options: JWTOptions = {}, verifyOptions: VerifyOptions = {}): HookDecorator {

--- a/packages/jwt/src/jwt-optional.hook.ts
+++ b/packages/jwt/src/jwt-optional.hook.ts
@@ -2,8 +2,9 @@
 import { VerifyOptions } from 'jsonwebtoken';
 
 // FoalTS
+import { HookDecorator } from '@foal/core';
 import { JWT, JWTOptions } from './jwt.hook';
 
-export function JWTOptional(options: JWTOptions = {}, verifyOptions: VerifyOptions = {}) {
+export function JWTOptional(options: JWTOptions = {}, verifyOptions: VerifyOptions = {}): HookDecorator {
   return JWT(false, options, verifyOptions);
 }

--- a/packages/jwt/src/jwt-required.hook.ts
+++ b/packages/jwt/src/jwt-required.hook.ts
@@ -2,8 +2,9 @@
 import { VerifyOptions } from 'jsonwebtoken';
 
 // FoalTS
+import { HookDecorator } from '@foal/core';
 import { JWT, JWTOptions } from './jwt.hook';
 
-export function JWTRequired(options: JWTOptions = {}, verifyOptions: VerifyOptions = {}) {
+export function JWTRequired(options: JWTOptions = {}, verifyOptions: VerifyOptions = {}): HookDecorator {
   return JWT(true, options, verifyOptions);
 }

--- a/packages/jwt/src/jwt-required.hook.ts
+++ b/packages/jwt/src/jwt-required.hook.ts
@@ -1,8 +1,8 @@
 // 3p
+import { HookDecorator } from '@foal/core';
 import { VerifyOptions } from 'jsonwebtoken';
 
 // FoalTS
-import { HookDecorator } from '@foal/core';
 import { JWT, JWTOptions } from './jwt.hook';
 
 export function JWTRequired(options: JWTOptions = {}, verifyOptions: VerifyOptions = {}): HookDecorator {


### PR DESCRIPTION
# Issue

The compilation of the package `@foal/jwt` includes an error. The returned type of `JWTRequired` and `JWTOptional` is `import("../../../../../../../../Users/loicpoullain/projects/FoalTS/foal/packages/jwt/node_modules/@foal/core/lib/core/hooks").HookDecorator;` which may make fail the `npm run develop` command.

# Solution and steps

Do not let typescript infer the return type of the hooks. Add it manually

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
