### PR TITLE
Add a class `ConfigMock` to mock the `Config` when it used as a service

### DIFF
--- a/docs/deployment-and-environments/configuration.md
+++ b/docs/deployment-and-environments/configuration.md
@@ -133,17 +133,26 @@ export class AppController {
 
 *app.controller.spec.ts*
 ```typescript
-import { createController } from '@foal/core';
+import { createController, ConfigMock } from '@foal/core';
 
 import { AppController } from './app.controller';
 
 ...
-const config = {
-  get: (str: string) => str === 'secret' ? 'fake_secret' : ''
-};
+const config = new ConfigMock();
+config.set('secret', 'fake_secret');
 const controller = createController(AppController, { config });
 ...
 
+```
+
+The `ConfigMock` is a class to mock the configuration during testing. Here is its signature:
+
+```typescript
+interface {
+  set(key: string, value: any): void;
+  reset(): void;
+  get<T = any>(key: string, defaultValue?: T): T;
+}
 ```
 
 ## Additional Resources

--- a/packages/core/src/core/config-mock.spec.ts
+++ b/packages/core/src/core/config-mock.spec.ts
@@ -26,4 +26,22 @@ describe('ConfigMock', () => {
 
   });
 
+  describe('when "reset" is called', () => {
+
+    it('should clear every config value previously given with the "set" method.', () => {
+      const config = new ConfigMock();
+      config.set('a', 'A');
+      config.set('b', 'B');
+
+      strictEqual(config.get('a'), 'A');
+      strictEqual(config.get('b'), 'B');
+
+      config.reset();
+
+      strictEqual(config.get('a'), undefined);
+      strictEqual(config.get('b'), undefined);
+    });
+
+  });
+
 });

--- a/packages/core/src/core/config-mock.spec.ts
+++ b/packages/core/src/core/config-mock.spec.ts
@@ -1,0 +1,29 @@
+import { strictEqual } from 'assert';
+import { ConfigMock } from './config-mock';
+
+describe('ConfigMock', () => {
+
+  describe('when "get" is called', () => {
+
+    it('should return the value given previously with the "set" method.', () => {
+      const expected = 'barfoo';
+
+      const config = new ConfigMock();
+      config.set('settings.foo.bar', expected);
+
+      const actual = config.get('settings.foo.bar');
+      strictEqual(actual, expected);
+    });
+
+    it('should return the default value if no value was previously provided.', () => {
+      const expected = 'barfoo';
+
+      const config = new ConfigMock();
+
+      const actual = config.get('settings.foo.bar', expected);
+      strictEqual(actual, expected);
+    });
+
+  });
+
+});

--- a/packages/core/src/core/config-mock.ts
+++ b/packages/core/src/core/config-mock.ts
@@ -1,0 +1,38 @@
+import { Config } from './config';
+
+/**
+ * Mock the Config class when it is used as a service.
+ *
+ * @export
+ * @class ConfigMock
+ * @implements {Config}
+ */
+export class ConfigMock implements Config {
+
+  private map: Map<string, any> = new Map();
+
+  /**
+   * Set an configuration variable.
+   *
+   * @param {string} key - Name of the config key using dots and camel case.
+   * @param {*} value - The config value (ex: 36000).
+   * @memberof ConfigMock
+   */
+  set(key: string, value: any) {
+    this.map.set(key, value);
+  }
+
+  /**
+   * Return the config value previously given by ConfigMock.set.
+   *
+   * @template T - TypeScript type of the returned value. Default is `any`.
+   * @param {string} key - Name of the config key using dots and camel case.
+   * @param {T} [defaultValue] - Default value to return if no configuration is found with that key.
+   * @returns {T} The configuration value.
+   * @memberof ConfigMock
+   */
+  get<T = any>(key: string, defaultValue?: T | undefined): T {
+    return this.map.get(key) || defaultValue;
+  }
+
+}

--- a/packages/core/src/core/config-mock.ts
+++ b/packages/core/src/core/config-mock.ts
@@ -23,7 +23,7 @@ export class ConfigMock implements Config {
   }
 
   /**
-   * Return the config value previously given by ConfigMock.set.
+   * Return the config value previously given with ConfigMock.set.
    *
    * @template T - TypeScript type of the returned value. Default is `any`.
    * @param {string} key - Name of the config key using dots and camel case.
@@ -33,6 +33,15 @@ export class ConfigMock implements Config {
    */
   get<T = any>(key: string, defaultValue?: T | undefined): T {
     return this.map.get(key) || defaultValue;
+  }
+
+  /**
+   * Clear every config value previously given with Config.set.
+   *
+   * @memberof ConfigMock
+   */
+  reset(): void {
+    this.map.clear();
   }
 
 }

--- a/packages/core/src/core/config-mock.ts
+++ b/packages/core/src/core/config-mock.ts
@@ -18,7 +18,7 @@ export class ConfigMock implements Config {
    * @param {*} value - The config value (ex: 36000).
    * @memberof ConfigMock
    */
-  set(key: string, value: any) {
+  set(key: string, value: any): void {
     this.map.set(key, value);
   }
 

--- a/packages/core/src/core/index.ts
+++ b/packages/core/src/core/index.ts
@@ -3,5 +3,6 @@ export { createController } from './controllers';
 export * from './http';
 export * from './hooks';
 export * from './routes';
+export { ConfigMock } from './config-mock';
 export { Config } from './config';
 export { createService, dependency, ServiceManager } from './service-manager';

--- a/packages/jwt/src/jwt.hook.ts
+++ b/packages/jwt/src/jwt.hook.ts
@@ -28,7 +28,8 @@ export interface JWTOptions {
  */
 export function JWT(required: boolean, options: JWTOptions, verifyOptions: VerifyOptions): HookDecorator {
   return Hook(async (ctx, services) => {
-    const secretOrPublicKey = Config.get<string|undefined>('settings.jwt.secretOrPublicKey');
+    const config = services.get(Config);
+    const secretOrPublicKey = config.get<string|undefined>('settings.jwt.secretOrPublicKey');
     if (!secretOrPublicKey) {
       throw new Error(
         'You must provide a settings.jwt.secretOrPublicKey in default.json or '
@@ -38,7 +39,7 @@ export function JWT(required: boolean, options: JWTOptions, verifyOptions: Verif
 
     let token: string;
     if (options.cookie) {
-      const cookieName = Config.get<string>('settings.jwt.cookieName', 'auth');
+      const cookieName = config.get<string>('settings.jwt.cookieName', 'auth');
       const content = ctx.request.cookies[cookieName] as string|undefined;
 
       if (!content) {


### PR DESCRIPTION
# Issue

Resolves #367.

# Solution and steps

- [x] Add, implement and export the `ConfigMock` class.
- [x] Use the `ConfigMock` class to test the hooks `JWTRequired` and `JWTOptional`.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
