### PR TITLE
Fix typos in the `get-started` tutorial

### DIFF
--- a/docs/tutorials/simple-todo-list/5-the-rest-api.md
+++ b/docs/tutorials/simple-todo-list/5-the-rest-api.md
@@ -32,7 +32,10 @@ Refresh your browser, you should see the two todos printed.
 Now, we would like to return the todos stored in the database. Update the code as follows:
 
 ```typescript
-import { Get, HttpResponseOK } from '@foal/core';
+import {
+  Context, Delete, Get, HttpResponseCreated, HttpResponseNoContent,
+  HttpResponseNotFound, HttpResponseOK, Post
+} from '@foal/core';
 import { getRepository } from 'typeorm';
 
 import { Todo } from '../entities';

--- a/docs/tutorials/simple-todo-list/6-validation-and-sanitization.md
+++ b/docs/tutorials/simple-todo-list/6-validation-and-sanitization.md
@@ -13,19 +13,28 @@ The `ValidateBody` and `ValidateParams` check respectively the `body` and `param
 Let's add validation and sanitization to your application. In fact, you have already defined the todo schema in the `create-todo` script earlier.
 
 ```typescript
+import {
+  ...
+  ValidateBody, ValidateParams
+} from '@foal/core';
+
+export class ApiController {
+
+  ...
+
   @Post('/todos')
   @ValidateBody({
     // The body request should be an object once parsed by the framework.
-    type: 'object',
+    // Every additional properties that are not defined in the "properties"
+    // object should be removed.
+    additionalProperties: false,
     properties: {
       // The "text" property of ctx.request.body should be a string if it exists.
       text: { type: 'string' }
     },
     // The property "text" is required.
     required: [ 'text' ],
-    // Every additional properties that are not defined in the "properties"
-    // object should be removed.
-    additionalProperties: false,
+    type: 'object',
   })
   async postTodo(ctx: Context) {
     const todo = new Todo();
@@ -54,4 +63,7 @@ Let's add validation and sanitization to your application. In fact, you have alr
     await getRepository(Todo).remove(todo);
     return new HttpResponseNoContent();
   }
+
+}
+
 ```


### PR DESCRIPTION
# Issue

The `get-started` tutorial has some typos. See [here](https://www.reddit.com/r/typescript/comments/akn2xg/foalts_a_web_framework_for_building_serverside/ef8x6aq) the comment on reddit.

# Solution and steps

Fix these things:
- [ ] ~The copied source of "create-todo.ts" does not end with new line~. -> Couldn't be able to fix this. This is specific to how gitbook displays code.
- [x] `Context`, `HttpResponseNotFound`, `HttpResponseNoContent`, `HttpResponseCreated`, `Context`, `Delete`, `Post` are not imported in `src\app\controllers\api.controller.ts`.
- [x] 6-validation-and-sanitization needs 2 more imports from `@foal/core`.
- [x] Decorator object props should be alphabetically.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
