### PR TITLE
[@foal/cli] Upgrade TSC to version 3 or greater

### DIFF
--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -52,6 +52,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^2.8.3"
+    "typescript": "^3.3.3"
   }
 }

--- a/packages/cli/src/generate/specs/app/package.mongodb.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.json
@@ -47,6 +47,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^2.8.3"
+    "typescript": "^3.3.3"
   }
 }

--- a/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
@@ -48,6 +48,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^2.8.3"
+    "typescript": "^3.3.3"
   }
 }

--- a/packages/cli/src/generate/specs/app/package.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.yaml.json
@@ -53,6 +53,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^2.8.3"
+    "typescript": "^3.3.3"
   }
 }

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -52,6 +52,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^2.8.3"
+    "typescript": "^3.3.3"
   }
 }

--- a/packages/cli/src/generate/templates/app/package.mongodb.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.json
@@ -47,6 +47,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^2.8.3"
+    "typescript": "^3.3.3"
   }
 }

--- a/packages/cli/src/generate/templates/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.yaml.json
@@ -48,6 +48,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^2.8.3"
+    "typescript": "^3.3.3"
   }
 }

--- a/packages/cli/src/generate/templates/app/package.yaml.json
+++ b/packages/cli/src/generate/templates/app/package.yaml.json
@@ -53,6 +53,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^2.8.3"
+    "typescript": "^3.3.3"
   }
 }


### PR DESCRIPTION
# Issue

The package `typeorm` now requires TypeScript 3.3 or greater since the version `0.2.15`, causing the build to fail on every new project with Foal (see #377).

# Solution and steps

Every new project will start with the version 3.3 of the TypeScript Compiler or greater (instead of v2.9.2).

This won't introduce any breaking changes since the framework code is compatible with both versions 2 or 3 of TypeScript (see [here](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes)).

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
