### PR TITLE
Validate project name as per npm conventions

### DIFF
--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -30,7 +30,7 @@ function log(msg: string) {
 }
 
 function validateProjectName(name: string) {
-  let flag = 0;
+  // As per npm naming conventions (https://www.npmjs.com/package/validate-npm-package-name)
   const specialChars = ['!',
     '@',
     '#',
@@ -55,18 +55,8 @@ function validateProjectName(name: string) {
     ',',
     '.',
     '?'
-  ];
-
-  specialChars.map(char => {
-    if (name.includes(char)) {
-      flag = 1;
-      return false;
-    }
-  });
-
-  if (flag === 0) {
-    return true;
-  }
+ ];
+ return !specialChars.find(char => name.includes(char));  
 }
 
 export async function createApp({ name, sessionSecret, autoInstall, initRepo }:
@@ -101,7 +91,6 @@ export async function createApp({ name, sessionSecret, autoInstall, initRepo }:
     );
     return;
   }
-
   mkdirIfDoesNotExist(names.kebabName);
 
   log('  📂 Creating files...');

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -56,7 +56,7 @@ function validateProjectName(name: string) {
     '.',
     '?'
  ];
- return !specialChars.find(char => name.includes(char));  
+  return !specialChars.find(char => name.includes(char));
 }
 
 export async function createApp({ name, sessionSecret, autoInstall, initRepo }:

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -29,6 +29,46 @@ function log(msg: string) {
   }
 }
 
+function validateProjectName(name: string) {
+  let flag = 0;
+  const specialChars = ['!',
+    '@',
+    '#',
+    '$',
+    '%',
+    '^',
+    '&',
+    '*',
+    '(',
+    ')',
+    '/',
+    '\\',
+    '+',
+    '{',
+    '}',
+    '[',
+    ']',
+    ':',
+    ';',
+    '<',
+    '>',
+    ',',
+    '.',
+    '?'
+  ];
+
+  specialChars.map(char => {
+    if (name.includes(char)) {
+      flag = 1;
+      return false;
+    }
+  });
+
+  if (flag === 0) {
+    return true;
+  }
+}
+
 export async function createApp({ name, sessionSecret, autoInstall, initRepo }:
   { name: string, sessionSecret?: string, autoInstall?: boolean, initRepo?: boolean }) {
   const names = getNames(name);
@@ -53,6 +93,14 @@ export async function createApp({ name, sessionSecret, autoInstall, initRepo }:
     ...names,
     sessionSecret: sessionSecret ? sessionSecret : crypto.randomBytes(16).toString('hex')
   };
+
+     // Validating whether if the project-name follows npm naming conventions
+  if (!validateProjectName(name)) {
+    console.log(
+      red(`\n ${red(`${name} doesn't follow the npm naming conventions. Kindly give a vaild project-name`)}`)
+    );
+    return;
+  }
 
   mkdirIfDoesNotExist(names.kebabName);
 


### PR DESCRIPTION
## Present Issue

> Closes #313

User can provide any sort of special characters for the  `projectName` with `foal createapp` which doesn't make any sense.
For instance, `foal createapp !@#` works as per now.

## Proposed solution

Validate the name provided as an argument and show warnings appropriately.