### PR TITLE
Allow `JWTRequired` and `JWTOptional` retrieve the tokens from a cookie

### DIFF
--- a/packages/jwt/e2e/jwt.spec.ts
+++ b/packages/jwt/e2e/jwt.spec.ts
@@ -4,6 +4,7 @@ import { sign } from 'jsonwebtoken';
 import * as request from 'supertest';
 
 // FoalTS
+import { ok } from 'assert';
 import { JWTRequired } from '../src';
 
 const secret = 'my_strong_secret';
@@ -11,18 +12,18 @@ const secret = 'my_strong_secret';
 before(() => process.env.JWT_SECRET_OR_PUBLIC_KEY = secret);
 after(() => process.env.JWT_SECRET_OR_PUBLIC_KEY = '');
 
-it('JWT test', async () => {
+interface User {
+  id: number;
+  username: string;
+  isAdmin: boolean;
+}
 
-  interface User {
-    id: number;
-    username: string;
-    isAdmin: boolean;
-  }
+const users: User[] = [
+  { id: 1, username: 'John', isAdmin: true },
+  { id: 2, username: 'Mary', isAdmin: false },
+];
 
-  const users: User[] = [
-    { id: 1, username: 'John', isAdmin: true },
-    { id: 2, username: 'Mary', isAdmin: false },
-  ];
+it('JWT test (no cookie)', async () => {
 
   const blackList: string[] = [];
 
@@ -120,4 +121,85 @@ it('JWT test', async () => {
       code: 'invalid_token',
       description: 'jwt revoked'
     });
+});
+
+it('JWT test (with cookies)', async () => {
+  class AppController {
+    @Post('/login')
+    async logIn(ctx: Context) {
+      const user = users.find(user => user.username === ctx.request.body.username);
+      if (!user) {
+        return new HttpResponseUnauthorized();
+      }
+      const payload = {
+        id: user.id,
+        username: user.username
+      };
+
+      const jwt = await new Promise((resolve, reject) => {
+        sign(payload, secret, { subject: user.id.toString() }, (err, value) => {
+          if (err) { reject(err); } else { resolve(value); }
+        });
+      });
+      const response = new HttpResponseOK();
+      response.setCookie('auth', jwt as string);
+      return response;
+    }
+
+    @Get('/get-username')
+    @JWTRequired({ cookie: true })
+    async getUsername(ctx) {
+      return new HttpResponseOK(ctx.user.username);
+    }
+  }
+
+  const app = createApp(AppController);
+
+  /* Try to login with a wrong username */
+
+  await request(app)
+    .post('/login')
+    .send({ username: 'Someone' })
+    .expect(401);
+
+  /* Login with a correct username */
+
+  let jwt = '';
+  await request(app)
+    .post('/login')
+    .send({ username: 'John' })
+    .expect(200)
+    .then(data => {
+      ok(Array.isArray(data.header['set-cookie']));
+      jwt = data.header['set-cookie'][0].split(';')[0].split('auth=')[1];
+    });
+
+  /* Request /get-username without the jwt */
+
+  await request(app)
+    .get('/get-username')
+    .expect(400)
+    .expect({
+      code: 'invalid_request',
+      description: 'Auth cookie not found.'
+    });
+
+  /* Request /get-username with a bad jwt */
+
+  await request(app)
+    .get('/get-username')
+    .set('Cookie', 'auth=hello')
+    .expect(401)
+    .expect({
+      code: 'invalid_token',
+      description: 'jwt malformed'
+    });
+
+  /* Request /get-username with the correct jwt */
+
+  await request(app)
+    .get('/get-username')
+    .set('Cookie', `auth=${jwt};`)
+    .expect(200)
+    .expect('John');
 });

--- a/packages/jwt/src/jwt.hook.spec.ts
+++ b/packages/jwt/src/jwt.hook.spec.ts
@@ -62,10 +62,38 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
         });
       });
 
+      it('should return an HttpResponseBadRequest object if options.cookie=true and '
+          + 'the cookie does not exist.', async () => {
+        const hook = getHookFunction(JWT({ cookie: true }));
+
+        const ctx = new Context({ get(str: string) { return undefined; }, cookies: {} });
+        const services = new ServiceManager();
+
+        const response = await hook(ctx, services);
+        if (!isHttpResponseBadRequest(response)) {
+          throw new Error('Response should be an instance of HttpResponseBadRequest.');
+        }
+        deepStrictEqual(response.body, {
+          code: 'invalid_request',
+          description: 'Auth cookie not found.'
+        });
+      });
+
     } else {
 
       it('should let ctx.user equal undefined if the Authorization header does not exist.', async () => {
         const ctx = new Context({ get(str: string) { return undefined; } });
+        const services = new ServiceManager();
+
+        const response = await hook(ctx, services);
+        strictEqual(response, undefined);
+        strictEqual(ctx.user, undefined);
+      });
+
+      it('should let ctx.user equal undefined if options.cookie=true and the cookie does not exist.', async () => {
+        const hook = getHookFunction(JWT({ cookie: true }));
+
+        const ctx = new Context({ get(str: string) { return undefined; }, cookies: {} });
         const services = new ServiceManager();
 
         const response = await hook(ctx, services);
@@ -273,11 +301,24 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
       );
     });
 
-    it('should set ctx.user with the decoded payload if no fetchUser was given.', async () => {
+    it('should set ctx.user with the decoded payload if no fetchUser was given (cookie=false).', async () => {
       const hook = getHookFunction(JWT());
 
       const jwt = sign({ foo: 'bar' }, secret, {});
       const ctx = new Context({ get(str: string) { return str === 'Authorization' ? `Bearer ${jwt}` : undefined; } });
+      const services = new ServiceManager();
+
+      await hook(ctx, services);
+
+      notStrictEqual(ctx.user, undefined);
+      strictEqual((ctx.user as any).foo, 'bar');
+    });
+
+    it('should set ctx.user with the decoded payload if no fetchUser was given (cookie=true).', async () => {
+      const hook = getHookFunction(JWT({ cookie: true }));
+
+      const jwt = sign({ foo: 'bar' }, secret, {});
+      const ctx = new Context({ get: () => undefined, cookies: { auth: jwt } });
       const services = new ServiceManager();
 
       await hook(ctx, services);

--- a/packages/jwt/src/jwt.hook.spec.ts
+++ b/packages/jwt/src/jwt.hook.spec.ts
@@ -301,7 +301,7 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
       );
     });
 
-    it('should set ctx.user with the decoded payload if no fetchUser was given (cookie=false).', async () => {
+    it('should set ctx.user with the decoded payload if no fetchUser was given.', async () => {
       const hook = getHookFunction(JWT());
 
       const jwt = sign({ foo: 'bar' }, secret, {});
@@ -314,7 +314,7 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
       strictEqual((ctx.user as any).foo, 'bar');
     });
 
-    it('should set ctx.user with the decoded payload if no fetchUser was given (cookie=true).', async () => {
+    it('should set ctx.user with the decoded payload if no fetchUser was given (options.cookie=true).', async () => {
       const hook = getHookFunction(JWT({ cookie: true }));
 
       const jwt = sign({ foo: 'bar' }, secret, {});
@@ -325,6 +325,22 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
       notStrictEqual(ctx.user, undefined);
       strictEqual((ctx.user as any).foo, 'bar');
+    });
+
+    it('should set ctx.user with the decoded payload if no fetchUser was given (options.cookie=true '
+        + 'and JWT_COOKIE_NAME=xxx).', async () => {
+      process.env.JWT_COOKIE_NAME = 'xxx';
+      const hook = getHookFunction(JWT({ cookie: true }));
+
+      const jwt = sign({ foo: 'bar' }, secret, {});
+      const ctx = new Context({ get: () => undefined, cookies: { xxx: jwt } });
+      const services = new ServiceManager();
+
+      await hook(ctx, services);
+
+      notStrictEqual(ctx.user, undefined);
+      strictEqual((ctx.user as any).foo, 'bar');
+      process.env.JWT_COOKIE_NAME = '';
     });
 
     it('should return an HttpResponseUnauthorized object if there is no subject and a fetchUser'

--- a/packages/jwt/src/jwt.hook.ts
+++ b/packages/jwt/src/jwt.hook.ts
@@ -8,6 +8,7 @@ import { verify, VerifyOptions } from 'jsonwebtoken';
 export interface JWTOptions {
   user?: (id: string|number) => Promise<any|undefined>;
   blackList?: (token: string) => boolean|Promise<boolean>;
+  cookie?: boolean;
 }
 
 export function JWT(required: boolean, options: JWTOptions, verifyOptions: VerifyOptions): HookDecorator {
@@ -18,22 +19,44 @@ export function JWT(required: boolean, options: JWTOptions, verifyOptions: Verif
         'You must provide a secretOrPublicKey in jwt.json or in the JWT_SECRET_OR_PUBLIC_KEY environment variable.'
         );
     }
-    const authorizationHeader = ctx.request.get('Authorization') as string|undefined || '';
-    if (!authorizationHeader) {
-      if (!required) {
-        return;
+
+    let token: string;
+    if (options.cookie) {
+      const content = ctx.request.cookies.auth as string|undefined;
+
+      if (!content) {
+        if (!required) {
+          return;
+        }
+        return new HttpResponseBadRequest({
+          code: 'invalid_request',
+          description: 'Auth cookie not found.'
+        });
       }
-      return new HttpResponseBadRequest({
-        code: 'invalid_request',
-        description: 'Authorization header not found.'
-      });
-    }
-    const token = authorizationHeader.split('Bearer ')[1] as string|undefined;
-    if (!token) {
-      return new HttpResponseBadRequest({
-        code: 'invalid_request',
-        description: 'Expected a bearer token. Scheme is Authorization: Bearer <token>.'
-      });
+
+      token = content;
+    } else {
+      const authorizationHeader = ctx.request.get('Authorization') as string|undefined || '';
+
+      if (!authorizationHeader) {
+        if (!required) {
+          return;
+        }
+        return new HttpResponseBadRequest({
+          code: 'invalid_request',
+          description: 'Authorization header not found.'
+        });
+      }
+
+      const content = authorizationHeader.split('Bearer ')[1] as string|undefined;
+      if (!content) {
+        return new HttpResponseBadRequest({
+          code: 'invalid_request',
+          description: 'Expected a bearer token. Scheme is Authorization: Bearer <token>.'
+        });
+      }
+
+      token = content;
     }
 
     if (options.blackList && await options.blackList(token)) {

--- a/packages/jwt/src/jwt.hook.ts
+++ b/packages/jwt/src/jwt.hook.ts
@@ -22,7 +22,8 @@ export function JWT(required: boolean, options: JWTOptions, verifyOptions: Verif
 
     let token: string;
     if (options.cookie) {
-      const content = ctx.request.cookies.auth as string|undefined;
+      const cookieName = Config.get('jwt', 'cookieName') as string|undefined || 'auth';
+      const content = ctx.request.cookies[cookieName] as string|undefined;
 
       if (!content) {
         if (!required) {


### PR DESCRIPTION
# Issue

See #335.

# Solution and steps

- [x] Add the `cookie` option.
- [x] Handle the case where the cookie does not exist.
- [x] Let the user use a custom cookie name.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
