### PR TITLE
[Docs] Add "scheduling jobs" section

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -66,6 +66,7 @@
   * [Templating](./utilities/templating.md)
   * [Logging & Debugging](./utilities/logging-and-debugging.md)
 * Cookbook
+  * [Scheduling Jobs](./cookbook/scheduling-jobs.md)
   * [404 Page](./cookbook/404-page.md)
   * [Custom Directory Structure](./cookbook/custom-directory-structure.md)
 * Deployment & Environments

--- a/docs/cookbook/scheduling-jobs.md
+++ b/docs/cookbook/scheduling-jobs.md
@@ -1,0 +1,69 @@
+# Scheduling Jobs
+
+You can schedule jobs using [shell scripts](../development-environment/create-and-run-scripts.md) and the [node-schedule](https://www.npmjs.com/package/node-schedule) library.
+
+## Example
+
+*scripts/fetch-metrics.ts*
+```typescript
+export function main(args) {
+  // Do some stuff
+}
+
+```
+
+*scripts/schedule-jobs.ts*
+```typescript
+// 3p
+import { scheduleJob } from 'node-schedule';
+import { main as fetchMetrics } from './fetch-metrics';
+
+export async function main(args) {
+  console.log('Scheduling the job...');
+
+  // Run the fetch-metrics script every day at 10:00 AM.
+  scheduleJob(
+    { hour: 10, minute: 0 },
+    () => fetchMetrics(args)
+  );
+
+  console.log('Job scheduled!');
+}
+
+```
+
+Schedule the job(s):
+```sh
+npm run build:scripts
+foal run schedule-jobs arg1=value1
+```
+
+## Background Jobs with pm2
+
+While the above command works, it does not run the scheduler and the jobs in the background. To do this, you can use [pm2](http://pm2.keymetrics.io/), a popular process manager for Node.js.
+
+First you need to install *locally* the Foal CLI:
+```
+npm install @foal/cli
+```
+
+Then you can run the scheduler like this:
+
+```sh
+pm2 start ./node_modules/.bin/foal --name scheduler -- run schedule-jobs arg1=value1
+```
+
+If everything works fine, you should see your scheduler running with this command:
+```sh
+pm2 ls
+```
+
+To display the logs of the scheduler and the jobs, use this one:
+```
+pm2 logs scheduler
+```
+
+Eventually, to stop the scheduler and the jobs, you can use this command:
+```
+pm2 delete scheduler
+```


### PR DESCRIPTION
Add a section to the docs to explain how to schedule jobs with shell scripts, the `node-schedule` library and pm2.