### PR TITLE
[Internal] [@foal/cli] Add and use rmDirAndFilesIfExist in the tests

### DIFF
--- a/packages/cli/src/generate/generators/angular/connect-angular.spec.ts
+++ b/packages/cli/src/generate/generators/angular/connect-angular.spec.ts
@@ -1,17 +1,10 @@
-import { mkdirIfDoesNotExist, rmdirIfExists, rmfileIfExists, TestEnvironment } from '../../utils';
+import { mkdirIfDoesNotExist, rmDirAndFilesIfExist, TestEnvironment } from '../../utils';
 import { connectAngular } from './connect-angular';
 
 // TODO: To improve: make the tests (more) independent from each other.
 describe('connectAngular', () => {
 
-  afterEach(() => {
-    rmfileIfExists('connector-test/angular/src/proxy.conf.json');
-    rmdirIfExists('connector-test/angular/src');
-    rmfileIfExists('connector-test/angular/angular.json');
-    rmfileIfExists('connector-test/angular/package.json');
-    rmdirIfExists('connector-test/angular');
-    rmdirIfExists('connector-test');
-  });
+  afterEach(() => rmDirAndFilesIfExist('connector-test'));
 
   const testEnv = new TestEnvironment('angular');
 

--- a/packages/cli/src/generate/generators/app/create-app.spec.ts
+++ b/packages/cli/src/generate/generators/app/create-app.spec.ts
@@ -6,78 +6,7 @@ describe('createApp', () => {
 
   const testEnv = new TestEnvironment('app', 'test-foo-bar');
 
-  afterEach(() => {
-    testEnv.rmfileIfExists('.gitignore');
-    testEnv.rmfileIfExists('ormconfig.json');
-    testEnv.rmfileIfExists('ormconfig.yml');
-    testEnv.rmfileIfExists('package.json');
-    testEnv.rmfileIfExists('tsconfig.app.json');
-    testEnv.rmfileIfExists('tsconfig.e2e.json');
-    testEnv.rmfileIfExists('tsconfig.json');
-    testEnv.rmfileIfExists('tsconfig.migrations.json');
-    testEnv.rmfileIfExists('tsconfig.scripts.json');
-    testEnv.rmfileIfExists('tsconfig.test.json');
-    testEnv.rmfileIfExists('tslint.json');
-
-    // Config
-    testEnv.rmfileIfExists('config/e2e.json');
-    testEnv.rmfileIfExists('config/development.json');
-    testEnv.rmfileIfExists('config/default.json');
-    testEnv.rmfileIfExists('config/production.json');
-
-    testEnv.rmfileIfExists('config/e2e.yml');
-    testEnv.rmfileIfExists('config/development.yml');
-    testEnv.rmfileIfExists('config/default.yml');
-    testEnv.rmfileIfExists('config/production.yml');
-    testEnv.rmdirIfExists('config');
-
-    // Public
-    testEnv.rmfileIfExists('public/logo.png');
-    testEnv.rmfileIfExists('public/index.html');
-    testEnv.rmdirIfExists('public');
-
-    // Src
-    testEnv.rmfileIfExists('src/app/controllers/index.ts');
-    testEnv.rmfileIfExists('src/app/controllers/api.controller.spec.ts');
-    testEnv.rmfileIfExists('src/app/controllers/api.controller.ts');
-    testEnv.rmdirIfExists('src/app/controllers');
-
-    testEnv.rmfileIfExists('src/app/hooks/index.ts');
-    testEnv.rmdirIfExists('src/app/hooks');
-
-    testEnv.rmfileIfExists('src/app/entities/index.ts');
-    testEnv.rmfileIfExists('src/app/entities/user.entity.ts');
-    testEnv.rmdirIfExists('src/app/entities');
-
-    testEnv.rmfileIfExists('src/app/models/index.ts');
-    testEnv.rmfileIfExists('src/app/models/user.model.ts');
-    testEnv.rmdirIfExists('src/app/models');
-
-    testEnv.rmfileIfExists('src/app/sub-apps/index.ts');
-    testEnv.rmdirIfExists('src/app/sub-apps');
-
-    testEnv.rmfileIfExists('src/app/services/index.ts');
-    testEnv.rmdirIfExists('src/app/services');
-
-    testEnv.rmfileIfExists('src/app/app.controller.ts');
-    testEnv.rmdirIfExists('src/app');
-
-    testEnv.rmfileIfExists('src/e2e/index.ts');
-    testEnv.rmdirIfExists('src/e2e');
-
-    testEnv.rmfileIfExists('src/scripts/create-group.ts');
-    testEnv.rmfileIfExists('src/scripts/create-perm.ts');
-    testEnv.rmfileIfExists('src/scripts/create-user.ts');
-    testEnv.rmdirIfExists('src/scripts');
-
-    testEnv.rmfileIfExists('src/e2e.ts');
-    testEnv.rmfileIfExists('src/index.ts');
-    testEnv.rmfileIfExists('src/test.ts');
-    testEnv.rmdirIfExists('src');
-
-    // Root
-    testEnv.rmdirIfExists('../test-foo-bar');
-  });
+  afterEach(() => testEnv.rmDirAndFilesIfExist('../test-foo-bar'));
 
   it('should render the config templates.', async () => {
     await createApp({ name: 'test-fooBar', sessionSecret: 'my-secret' });

--- a/packages/cli/src/generate/generators/controller/create-controller.spec.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.spec.ts
@@ -1,6 +1,6 @@
 // FoalTS
 import {
-  rmdirIfExists,
+  rmDirAndFilesIfExist,
   rmfileIfExists,
   TestEnvironment
 } from '../../utils';
@@ -9,21 +9,10 @@ import { createController } from './create-controller';
 describe('createController', () => {
 
   afterEach(() => {
-    rmfileIfExists('src/app/controllers/test-foo-bar.controller.ts');
-    rmfileIfExists('src/app/controllers/test-foo-bar.controller.spec.ts');
-    rmfileIfExists('src/app/controllers/index.ts');
-    rmdirIfExists('src/app/controllers');
-    rmfileIfExists('src/app/app.controller.ts');
-    rmdirIfExists('src/app');
+    rmDirAndFilesIfExist('src/app');
     // We cannot remove src/ since the generator code lives within. This is bad testing
     // approach.
-    // rmdirIfExists('src');
-
-    rmfileIfExists('controllers/test-foo-bar.controller.ts');
-    rmfileIfExists('controllers/test-foo-bar.controller.spec.ts');
-    rmfileIfExists('controllers/index.ts');
-    rmdirIfExists('controllers');
-
+    rmDirAndFilesIfExist('controllers');
     rmfileIfExists('test-foo-bar.controller.ts');
     rmfileIfExists('test-foo-bar.controller.spec.ts');
     rmfileIfExists('index.ts');

--- a/packages/cli/src/generate/generators/entity/create-entity.spec.ts
+++ b/packages/cli/src/generate/generators/entity/create-entity.spec.ts
@@ -1,6 +1,6 @@
 // FoalTS
 import {
-  rmdirIfExists,
+  rmDirAndFilesIfExist,
   rmfileIfExists,
   TestEnvironment,
 } from '../../utils';
@@ -9,18 +9,10 @@ import { createEntity } from './create-entity';
 describe('createEntity', () => {
 
   afterEach(() => {
-    rmfileIfExists('src/app/entities/test-foo-bar.entity.ts');
-    rmfileIfExists('src/app/entities/index.ts');
-    rmdirIfExists('src/app/entities');
-    rmdirIfExists('src/app');
+    rmDirAndFilesIfExist('src/app');
     // We cannot remove src/ since the generator code lives within. This is bad testing
     // approach.
-    // rmdirIfExists('src');
-
-    rmfileIfExists('entities/test-foo-bar.entity.ts');
-    rmfileIfExists('entities/index.ts');
-    rmdirIfExists('entities');
-
+    rmDirAndFilesIfExist('entities');
     rmfileIfExists('test-foo-bar.entity.ts');
     rmfileIfExists('index.ts');
   });

--- a/packages/cli/src/generate/generators/hook/create-hook.spec.ts
+++ b/packages/cli/src/generate/generators/hook/create-hook.spec.ts
@@ -1,6 +1,6 @@
 // FoalTS
 import {
-  rmdirIfExists,
+  rmDirAndFilesIfExist,
   rmfileIfExists,
   TestEnvironment,
 } from '../../utils';
@@ -9,18 +9,10 @@ import { createHook } from './create-hook';
 describe('createHook', () => {
 
   afterEach(() => {
-    rmfileIfExists('src/app/hooks/test-foo-bar.hook.ts');
-    rmfileIfExists('src/app/hooks/index.ts');
-    rmdirIfExists('src/app/hooks');
-    rmdirIfExists('src/app');
+    rmDirAndFilesIfExist('src/app');
     // We cannot remove src/ since the generator code lives within. This is bad testing
     // approach.
-    // rmdirIfExists('src');
-
-    rmfileIfExists('hooks/test-foo-bar.hook.ts');
-    rmfileIfExists('hooks/index.ts');
-    rmdirIfExists('hooks');
-
+    rmDirAndFilesIfExist('hooks');
     rmfileIfExists('test-foo-bar.hook.ts');
     rmfileIfExists('index.ts');
   });

--- a/packages/cli/src/generate/generators/model/create-model.spec.ts
+++ b/packages/cli/src/generate/generators/model/create-model.spec.ts
@@ -1,6 +1,6 @@
 // FoalTS
 import {
-  rmdirIfExists,
+  rmDirAndFilesIfExist,
   rmfileIfExists,
   TestEnvironment,
 } from '../../utils';
@@ -9,20 +9,10 @@ import { createModel } from './create-model';
 describe('createModel', () => {
 
   afterEach(() => {
-    rmfileIfExists('src/app/models/a-test-foo-bar.model.ts');
-    rmfileIfExists('src/app/models/test-foo-bar.model.ts');
-    rmfileIfExists('src/app/models/index.ts');
-    rmdirIfExists('src/app/models');
-    rmdirIfExists('src/app');
+    rmDirAndFilesIfExist('src/app');
     // We cannot remove src/ since the generator code lives within. This is bad testing
     // approach.
-    // rmdirIfExists('src');
-
-    rmfileIfExists('models/a-test-foo-bar.model.ts');
-    rmfileIfExists('models/test-foo-bar.model.ts');
-    rmfileIfExists('models/index.ts');
-    rmdirIfExists('models');
-
+    rmDirAndFilesIfExist('models');
     rmfileIfExists('a-test-foo-bar.model.ts');
     rmfileIfExists('test-foo-bar.model.ts');
     rmfileIfExists('index.ts');

--- a/packages/cli/src/generate/generators/react/connect-react.spec.ts
+++ b/packages/cli/src/generate/generators/react/connect-react.spec.ts
@@ -1,13 +1,9 @@
-import { mkdirIfDoesNotExist, rmdirIfExists, rmfileIfExists, TestEnvironment } from '../../utils';
+import { mkdirIfDoesNotExist, rmDirAndFilesIfExist, TestEnvironment } from '../../utils';
 import { connectReact } from './connect-react';
 
 describe('connectReact', () => {
 
-  afterEach(() => {
-    rmfileIfExists('connector-test/react/package.json');
-    rmdirIfExists('connector-test/react');
-    rmdirIfExists('connector-test');
-  });
+  afterEach(() => rmDirAndFilesIfExist('connector-test'));
 
   const testEnv = new TestEnvironment('react');
 

--- a/packages/cli/src/generate/generators/rest-api/create-rest-api.spec.ts
+++ b/packages/cli/src/generate/generators/rest-api/create-rest-api.spec.ts
@@ -1,6 +1,6 @@
 // FoalTS
 import {
-  rmdirIfExists,
+  rmDirAndFilesIfExist,
   rmfileIfExists,
   TestEnvironment,
 } from '../../utils';
@@ -9,32 +9,12 @@ import { createRestApi } from './create-rest-api';
 describe('createRestApi', () => {
 
   afterEach(() => {
-    rmfileIfExists('src/app/entities/test-foo-bar.entity.ts');
-    rmfileIfExists('src/app/entities/index.ts');
-    rmdirIfExists('src/app/entities');
-
-    rmfileIfExists('src/app/controllers/test-foo-bar.controller.ts');
-    rmfileIfExists('src/app/controllers/test-foo-bar.controller.spec.ts');
-    rmfileIfExists('src/app/controllers/index.ts');
-    rmdirIfExists('src/app/controllers');
-
-    rmfileIfExists('src/app/app.controller.ts');
-    rmdirIfExists('src/app');
+    rmDirAndFilesIfExist('src/app');
     // We cannot remove src/ since the generator code lives within. This is bad testing
     // approach.
-    // rmdirIfExists('src');
-
-    rmfileIfExists('entities/test-foo-bar.entity.ts');
-    rmfileIfExists('entities/index.ts');
-    rmdirIfExists('entities');
-
-    rmfileIfExists('controllers/test-foo-bar.controller.ts');
-    rmfileIfExists('controllers/test-foo-bar.controller.spec.ts');
-    rmfileIfExists('controllers/index.ts');
-    rmdirIfExists('controllers');
-
+    rmDirAndFilesIfExist('entities');
+    rmDirAndFilesIfExist('controllers');
     rmfileIfExists('app.controller.ts');
-
     rmfileIfExists('test-foo-bar.entity.ts');
     rmfileIfExists('test-foo-bar.controller.ts');
     rmfileIfExists('test-foo-bar.controller.spec.ts');

--- a/packages/cli/src/generate/generators/script/create-script.spec.ts
+++ b/packages/cli/src/generate/generators/script/create-script.spec.ts
@@ -1,7 +1,6 @@
 // FoalTS
 import {
-  rmdirIfExists,
-  rmfileIfExists,
+  rmDirAndFilesIfExist,
   TestEnvironment,
 } from '../../utils';
 import { createScript } from './create-script';
@@ -11,11 +10,9 @@ import { createScript } from './create-script';
 describe('createScript', () => {
 
   afterEach(() => {
-    rmfileIfExists('src/scripts/test-foo-bar.ts');
-    rmdirIfExists('src/scripts');
+    rmDirAndFilesIfExist('src/scripts');
     // We cannot remove src/ since the generator code lives within. This is bad testing
     // approach.
-    // rmdirIfExists('src');
   });
 
   describe(`when the directory src/scripts/ exists`, () => {

--- a/packages/cli/src/generate/generators/service/create-service.spec.ts
+++ b/packages/cli/src/generate/generators/service/create-service.spec.ts
@@ -1,6 +1,6 @@
 // FoalTS
 import {
-  rmdirIfExists,
+  rmDirAndFilesIfExist,
   rmfileIfExists,
   TestEnvironment
 } from '../../utils';
@@ -9,27 +9,14 @@ import { createService } from './create-service';
 describe('createService', () => {
 
   afterEach(() => {
-    rmfileIfExists('src/app/services/test-foo-bar.service.ts');
-    rmfileIfExists('src/app/services/test-foo-bar-collection.service.ts');
-    rmfileIfExists('src/app/services/test-foo-bar-resolver.service.ts');
-    rmfileIfExists('src/app/services/index.ts');
-    rmdirIfExists('src/app/services');
-    rmdirIfExists('src/app');
+    rmDirAndFilesIfExist('src/app');
     // We cannot remove src/ since the generator code lives within. This is bad testing
     // approach.
-    // rmdirIfExists('src');
-
-    rmfileIfExists('services/test-foo-bar.service.ts');
-    rmfileIfExists('services/test-foo-bar-collection.service.ts');
-    rmfileIfExists('services/test-foo-bar-resolver.service.ts');
-    rmfileIfExists('services/index.ts');
-    rmdirIfExists('services');
-
+    rmDirAndFilesIfExist('services');
     rmfileIfExists('test-foo-bar.service.ts');
     rmfileIfExists('test-foo-bar-collection.service.ts');
     rmfileIfExists('test-foo-bar-resolver.service.ts');
     rmfileIfExists('index.ts');
-
   });
 
   function test(root: string) {

--- a/packages/cli/src/generate/generators/sub-app/create-sub-app.spec.ts
+++ b/packages/cli/src/generate/generators/sub-app/create-sub-app.spec.ts
@@ -7,51 +7,22 @@ import {
   mkdirIfNotExists,
   readFileFromRoot,
   readFileFromTemplatesSpec,
-  rmdirIfExists,
+  rmDirAndFilesIfExist,
   rmfileIfExists
 } from '../../utils';
 import { createSubApp } from './create-sub-app';
 
 // TODO: Use TestEnvironment.
 
-function removeFiles(prefix: string = '') {
-  rmdirIfExists(`${prefix}test-foo-bar/controllers/templates`);
-  rmfileIfExists(`${prefix}test-foo-bar/controllers/index.ts`);
-  rmdirIfExists(`${prefix}test-foo-bar/controllers`);
-
-  rmfileIfExists(`${prefix}test-foo-bar/hooks/index.ts`);
-  rmdirIfExists(`${prefix}test-foo-bar/hooks`);
-
-  rmfileIfExists(`${prefix}test-foo-bar/entities/index.ts`);
-  rmdirIfExists(`${prefix}test-foo-bar/entities`);
-
-  rmfileIfExists(`${prefix}test-foo-bar/sub-apps/index.ts`);
-  rmdirIfExists(`${prefix}test-foo-bar/sub-apps`);
-
-  rmfileIfExists(`${prefix}test-foo-bar/services/index.ts`);
-  rmdirIfExists(`${prefix}test-foo-bar/services`);
-
-  rmfileIfExists(`${prefix}test-foo-bar/test-foo-bar.controller.ts`);
-  rmfileIfExists(`${prefix}test-foo-bar/index.ts`);
-
-  rmdirIfExists(`${prefix}test-foo-bar`);
-  rmfileIfExists(`${prefix}index.ts`);
-}
-
 describe('createSubApp', () => {
 
   afterEach(() => {
-    removeFiles('src/app/sub-apps/');
-    rmdirIfExists('src/app/sub-apps');
-    rmdirIfExists('src/app');
+    rmDirAndFilesIfExist('src/app');
     // We cannot remove src/ since the generator code lives within. This is bad testing
     // approach.
-    // rmdirIfExists('src');
-
-    removeFiles('sub-apps/');
-    rmdirIfExists('sub-apps');
-
-    removeFiles();
+    rmDirAndFilesIfExist('sub-apps');
+    rmDirAndFilesIfExist('test-foo-bar');
+    rmfileIfExists('index.ts');
   });
 
   const indexInitialContent = 'export { BarFooController } from \'./bar-foo\';\n';

--- a/packages/cli/src/generate/generators/vscode-config/create-vscode-config.spec.ts
+++ b/packages/cli/src/generate/generators/vscode-config/create-vscode-config.spec.ts
@@ -1,18 +1,13 @@
 // FoalTS
 import {
-  rmdirIfExists,
-  rmfileIfExists,
+  rmDirAndFilesIfExist,
   TestEnvironment,
 } from '../../utils';
 import { createVSCodeConfig } from './create-vscode-config';
 
 describe('createVSCodeConfig', () => {
 
-  afterEach(() => {
-    rmfileIfExists('.vscode/launch.json');
-    rmfileIfExists('.vscode/tasks.json');
-    rmdirIfExists('.vscode');
-  });
+  afterEach(() => rmDirAndFilesIfExist('.vscode'));
 
   const testEnv = new TestEnvironment('vscode-config', '.vscode');
 

--- a/packages/cli/src/generate/generators/vue/connect-vue.spec.ts
+++ b/packages/cli/src/generate/generators/vue/connect-vue.spec.ts
@@ -1,13 +1,9 @@
-import { mkdirIfDoesNotExist, rmdirIfExists, rmfileIfExists, TestEnvironment } from '../../utils';
+import { mkdirIfDoesNotExist, rmDirAndFilesIfExist, TestEnvironment } from '../../utils';
 import { connectVue } from './connect-vue';
 
 describe('connectVue', () => {
 
-  afterEach(() => {
-    rmfileIfExists('connector-test/vue/package.json');
-    rmdirIfExists('connector-test/vue');
-    rmdirIfExists('connector-test');
-  });
+  afterEach(() => rmDirAndFilesIfExist('connector-test'));
 
   const testEnv = new TestEnvironment('vue');
 

--- a/packages/cli/src/generate/utils/index.ts
+++ b/packages/cli/src/generate/utils/index.ts
@@ -6,6 +6,7 @@ import { join } from 'path';
 export { findProjectPath } from './find-project-path';
 export { Generator } from './generator';
 export { initGitRepo } from './init-git-repo';
+export { rmDirAndFilesIfExist } from './rm-dir-and-files-if-exist';
 export { mkdirIfDoesNotExist } from './mkdir-if-does-not-exist';
 export { TestEnvironment } from './test-environment';
 export { getNames } from './get-names';
@@ -24,12 +25,6 @@ export function mkdirIfNotExists(path: string) {
 export function rmfileIfExists(path: string) {
   if (fs.existsSync(path)) {
     fs.unlinkSync(path);
-  }
-}
-
-export function rmdirIfExists(path: string) {
-  if (fs.existsSync(path)) {
-    fs.rmdirSync(path);
   }
 }
 

--- a/packages/cli/src/generate/utils/rm-dir-and-files-if-exist.ts
+++ b/packages/cli/src/generate/utils/rm-dir-and-files-if-exist.ts
@@ -1,0 +1,22 @@
+// std
+import { existsSync, readdirSync, rmdirSync, statSync, unlinkSync } from 'fs';
+import { join } from 'path';
+
+export function rmDirAndFilesIfExist(path: string) {
+  if (!existsSync(path)) {
+    return;
+  }
+
+  const files = readdirSync(path);
+  for (const file of files) {
+    const stats = statSync(join(path, file));
+
+    if (stats.isDirectory()) {
+      rmDirAndFilesIfExist(join(path, file));
+    } else {
+      unlinkSync(join(path, file));
+    }
+  }
+
+  rmdirSync(path);
+}

--- a/packages/cli/src/generate/utils/test-environment.ts
+++ b/packages/cli/src/generate/utils/test-environment.ts
@@ -1,6 +1,6 @@
 // std
 import { ok, strictEqual } from 'assert';
-import { copyFileSync, existsSync, readFileSync, rmdirSync, unlinkSync } from 'fs';
+import { copyFileSync, existsSync, readdirSync, readFileSync, rmdirSync, statSync, unlinkSync } from 'fs';
 import { join } from 'path';
 
 // FoalTS
@@ -25,17 +25,29 @@ export class TestEnvironment {
   }
 
   /* Remove environment */
-  rmdirIfExists(path: string) {
-    path = join(this.root, path);
-    if (existsSync(path)) {
-      rmdirSync(path);
-    }
-  }
   rmfileIfExists(path: string) {
     path = join(this.root, path);
     if (existsSync(path)) {
       unlinkSync(path);
     }
+  }
+  rmDirAndFilesIfExist(path: string) {
+    const absolutePath = join(this.root, path);
+    if (!existsSync(absolutePath)) {
+      return;
+    }
+
+    const files = readdirSync(absolutePath);
+    for (const file of files) {
+      const stat = statSync(join(absolutePath, file));
+      if (stat.isDirectory()) {
+        this.rmDirAndFilesIfExist(join(path, file));
+      } else {
+        unlinkSync(join(absolutePath, file));
+      }
+    }
+
+    rmdirSync(absolutePath);
   }
 
   /* Test */

--- a/packages/cli/src/run-script/run-script.spec.ts
+++ b/packages/cli/src/run-script/run-script.spec.ts
@@ -4,16 +4,14 @@ import { join } from 'path';
 
 // FoalTS
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { mkdirIfDoesNotExist, rmdirIfExists, rmfileIfExists } from '../generate/utils';
+import { mkdirIfDoesNotExist, rmDirAndFilesIfExist, rmfileIfExists } from '../generate/utils';
 import { runScript } from './run-script';
 
 describe('runScript', () => {
 
   afterEach(() => {
-    rmfileIfExists('src/scripts/my-script.ts');
-    rmdirIfExists('src/scripts');
-    rmfileIfExists('build/scripts/my-script.js');
-    rmdirIfExists('build/scripts');
+    rmDirAndFilesIfExist('src/scripts');
+    rmDirAndFilesIfExist('build/scripts');
     rmfileIfExists('my-script-temp');
   });
 


### PR DESCRIPTION
# Issue

In the `afterEach` step during testing, it is tedious to specify all the files to delete.

# Solution and steps

Add and use a utility called `rmDirAndFilesIfExist`.

# Checklist

- [ ] ~Add/update/check docs (code comments and docs/ folder)~.
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
