### PR TITLE
Let developers specify a virtual path prefix for static files

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -72,6 +72,7 @@
   * [CSRF Protection](./security/csrf-protection.md)
   * [XSS Protection](./security/xss-protection.md)
 * Utilities
+  * [Static Files](./utilities/static-files.md)
   * [Templating](./utilities/templating.md)
   * [Logging & Debugging](./utilities/logging-and-debugging.md)
 * Cookbook

--- a/docs/utilities/static-files.md
+++ b/docs/utilities/static-files.md
@@ -1,0 +1,54 @@
+# Serving Static Files
+
+By default, Foal serves static files from the `public/` directory.
+
+## Example
+
+*`public/`*
+```
+index.html
+styles.css
+app.js
+```
+
+*Paths served*
+```
+/ -> returns index.html
+/index.html -> returns index.html
+/styles.css -> returns styles.css
+/app.js -> returns app.js
+```
+
+# Change the directory
+
+You can change the directory where the static files are served using the badly named configuration key `staticUrl`.
+
+*Example with `config/default.json`*
+```json
+{
+  "settings": {
+    "staticUrl": "another-directory/"
+  }
+}
+```
+
+# Add a virtual prefix path
+
+You can add a virtual prefix path using the configuration key `staticPathPrefix`.
+
+*Example with `config/default.json`*
+```json
+{
+  "settings": {
+    "staticPathPrefix": "static/"
+  }
+}
+```
+
+*Paths served (example)*
+```
+/static/ -> returns index.html
+/static/index.html -> returns index.html
+/static/styles.css -> returns styles.css
+/static/app.js -> returns app.js
+```

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -24,13 +24,16 @@ describe('createApp', () => {
 
   after(() => {
     delete process.env.SETTINGS_STATIC_URL;
-    delete process.env.SETTINGS_STATIC_PATH_PREFIX;
     if (existsSync('test-public/hello-world.html')) {
       unlinkSync('test-public/hello-world.html');
     }
     if (existsSync('test-public')) {
       rmdirSync('test-public');
     }
+  });
+
+  afterEach(() => {
+    delete process.env.SETTINGS_STATIC_PATH_PREFIX;
   });
 
   it('should serve static files.', async () => {

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -8,10 +8,48 @@ import { MemoryStore } from 'express-session';
 import * as request from 'supertest';
 
 // FoalTS
+import { existsSync, mkdirSync, rmdirSync, unlinkSync, writeFileSync } from 'fs';
 import { Context, Delete, Get, Head, HttpResponseOK, Options, Patch, Post, Put } from '../core';
 import { createApp } from './create-app';
 
 describe('createApp', () => {
+
+  before(() => {
+    if (!existsSync('test-public')) {
+      mkdirSync('test-public');
+    }
+    writeFileSync('test-public/hello-world.html', '<h1>Hello world!</h1>', 'utf8');
+    process.env.SETTINGS_STATIC_URL = 'test-public';
+  });
+
+  after(() => {
+    delete process.env.SETTINGS_STATIC_URL;
+    delete process.env.SETTINGS_STATIC_PATH_PREFIX;
+    if (existsSync('test-public/hello-world.html')) {
+      unlinkSync('test-public/hello-world.html');
+    }
+    if (existsSync('test-public')) {
+      rmdirSync('test-public');
+    }
+  });
+
+  it('should serve static files.', async () => {
+    const app = createApp(class {});
+    await request(app)
+      .get('/hello-world.html')
+      .expect(200)
+      .expect('Content-type', 'text/html; charset=UTF-8');
+  });
+
+  it('should support custom path prefix when serving static files.', async () => {
+    process.env.SETTINGS_STATIC_PATH_PREFIX = '/prefix';
+
+    const app = createApp(class {});
+    await request(app)
+      .get('/prefix/hello-world.html')
+      .expect(200)
+      .expect('Content-type', 'text/html; charset=UTF-8');
+  });
 
   it('should return a 403 "Bad csrf token" on POST/PATCH/PUT/DELETE requests with bad'
       + ' csrf token.', () => {

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -37,7 +37,7 @@ describe('createApp', () => {
     const app = createApp(class {});
     await request(app)
       .get('/hello-world.html')
-      .expect(200)
+      .expect(200, '<h1>Hello world!</h1>')
       .expect('Content-type', 'text/html; charset=UTF-8');
   });
 
@@ -47,7 +47,7 @@ describe('createApp', () => {
     const app = createApp(class {});
     await request(app)
       .get('/prefix/hello-world.html')
-      .expect(200)
+      .expect(200, '<h1>Hello world!</h1>')
       .expect('Content-type', 'text/html; charset=UTF-8');
   });
 

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -45,7 +45,10 @@ export function createApp(rootControllerClass: Class, options: CreateAppOptions 
   );
 
   app.use(logger(loggerFormat));
-  app.use(express.static(Config.get('settings.staticUrl', 'public')));
+  app.use(
+    Config.get('settings.staticPathPrefix', ''),
+    express.static(Config.get('settings.staticUrl', 'public'))
+  );
   app.use(helmet());
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));


### PR DESCRIPTION
# Issue

See #382 

# Solution and steps

Add the settings.staticPathPrefix option.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
