### PR TITLE
Reduce the number of dependencies of the core package (by removing helmet).

### DIFF
--- a/docs/security/http-headers-protection.md
+++ b/docs/security/http-headers-protection.md
@@ -1,13 +1,14 @@
 # HTTP Headers Protection
 
-FoalTS uses [helmet](https://helmetjs.github.io/) under the hood to set various HTTP headers.
+To protect the application against some (!) common attacks, FoalTS sets by default various HTTP headers. These can be overrided in the `HttpResponse` objects.
 
-These headers are:
-```
-Strict-Transport-Security: max-age=15552000; includeSubDomains
-X-Content-Type-Options: nosniff
-X-DNS-Prefetch-Control: off
-X-Download-Options: noopen
-X-Frame-Options: SAMEORIGIN
-X-XSS-Protection: 1; mode=block
-```
+> Note that this is not a silver bullet, it is just a little help.
+
+| Header name | Value |
+| --- | --- |
+| `Strict-Transport-Security` | `max-age=15552000; includeSubDomains` |
+| `X-Content-Type-Options` | `nosniff` |
+| `X-DNS-Prefetch-Control` | `off` |
+| `X-Download-Options` | `noopen` |
+| `X-Frame-Options` | `SAMEORIGIN` |
+| `X-XSS-Protection` | `1; mode=block` |

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -373,11 +373,6 @@
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 		},
-		"camelize": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-			"integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
-		},
 		"chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -473,11 +468,6 @@
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
 			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
 		},
-		"content-security-policy-builder": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/content-security-policy-builder/-/content-security-policy-builder-2.0.0.tgz",
-			"integrity": "sha512-j+Nhmj1yfZAikJLImCvPJFE29x/UuBi+/MWqggGGc515JKaZrjuei2RhULJmy0MsstW3E3htl002bwmBNMKr7w=="
-		},
 		"content-type": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
@@ -548,11 +538,6 @@
 				"http-errors": "~1.5.0"
 			}
 		},
-		"dasherize": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dasherize/-/dasherize-2.0.0.tgz",
-			"integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg="
-		},
 		"debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -585,16 +570,6 @@
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
-		},
-		"dns-prefetch-control": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/dns-prefetch-control/-/dns-prefetch-control-0.1.0.tgz",
-			"integrity": "sha1-YN20V3dOF48flBXwyrsOhbCzALI="
-		},
-		"dont-sniff-mimetype": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-1.0.0.tgz",
-			"integrity": "sha1-WTKJDcn04vGeXrAqIAJuXl78j1g="
 		},
 		"ee-first": {
 			"version": "1.1.1",
@@ -639,11 +614,6 @@
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
 			}
-		},
-		"expect-ct": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/expect-ct/-/expect-ct-0.1.1.tgz",
-			"integrity": "sha512-ngXzTfoRGG7fYens3/RMb6yYoVLvLMfmsSllP/mZPxNHgFq41TmPSLF/nLY7fwoclI2vElvAmILFWGUYqdjfCg=="
 		},
 		"express": {
 			"version": "4.16.4",
@@ -735,11 +705,6 @@
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
 		},
-		"feature-policy": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/feature-policy/-/feature-policy-0.2.0.tgz",
-			"integrity": "sha512-2hGrlv6efG4hscYVZeaYjpzpT6I2OZgYqE2yDUzeAcKj2D1SH0AsEzqJNXzdoglEddcIXQQYop3lD97XpG75Jw=="
-		},
 		"finalhandler": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -788,11 +753,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
 			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
-		},
-		"frameguard": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/frameguard/-/frameguard-3.0.0.tgz",
-			"integrity": "sha1-e8rUae57lukdEs6zlZx4I1qScuk="
 		},
 		"fresh": {
 			"version": "0.5.2",
@@ -862,56 +822,6 @@
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
 			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
 		},
-		"helmet": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/helmet/-/helmet-3.16.0.tgz",
-			"integrity": "sha512-rsTKRogc5OYGlvSHuq5QsmOsOzF6uDoMqpfh+Np8r23+QxDq+SUx90Rf8HyIKQVl7H6NswZEwfcykinbAeZ6UQ==",
-			"requires": {
-				"depd": "2.0.0",
-				"dns-prefetch-control": "0.1.0",
-				"dont-sniff-mimetype": "1.0.0",
-				"expect-ct": "0.1.1",
-				"feature-policy": "0.2.0",
-				"frameguard": "3.0.0",
-				"helmet-crossdomain": "0.3.0",
-				"helmet-csp": "2.7.1",
-				"hide-powered-by": "1.0.0",
-				"hpkp": "2.0.0",
-				"hsts": "2.2.0",
-				"ienoopen": "1.1.0",
-				"nocache": "2.0.0",
-				"referrer-policy": "1.1.0",
-				"x-xss-protection": "1.1.0"
-			},
-			"dependencies": {
-				"depd": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-					"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-				}
-			}
-		},
-		"helmet-crossdomain": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/helmet-crossdomain/-/helmet-crossdomain-0.3.0.tgz",
-			"integrity": "sha512-YiXhj0E35nC4Na5EPE4mTfoXMf9JTGpN4OtB4aLqShKuH9d2HNaJX5MQoglO6STVka0uMsHyG5lCut5Kzsy7Lg=="
-		},
-		"helmet-csp": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/helmet-csp/-/helmet-csp-2.7.1.tgz",
-			"integrity": "sha512-sCHwywg4daQ2mY0YYwXSZRsgcCeerUwxMwNixGA7aMLkVmPTYBl7gJoZDHOZyXkqPrtuDT3s2B1A+RLI7WxSdQ==",
-			"requires": {
-				"camelize": "1.0.0",
-				"content-security-policy-builder": "2.0.0",
-				"dasherize": "2.0.0",
-				"platform": "1.3.5"
-			}
-		},
-		"hide-powered-by": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-1.0.0.tgz",
-			"integrity": "sha1-SoWtZYgfYoV/xwr3F0oRhNzM4ys="
-		},
 		"homedir-polyfill": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -924,26 +834,6 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
 			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
-		},
-		"hpkp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/hpkp/-/hpkp-2.0.0.tgz",
-			"integrity": "sha1-EOFCJk52IVpdMMROxD3mTe5tFnI="
-		},
-		"hsts": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/hsts/-/hsts-2.2.0.tgz",
-			"integrity": "sha512-ToaTnQ2TbJkochoVcdXYm4HOCliNozlviNsg+X2XQLQvZNI/kCHR9rZxVYpJB3UPcHz80PgxRyWQ7PdU1r+VBQ==",
-			"requires": {
-				"depd": "2.0.0"
-			},
-			"dependencies": {
-				"depd": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-					"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-				}
-			}
 		},
 		"http-errors": {
 			"version": "1.5.1",
@@ -962,11 +852,6 @@
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
-		},
-		"ienoopen": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/ienoopen/-/ienoopen-1.1.0.tgz",
-			"integrity": "sha512-MFs36e/ca6ohEKtinTJ5VvAJ6oDRAYFdYXweUnGY9L9vcoqFOU4n2ZhmJ0C4z/cwGZ3YIQRSB3XZ1+ghZkY5NQ=="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -1253,11 +1138,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
 			"integrity": "sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g="
-		},
-		"nocache": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/nocache/-/nocache-2.0.0.tgz",
-			"integrity": "sha1-ICtIAhoMTL3i34DeFaF0Q8i0OYA="
 		},
 		"node-mocks-http": {
 			"version": "1.7.3",
@@ -3258,11 +3138,6 @@
 				"split": "^1.0.0"
 			}
 		},
-		"platform": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
-			"integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q=="
-		},
 		"postgres-array": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -3379,11 +3254,6 @@
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
 			}
-		},
-		"referrer-policy": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/referrer-policy/-/referrer-policy-1.1.0.tgz",
-			"integrity": "sha1-NXdOtzW/UPtsB46DM0tHI1AgfXk="
 		},
 		"reflect-metadata": {
 			"version": "0.1.13",
@@ -3914,11 +3784,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-		},
-		"x-xss-protection": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.1.0.tgz",
-			"integrity": "sha512-rx3GzJlgEeZ08MIcDsU2vY2B1QEriUKJTSiNHHUIem6eg9pzVOr2TL3Y4Pd6TMAM5D5azGjcxqI62piITBDHVg=="
 		},
 		"xtend": {
 			"version": "4.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -81,7 +81,6 @@
     "csurf": "^1.9.0",
     "express": "^4.16.3",
     "express-session": "^1.15.6",
-    "helmet": "^3.12.1",
     "mime": "^2.4.0",
     "morgan": "^1.9.0",
     "reflect-metadata": "^0.1.10"

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -38,7 +38,7 @@ describe('createApp', () => {
     delete process.env.SETTINGS_STATIC_PATH_PREFIX;
   });
 
-  it('should include security headers in the HTTP responses.', async () => {
+  it('should include security headers in HTTP responses.', async () => {
     class AppController {
       @Get('/')
       index() {
@@ -60,7 +60,7 @@ describe('createApp', () => {
       .expect('X-Custom-Header', 'foobar');
   });
 
-  it('should not include the X-Powered-By: Express header in the HTTP responses.', async () => {
+  it('should not include the X-Powered-By: Express header in HTTP responses.', async () => {
     class AppController {
       @Get('/')
       index() {
@@ -72,7 +72,6 @@ describe('createApp', () => {
     await request(app)
       .get('/')
       .then(response => {
-        console.log(response.header);
         if (response.header['x-powered-by']) {
           throw new Error('The header "X-Powered-By" should not exist.');
         }

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -38,12 +38,54 @@ describe('createApp', () => {
     delete process.env.SETTINGS_STATIC_PATH_PREFIX;
   });
 
-  it('should serve static files.', async () => {
+  it('should include security headers in the HTTP responses.', async () => {
+    class AppController {
+      @Get('/')
+      index() {
+        const response = new HttpResponseOK();
+        response.setHeader('X-Custom-Header', 'foobar');
+        return response;
+      }
+    }
+    const app = createApp(AppController);
+
+    await request(app)
+      .get('/')
+      .expect('X-Content-Type-Options', 'nosniff')
+      .expect('X-DNS-Prefetch-Control', 'off')
+      .expect('X-Download-Options', 'noopen')
+      .expect('X-Frame-Options', 'SAMEORIGIN')
+      .expect('X-XSS-Protection', '1; mode=block')
+      .expect('Strict-Transport-Security', 'max-age=15552000; includeSubDomains')
+      .expect('X-Custom-Header', 'foobar');
+  });
+
+  it('should not include the X-Powered-By: Express header in the HTTP responses.', async () => {
+    class AppController {
+      @Get('/')
+      index() {
+        return new HttpResponseOK();
+      }
+    }
+    const app = createApp(AppController);
+
+    await request(app)
+      .get('/')
+      .then(response => {
+        console.log(response.header);
+        if (response.header['x-powered-by']) {
+          throw new Error('The header "X-Powered-By" should not exist.');
+        }
+      });
+  });
+
+  it('should serve static files (with the proper headers).', async () => {
     const app = createApp(class {});
     await request(app)
       .get('/hello-world.html')
       .expect(200, '<h1>Hello world!</h1>')
-      .expect('Content-type', 'text/html; charset=UTF-8');
+      .expect('Content-type', 'text/html; charset=UTF-8')
+      .expect('X-Content-Type-Options', 'nosniff');
   });
 
   it('should support custom path prefix when serving static files.', async () => {

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -3,7 +3,6 @@ import * as cookieParser from 'cookie-parser';
 import * as csurf from 'csurf';
 import * as express from 'express';
 import * as session from 'express-session';
-import * as helmet from 'helmet';
 import * as logger from 'morgan';
 
 // FoalTS
@@ -45,11 +44,20 @@ export function createApp(rootControllerClass: Class, options: CreateAppOptions 
   );
 
   app.use(logger(loggerFormat));
+  app.use((_, res, next) => {
+    res.removeHeader('X-Powered-By');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('X-DNS-Prefetch-Control', 'off');
+    res.setHeader('X-Download-Options', 'noopen');
+    res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+    res.setHeader('X-XSS-Protection', '1; mode=block');
+    res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+    next();
+  });
   app.use(
     Config.get('settings.staticPathPrefix', ''),
     express.static(Config.get('settings.staticUrl', 'public'))
   );
-  app.use(helmet());
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
   app.use(cookieParser());


### PR DESCRIPTION
# Issue

The `@foal/core` package depends indirectly on 99 packages. Depending on too many packages increases the `node_modules` size and reduces the framework security.

# Solution and steps

Remove [helmet](https://www.npmjs.com/package/helmet) (19 indirect dependencies) by manually setting the response headers.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
