### PR TITLE
[@foal/cli] Use source maps during testing

### DIFF
--- a/packages/cli/src/generate/specs/app/src/e2e.ts
+++ b/packages/cli/src/generate/specs/app/src/e2e.ts
@@ -1,1 +1,2 @@
+import 'source-map-support/register';
 process.env.NODE_ENV = 'e2e';

--- a/packages/cli/src/generate/specs/app/src/test.ts
+++ b/packages/cli/src/generate/specs/app/src/test.ts
@@ -1,1 +1,2 @@
+import 'source-map-support/register';
 process.env.NODE_ENV = 'test';

--- a/packages/cli/src/generate/templates/app/src/e2e.ts
+++ b/packages/cli/src/generate/templates/app/src/e2e.ts
@@ -1,1 +1,2 @@
+import 'source-map-support/register';
 process.env.NODE_ENV = 'e2e';

--- a/packages/cli/src/generate/templates/app/src/test.ts
+++ b/packages/cli/src/generate/templates/app/src/test.ts
@@ -1,1 +1,2 @@
+import 'source-map-support/register';
 process.env.NODE_ENV = 'test';


### PR DESCRIPTION
# Issue

See #385.

The tracebacks of the errors thrown during unit or e2e tests do not use the source maps. Thus the errors refer to the JS files and not the TS ones.

# Solution and steps

- [x] Register `source-map-support` before running the tests.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
