### PR TITLE
[Docs] CORS - Add docs on the Authorization header

### DIFF
--- a/docs/api-section/public-api-and-cors-requests.md
+++ b/docs/api-section/public-api-and-cors-requests.md
@@ -33,3 +33,16 @@ export class ApiController {
 
 }
 ```
+
+## CORS Requests and Authentication
+
+If your API requires a token to be sent in the `Authorization` header, then the name of this header should be specified in the `options` handler.
+
+```typescript
+  @Options('*')
+  options(ctx: Context) {
+    const response = new HttpResponseNoContent();
+    response.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization');
+    return response;
+  }
+```


### PR DESCRIPTION
# Issue

Resolves #416.

```
Access to XMLHttpRequest at 'some_origin' from origin 'another_origin' has been blocked by CORS policy: Request header field authorization is not allowed by Access-Control-Allow-Headers in preflight response.
```

# Solution and steps

Add documentation on how to solve this issue.
