### PR TITLE
[@foal/cli] Set the default cookie path to `/` in `config/`.

### DIFF
--- a/packages/cli/src/generate/specs/app/config/default.json
+++ b/packages/cli/src/generate/specs/app/config/default.json
@@ -6,6 +6,9 @@
     "loggerFormat": "tiny",
     "staticUrl": "public/",
     "session": {
+      "cookie": {
+        "path": "/"
+      },
       "resave": false,
       "saveUninitialized": false,
       "secret": "my-secret"

--- a/packages/cli/src/generate/specs/app/config/default.yml
+++ b/packages/cli/src/generate/specs/app/config/default.yml
@@ -6,6 +6,8 @@ settings:
   loggerFormat: tiny
   staticUrl: public/
   session:
+    cookie:
+      path: /
     resave: false
     saveUnitialized: false
     secret: my-secret

--- a/packages/cli/src/generate/templates/app/config/default.json
+++ b/packages/cli/src/generate/templates/app/config/default.json
@@ -6,6 +6,9 @@
     "loggerFormat": "tiny",
     "staticUrl": "public/",
     "session": {
+      "cookie": {
+        "path": "/"
+      },
       "resave": false,
       "saveUninitialized": false,
       "secret": "/* sessionSecret */"

--- a/packages/cli/src/generate/templates/app/config/default.yml
+++ b/packages/cli/src/generate/templates/app/config/default.yml
@@ -6,6 +6,8 @@ settings:
   loggerFormat: tiny
   staticUrl: public/
   session:
+    cookie:
+      path: /
     resave: false
     saveUnitialized: false
     secret: /* sessionSecret */

--- a/packages/typeorm/e2e/auth-redirect.spec.ts
+++ b/packages/typeorm/e2e/auth-redirect.spec.ts
@@ -10,7 +10,6 @@ import {
   HttpResponseNoContent,
   HttpResponseOK,
   HttpResponseRedirect,
-  HttpResponseUnauthorized,
   logIn,
   LoginRequired,
   logOut,


### PR DESCRIPTION
# Issue

Having a session cookie path not set makes the authentication to fail in some situations. See #357.

# Solution and steps

- [x] Update `default.json`
- [x] Update `default.yml`

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
