### PR TITLE
Fix case-sensitive headers in Log hook

### DIFF
--- a/packages/core/src/common/hooks/log.hook.spec.ts
+++ b/packages/core/src/common/hooks/log.hook.spec.ts
@@ -66,8 +66,9 @@ describe('Log', () => {
     const hook = getHookFunction(Log('foo', { headers: [ 'my-header1', 'my-header2' ], logFn }));
 
     const headers = {
+      // According to RFC 7230, each header field consists of a case-INsensitive field name.
+      'My-header2': 'header 2',
       'my-header1': 'header 1',
-      'my-header2': 'header 2',
       'my-header3': 'header 3'
     };
     const ctx = new Context({ headers });
@@ -77,6 +78,7 @@ describe('Log', () => {
     strictEqual(logFn.msgs[1][0], 'my-header1: ');
     strictEqual(logFn.msgs[1][1], 'header 1');
     strictEqual(logFn.msgs[2][0], 'my-header2: ');
+    // Test the case
     strictEqual(logFn.msgs[2][1], 'header 2');
   });
 

--- a/packages/core/src/common/hooks/log.hook.ts
+++ b/packages/core/src/common/hooks/log.hook.ts
@@ -45,7 +45,12 @@ export function Log(message: string, options: LogOptions = {}): HookDecorator {
     if (options.headers === true) {
       logFn('Headers: ', ctx.request.headers);
     } else if (Array.isArray(options.headers)) {
-      options.headers.forEach(header => logFn(`${header}: `, ctx.request.headers[header]));
+      for (const header of options.headers) {
+        const headerName = Object.keys(ctx.request.headers).find(
+          head => header.toLowerCase() === head.toLowerCase() // Header names are case insensitive.
+        );
+        logFn(`${header}: `, headerName === undefined ? undefined : ctx.request.headers[headerName]);
+      }
     }
   });
 }


### PR DESCRIPTION
# Issue

See #409 

# Solution and steps

Make the option `header` be insensitive to the case.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
