### PR TITLE
Validate arguments for createapp command

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -40,6 +40,12 @@ program
   .option('-m, --mongodb', 'Generate a new project using Mongoose/MongoDB instead of TypeORM/SQLite')
   .option('-y, --yaml', 'Generate a new project using YAML configuration instead of JSON')
   .action((name: string, options) => {
+    const args = process.argv.slice(3);
+    const appName = args.filter(item => !item.includes('-'));
+    if (appName.length > 1) {
+      console.log(red('\n Kindly provide only one argument as the project name'));
+      return;
+    }
     createApp({
       autoInstall: true,
       initRepo: true,


### PR DESCRIPTION
Towards #310 
New options were introduced as part of the recent release for `createapp` command for which the initial fix was out of scope. Made it such that the user is warned if he/she supplies multiple arguments for the `createapp` command (ignoring the options `-m, -y`)