### PR TITLE
Allow customized configuration for getAjvInstance

### DIFF
--- a/docs/validation-and-sanitization.md
+++ b/docs/validation-and-sanitization.md
@@ -19,6 +19,8 @@ Foal uses this [baseline ajv configuration](https://github.com/epoberezkin/ajv#o
 }
 ```
 
+You can override these settings with the config file `config/ajv.json` or using the environment variables `AJV_COERCE_TYPE`, `AJV_REMOVE_ADDITIONAL` and `AJV_USE_DEFAULTS`.
+
 ## The `validate` util
 
 The `validate` util throws a `ValidationError` if the given data does not fit the shema.
@@ -118,6 +120,9 @@ export class AppController {
 }
 
 ```
+
+
+Assuming that you did not change Foal's default configuration of Ajv (see above), you will get these results:
 
 | Request | Response |
 | --- | --- |

--- a/packages/core/src/common/utils/get-ajv-instance.spec.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.spec.ts
@@ -1,12 +1,12 @@
 import { strictEqual } from 'assert';
-import { getAjvInstance } from './get-ajv-instance';
+import { _instanceWrapper, getAjvInstance } from './get-ajv-instance';
 
 describe('getAjvInstance', () => {
 
   it('should use defaults.', () => {
     const schema = {
       properties: {
-        foo: { type: 'string', default: 'bar'}
+        foo: { type: 'string', default: 'bar' }
       },
       type: 'object',
     };
@@ -38,6 +38,53 @@ describe('getAjvInstance', () => {
     };
     getAjvInstance().validate(schema, data);
     strictEqual(data.foo, 3);
+  });
+
+  describe('', () => {
+
+    before(() => {
+      delete _instanceWrapper.instance;
+      process.env.AJV_COERCE_TYPES = 'false';
+      process.env.AJV_REMOVE_ADDITIONAL = 'false';
+      process.env.AJV_USE_DEFAULTS = 'false';
+    });
+
+    it('should accept custom configuration from the Config.', () => {
+      const schema = {
+        additionalProperties: false,
+        properties: {
+          foo: { type: 'number', default: 4 }
+        },
+        type: 'object',
+      };
+
+      const ajv = getAjvInstance();
+
+      // coerceTypes
+      const data = {
+        foo: '3'
+      };
+      strictEqual(ajv.validate(schema, data), false, 'Types should not be coerced.');
+
+      // removeAdditional
+      const data2 = {
+        bar: 'hello',
+        foo: 3,
+      };
+      strictEqual(ajv.validate(schema, data2), false, 'Additional properties should not be removed.');
+
+      // useDefaults
+      const data3 = {};
+      ajv.validate(schema, data3);
+      strictEqual((data3 as any).foo, undefined);
+    });
+
+    after(() => {
+      delete process.env.AJV_COERCE_TYPES;
+      delete process.env.AJV_REMOVE_ADDITIONAL;
+      delete process.env.AJV_USE_DEFAULTS;
+    });
+
   });
 
 });

--- a/packages/core/src/common/utils/get-ajv-instance.spec.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.spec.ts
@@ -80,6 +80,7 @@ describe('getAjvInstance', () => {
     });
 
     after(() => {
+      delete _instanceWrapper.instance;
       delete process.env.AJV_COERCE_TYPES;
       delete process.env.AJV_REMOVE_ADDITIONAL;
       delete process.env.AJV_USE_DEFAULTS;

--- a/packages/core/src/common/utils/get-ajv-instance.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.ts
@@ -1,12 +1,23 @@
 // 3p
 import * as Ajv from 'ajv';
+import { Config } from '../../core';
 
-const ajv = new Ajv({
-  coerceTypes: true,  // change data type of data to match type keyword
-  removeAdditional: true, // remove additional properties
-  useDefaults: true, // replace missing properties and items with the values from corresponding default keyword
-});
+// This is a little hack to test the customized configuration of `getAjvInstance`.
+// tslint:disable-next-line:variable-name
+export const _instanceWrapper: { instance: null|Ajv.Ajv } = {
+  instance: null
+};
 
-export function getAjvInstance() {
-  return ajv;
+export function getAjvInstance(): Ajv.Ajv {
+  if (!_instanceWrapper.instance) {
+    _instanceWrapper.instance = new Ajv({
+      // change data type of data to match type keyword
+      coerceTypes: Config.get('ajv', 'coerceTypes', true) as boolean,
+      // remove additional properties
+      removeAdditional: Config.get('ajv', 'removeAdditional', true) as boolean,
+      // replace missing properties and items with the values from corresponding default keyword
+      useDefaults: Config.get('ajv', 'useDefaults', true) as boolean,
+    });
+  }
+  return _instanceWrapper.instance;
 }

--- a/packages/core/src/common/utils/get-ajv-instance.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.ts
@@ -8,14 +8,22 @@ export const _instanceWrapper: { instance: null|Ajv.Ajv } = {
   instance: null
 };
 
+/**
+ * Returns the Ajv instance used internally by FoalTS.
+ *
+ * It has this default configuration:
+ *  - coerceTypes: true (Change data type of data to match `type` keyword.)
+ *  - removeAdditional: true (Remove additional properties when `additionalProperties` keyword is false.)
+ *  - useDefaults: true (Replace missing properties and items with the values from corresponding `default` keyword)
+ *
+ * This configuration can be overrided using the file `config/ajv.json` or through environment
+ * variables: AJV_COERCE_TYPES, AJV_REMOVE_ADDITIONAL, USE_DEFAULTS.
+ */
 export function getAjvInstance(): Ajv.Ajv {
   if (!_instanceWrapper.instance) {
     _instanceWrapper.instance = new Ajv({
-      // change data type of data to match type keyword
       coerceTypes: Config.get('ajv', 'coerceTypes', true) as boolean,
-      // remove additional properties
       removeAdditional: Config.get('ajv', 'removeAdditional', true) as boolean,
-      // replace missing properties and items with the values from corresponding default keyword
       useDefaults: Config.get('ajv', 'useDefaults', true) as boolean,
     });
   }


### PR DESCRIPTION
# Issue

Resolves #343 .

# Solution and steps

- Make `getAjvInstance` use `Config`.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
