### PR TITLE
Prevent name conflicts with "foal g rest-api"

### DIFF
--- a/packages/cli/src/generate/specs/rest-api/test-foo-bar.controller.current-dir.ts
+++ b/packages/cli/src/generate/specs/rest-api/test-foo-bar.controller.current-dir.ts
@@ -34,10 +34,10 @@ export class TestFooBarController {
     return new HttpResponseOK(testFooBars);
   }
 
-  @Get('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Get('/:testFooBarId')
+  @ValidateParams({ properties: { testFooBarId: { type: 'number' } }, type: 'object' })
   async getById(ctx: Context) {
-    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.id);
+    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.testFooBarId);
 
     if (!testFooBar) {
       return new HttpResponseNotFound();
@@ -53,7 +53,7 @@ export class TestFooBarController {
     return new HttpResponseCreated(testFooBar);
   }
 
-  @Post('/:id')
+  @Post('/:testFooBarId')
   postById() {
     return new HttpResponseMethodNotAllowed();
   }
@@ -63,11 +63,11 @@ export class TestFooBarController {
     return new HttpResponseMethodNotAllowed();
   }
 
-  @Patch('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Patch('/:testFooBarId')
+  @ValidateParams({ properties: { testFooBarId: { type: 'number' } }, type: 'object' })
   @ValidateBody({ ...testFooBarSchema, required: [] })
   async patchById(ctx: Context) {
-    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.id);
+    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.testFooBarId);
 
     if (!testFooBar) {
       return new HttpResponseNotFound();
@@ -85,11 +85,11 @@ export class TestFooBarController {
     return new HttpResponseMethodNotAllowed();
   }
 
-  @Put('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Put('/:testFooBarId')
+  @ValidateParams({ properties: { testFooBarId: { type: 'number' } }, type: 'object' })
   @ValidateBody(testFooBarSchema)
   async putById(ctx: Context) {
-    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.id);
+    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.testFooBarId);
 
     if (!testFooBar) {
       return new HttpResponseNotFound();
@@ -107,16 +107,16 @@ export class TestFooBarController {
     return new HttpResponseMethodNotAllowed();
   }
 
-  @Delete('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Delete('/:testFooBarId')
+  @ValidateParams({ properties: { testFooBarId: { type: 'number' } }, type: 'object' })
   async deleteById(ctx: Context) {
-    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.id);
+    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.testFooBarId);
 
     if (!testFooBar) {
       return new HttpResponseNotFound();
     }
 
-    await getRepository(TestFooBar).delete(ctx.request.params.id);
+    await getRepository(TestFooBar).delete(ctx.request.params.testFooBarId);
 
     return new HttpResponseNoContent();
   }

--- a/packages/cli/src/generate/specs/rest-api/test-foo-bar.controller.spec.current-dir.ts
+++ b/packages/cli/src/generate/specs/rest-api/test-foo-bar.controller.spec.current-dir.ts
@@ -105,15 +105,15 @@ describe('TestFooBarController', () => {
 
   describe('has a "getById" method that', () => {
 
-    it('should handle requests at GET /:id.', () => {
+    it('should handle requests at GET /:testFooBarId.', () => {
       strictEqual(getHttpMethod(TestFooBarController, 'getById'), 'GET');
-      strictEqual(getPath(TestFooBarController, 'getById'), '/:id');
+      strictEqual(getPath(TestFooBarController, 'getById'), '/:testFooBarId');
     });
 
     it('should return an HttpResponseOK object if the testFooBar was found.', async () => {
       const ctx = new Context({
         params: {
-          id: testFooBar2.id
+          testFooBarId: testFooBar2.id
         }
       });
       const response = await controller.getById(ctx);
@@ -129,7 +129,7 @@ describe('TestFooBarController', () => {
     it('should return an HttpResponseNotFound object if the testFooBar was not found.', async () => {
       const ctx = new Context({
         params: {
-          id: -1
+          testFooBarId: -1
         }
       });
       const response = await controller.getById(ctx);
@@ -177,9 +177,9 @@ describe('TestFooBarController', () => {
 
   describe('has a "postById" method that', () => {
 
-    it('should handle requests at POST /:id.', () => {
+    it('should handle requests at POST /:testFooBarId.', () => {
       strictEqual(getHttpMethod(TestFooBarController, 'postById'), 'POST');
-      strictEqual(getPath(TestFooBarController, 'postById'), '/:id');
+      strictEqual(getPath(TestFooBarController, 'postById'), '/:testFooBarId');
     });
 
     it('should return a HttpResponseMethodNotAllowed.', () => {
@@ -203,9 +203,9 @@ describe('TestFooBarController', () => {
 
   describe('has a "patchById" method that', () => {
 
-    it('should handle requests at PATCH /:id.', () => {
+    it('should handle requests at PATCH /:testFooBarId.', () => {
       strictEqual(getHttpMethod(TestFooBarController, 'patchById'), 'PATCH');
-      strictEqual(getPath(TestFooBarController, 'patchById'), '/:id');
+      strictEqual(getPath(TestFooBarController, 'patchById'), '/:testFooBarId');
     });
 
     it('should update the testFooBar in the database and return it through an HttpResponseOK object.', async () => {
@@ -214,7 +214,7 @@ describe('TestFooBarController', () => {
           text: 'TestFooBar 2 (version 2)',
         },
         params: {
-          id: testFooBar2.id
+          testFooBarId: testFooBar2.id
         }
       });
       const response = await controller.patchById(ctx);
@@ -241,7 +241,7 @@ describe('TestFooBarController', () => {
           text: 'TestFooBar 2 (version 2)',
         },
         params: {
-          id: testFooBar2.id
+          testFooBarId: testFooBar2.id
         }
       });
       await controller.patchById(ctx);
@@ -261,7 +261,7 @@ describe('TestFooBarController', () => {
           text: '',
         },
         params: {
-          id: -1
+          testFooBarId: -1
         }
       });
       const response = await controller.patchById(ctx);
@@ -288,9 +288,9 @@ describe('TestFooBarController', () => {
 
   describe('has a "putById" method that', () => {
 
-    it('should handle requests at PUT /:id.', () => {
+    it('should handle requests at PUT /:testFooBarId.', () => {
       strictEqual(getHttpMethod(TestFooBarController, 'putById'), 'PUT');
-      strictEqual(getPath(TestFooBarController, 'putById'), '/:id');
+      strictEqual(getPath(TestFooBarController, 'putById'), '/:testFooBarId');
     });
 
     it('should update the testFooBar in the database and return it through an HttpResponseOK object.', async () => {
@@ -299,7 +299,7 @@ describe('TestFooBarController', () => {
           text: 'TestFooBar 2 (version 2)',
         },
         params: {
-          id: testFooBar2.id
+          testFooBarId: testFooBar2.id
         }
       });
       const response = await controller.putById(ctx);
@@ -326,7 +326,7 @@ describe('TestFooBarController', () => {
           text: 'TestFooBar 2 (version 2)',
         },
         params: {
-          id: testFooBar2.id
+          testFooBarId: testFooBar2.id
         }
       });
       await controller.putById(ctx);
@@ -346,7 +346,7 @@ describe('TestFooBarController', () => {
           text: '',
         },
         params: {
-          id: -1
+          testFooBarId: -1
         }
       });
       const response = await controller.putById(ctx);
@@ -373,15 +373,15 @@ describe('TestFooBarController', () => {
 
   describe('has a "deleteById" method that', () => {
 
-    it('should handle requests at DELETE /:id.', () => {
+    it('should handle requests at DELETE /:testFooBarId.', () => {
       strictEqual(getHttpMethod(TestFooBarController, 'deleteById'), 'DELETE');
-      strictEqual(getPath(TestFooBarController, 'deleteById'), '/:id');
+      strictEqual(getPath(TestFooBarController, 'deleteById'), '/:testFooBarId');
     });
 
     it('should delete the testFooBar and return an HttpResponseNoContent object.', async () => {
       const ctx = new Context({
         params: {
-          id: testFooBar2.id
+          testFooBarId: testFooBar2.id
         }
       });
       const response = await controller.deleteById(ctx);
@@ -398,7 +398,7 @@ describe('TestFooBarController', () => {
     it('should not delete the other testFooBars.', async () => {
       const ctx = new Context({
         params: {
-          id: testFooBar2.id
+          testFooBarId: testFooBar2.id
         }
       });
       const response = await controller.deleteById(ctx);
@@ -415,7 +415,7 @@ describe('TestFooBarController', () => {
     it('should return an HttpResponseNotFound if the testFooBar was not fond.', async () => {
       const ctx = new Context({
         params: {
-          id: -1
+          testFooBarId: -1
         }
       });
       const response = await controller.deleteById(ctx);

--- a/packages/cli/src/generate/specs/rest-api/test-foo-bar.controller.spec.ts
+++ b/packages/cli/src/generate/specs/rest-api/test-foo-bar.controller.spec.ts
@@ -105,15 +105,15 @@ describe('TestFooBarController', () => {
 
   describe('has a "getById" method that', () => {
 
-    it('should handle requests at GET /:id.', () => {
+    it('should handle requests at GET /:testFooBarId.', () => {
       strictEqual(getHttpMethod(TestFooBarController, 'getById'), 'GET');
-      strictEqual(getPath(TestFooBarController, 'getById'), '/:id');
+      strictEqual(getPath(TestFooBarController, 'getById'), '/:testFooBarId');
     });
 
     it('should return an HttpResponseOK object if the testFooBar was found.', async () => {
       const ctx = new Context({
         params: {
-          id: testFooBar2.id
+          testFooBarId: testFooBar2.id
         }
       });
       const response = await controller.getById(ctx);
@@ -129,7 +129,7 @@ describe('TestFooBarController', () => {
     it('should return an HttpResponseNotFound object if the testFooBar was not found.', async () => {
       const ctx = new Context({
         params: {
-          id: -1
+          testFooBarId: -1
         }
       });
       const response = await controller.getById(ctx);
@@ -177,9 +177,9 @@ describe('TestFooBarController', () => {
 
   describe('has a "postById" method that', () => {
 
-    it('should handle requests at POST /:id.', () => {
+    it('should handle requests at POST /:testFooBarId.', () => {
       strictEqual(getHttpMethod(TestFooBarController, 'postById'), 'POST');
-      strictEqual(getPath(TestFooBarController, 'postById'), '/:id');
+      strictEqual(getPath(TestFooBarController, 'postById'), '/:testFooBarId');
     });
 
     it('should return a HttpResponseMethodNotAllowed.', () => {
@@ -203,9 +203,9 @@ describe('TestFooBarController', () => {
 
   describe('has a "patchById" method that', () => {
 
-    it('should handle requests at PATCH /:id.', () => {
+    it('should handle requests at PATCH /:testFooBarId.', () => {
       strictEqual(getHttpMethod(TestFooBarController, 'patchById'), 'PATCH');
-      strictEqual(getPath(TestFooBarController, 'patchById'), '/:id');
+      strictEqual(getPath(TestFooBarController, 'patchById'), '/:testFooBarId');
     });
 
     it('should update the testFooBar in the database and return it through an HttpResponseOK object.', async () => {
@@ -214,7 +214,7 @@ describe('TestFooBarController', () => {
           text: 'TestFooBar 2 (version 2)',
         },
         params: {
-          id: testFooBar2.id
+          testFooBarId: testFooBar2.id
         }
       });
       const response = await controller.patchById(ctx);
@@ -241,7 +241,7 @@ describe('TestFooBarController', () => {
           text: 'TestFooBar 2 (version 2)',
         },
         params: {
-          id: testFooBar2.id
+          testFooBarId: testFooBar2.id
         }
       });
       await controller.patchById(ctx);
@@ -261,7 +261,7 @@ describe('TestFooBarController', () => {
           text: '',
         },
         params: {
-          id: -1
+          testFooBarId: -1
         }
       });
       const response = await controller.patchById(ctx);
@@ -288,9 +288,9 @@ describe('TestFooBarController', () => {
 
   describe('has a "putById" method that', () => {
 
-    it('should handle requests at PUT /:id.', () => {
+    it('should handle requests at PUT /:testFooBarId.', () => {
       strictEqual(getHttpMethod(TestFooBarController, 'putById'), 'PUT');
-      strictEqual(getPath(TestFooBarController, 'putById'), '/:id');
+      strictEqual(getPath(TestFooBarController, 'putById'), '/:testFooBarId');
     });
 
     it('should update the testFooBar in the database and return it through an HttpResponseOK object.', async () => {
@@ -299,7 +299,7 @@ describe('TestFooBarController', () => {
           text: 'TestFooBar 2 (version 2)',
         },
         params: {
-          id: testFooBar2.id
+          testFooBarId: testFooBar2.id
         }
       });
       const response = await controller.putById(ctx);
@@ -326,7 +326,7 @@ describe('TestFooBarController', () => {
           text: 'TestFooBar 2 (version 2)',
         },
         params: {
-          id: testFooBar2.id
+          testFooBarId: testFooBar2.id
         }
       });
       await controller.putById(ctx);
@@ -346,7 +346,7 @@ describe('TestFooBarController', () => {
           text: '',
         },
         params: {
-          id: -1
+          testFooBarId: -1
         }
       });
       const response = await controller.putById(ctx);
@@ -373,15 +373,15 @@ describe('TestFooBarController', () => {
 
   describe('has a "deleteById" method that', () => {
 
-    it('should handle requests at DELETE /:id.', () => {
+    it('should handle requests at DELETE /:testFooBarId.', () => {
       strictEqual(getHttpMethod(TestFooBarController, 'deleteById'), 'DELETE');
-      strictEqual(getPath(TestFooBarController, 'deleteById'), '/:id');
+      strictEqual(getPath(TestFooBarController, 'deleteById'), '/:testFooBarId');
     });
 
     it('should delete the testFooBar and return an HttpResponseNoContent object.', async () => {
       const ctx = new Context({
         params: {
-          id: testFooBar2.id
+          testFooBarId: testFooBar2.id
         }
       });
       const response = await controller.deleteById(ctx);
@@ -398,7 +398,7 @@ describe('TestFooBarController', () => {
     it('should not delete the other testFooBars.', async () => {
       const ctx = new Context({
         params: {
-          id: testFooBar2.id
+          testFooBarId: testFooBar2.id
         }
       });
       const response = await controller.deleteById(ctx);
@@ -415,7 +415,7 @@ describe('TestFooBarController', () => {
     it('should return an HttpResponseNotFound if the testFooBar was not fond.', async () => {
       const ctx = new Context({
         params: {
-          id: -1
+          testFooBarId: -1
         }
       });
       const response = await controller.deleteById(ctx);

--- a/packages/cli/src/generate/specs/rest-api/test-foo-bar.controller.ts
+++ b/packages/cli/src/generate/specs/rest-api/test-foo-bar.controller.ts
@@ -34,10 +34,10 @@ export class TestFooBarController {
     return new HttpResponseOK(testFooBars);
   }
 
-  @Get('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Get('/:testFooBarId')
+  @ValidateParams({ properties: { testFooBarId: { type: 'number' } }, type: 'object' })
   async getById(ctx: Context) {
-    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.id);
+    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.testFooBarId);
 
     if (!testFooBar) {
       return new HttpResponseNotFound();
@@ -53,7 +53,7 @@ export class TestFooBarController {
     return new HttpResponseCreated(testFooBar);
   }
 
-  @Post('/:id')
+  @Post('/:testFooBarId')
   postById() {
     return new HttpResponseMethodNotAllowed();
   }
@@ -63,11 +63,11 @@ export class TestFooBarController {
     return new HttpResponseMethodNotAllowed();
   }
 
-  @Patch('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Patch('/:testFooBarId')
+  @ValidateParams({ properties: { testFooBarId: { type: 'number' } }, type: 'object' })
   @ValidateBody({ ...testFooBarSchema, required: [] })
   async patchById(ctx: Context) {
-    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.id);
+    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.testFooBarId);
 
     if (!testFooBar) {
       return new HttpResponseNotFound();
@@ -85,11 +85,11 @@ export class TestFooBarController {
     return new HttpResponseMethodNotAllowed();
   }
 
-  @Put('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Put('/:testFooBarId')
+  @ValidateParams({ properties: { testFooBarId: { type: 'number' } }, type: 'object' })
   @ValidateBody(testFooBarSchema)
   async putById(ctx: Context) {
-    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.id);
+    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.testFooBarId);
 
     if (!testFooBar) {
       return new HttpResponseNotFound();
@@ -107,16 +107,16 @@ export class TestFooBarController {
     return new HttpResponseMethodNotAllowed();
   }
 
-  @Delete('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Delete('/:testFooBarId')
+  @ValidateParams({ properties: { testFooBarId: { type: 'number' } }, type: 'object' })
   async deleteById(ctx: Context) {
-    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.id);
+    const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.testFooBarId);
 
     if (!testFooBar) {
       return new HttpResponseNotFound();
     }
 
-    await getRepository(TestFooBar).delete(ctx.request.params.id);
+    await getRepository(TestFooBar).delete(ctx.request.params.testFooBarId);
 
     return new HttpResponseNoContent();
   }

--- a/packages/cli/src/generate/templates/rest-api/controller.current-dir.ts
+++ b/packages/cli/src/generate/templates/rest-api/controller.current-dir.ts
@@ -34,10 +34,10 @@ export class /* upperFirstCamelName */Controller {
     return new HttpResponseOK(/* camelName */s);
   }
 
-  @Get('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Get('/:/* camelName */Id')
+  @ValidateParams({ properties: { /* camelName */Id: { type: 'number' } }, type: 'object' })
   async getById(ctx: Context) {
-    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params.id);
+    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params./* camelName */Id);
 
     if (!/* camelName */) {
       return new HttpResponseNotFound();
@@ -53,7 +53,7 @@ export class /* upperFirstCamelName */Controller {
     return new HttpResponseCreated(/* camelName */);
   }
 
-  @Post('/:id')
+  @Post('/:/* camelName */Id')
   postById() {
     return new HttpResponseMethodNotAllowed();
   }
@@ -63,11 +63,11 @@ export class /* upperFirstCamelName */Controller {
     return new HttpResponseMethodNotAllowed();
   }
 
-  @Patch('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Patch('/:/* camelName */Id')
+  @ValidateParams({ properties: { /* camelName */Id: { type: 'number' } }, type: 'object' })
   @ValidateBody({ .../* camelName */Schema, required: [] })
   async patchById(ctx: Context) {
-    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params.id);
+    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params./* camelName */Id);
 
     if (!/* camelName */) {
       return new HttpResponseNotFound();
@@ -85,11 +85,11 @@ export class /* upperFirstCamelName */Controller {
     return new HttpResponseMethodNotAllowed();
   }
 
-  @Put('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Put('/:/* camelName */Id')
+  @ValidateParams({ properties: { /* camelName */Id: { type: 'number' } }, type: 'object' })
   @ValidateBody(/* camelName */Schema)
   async putById(ctx: Context) {
-    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params.id);
+    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params./* camelName */Id);
 
     if (!/* camelName */) {
       return new HttpResponseNotFound();
@@ -107,16 +107,16 @@ export class /* upperFirstCamelName */Controller {
     return new HttpResponseMethodNotAllowed();
   }
 
-  @Delete('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Delete('/:/* camelName */Id')
+  @ValidateParams({ properties: { /* camelName */Id: { type: 'number' } }, type: 'object' })
   async deleteById(ctx: Context) {
-    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params.id);
+    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params./* camelName */Id);
 
     if (!/* camelName */) {
       return new HttpResponseNotFound();
     }
 
-    await getRepository(/* upperFirstCamelName */).delete(ctx.request.params.id);
+    await getRepository(/* upperFirstCamelName */).delete(ctx.request.params./* camelName */Id);
 
     return new HttpResponseNoContent();
   }

--- a/packages/cli/src/generate/templates/rest-api/controller.spec.current-dir.ts
+++ b/packages/cli/src/generate/templates/rest-api/controller.spec.current-dir.ts
@@ -105,15 +105,15 @@ describe('/* upperFirstCamelName */Controller', () => {
 
   describe('has a "getById" method that', () => {
 
-    it('should handle requests at GET /:id.', () => {
+    it('should handle requests at GET /:/* camelName */Id.', () => {
       strictEqual(getHttpMethod(/* upperFirstCamelName */Controller, 'getById'), 'GET');
-      strictEqual(getPath(/* upperFirstCamelName */Controller, 'getById'), '/:id');
+      strictEqual(getPath(/* upperFirstCamelName */Controller, 'getById'), '/:/* camelName */Id');
     });
 
     it('should return an HttpResponseOK object if the /* camelName */ was found.', async () => {
       const ctx = new Context({
         params: {
-          id: /* camelName */2.id
+          /* camelName */Id: /* camelName */2.id
         }
       });
       const response = await controller.getById(ctx);
@@ -129,7 +129,7 @@ describe('/* upperFirstCamelName */Controller', () => {
     it('should return an HttpResponseNotFound object if the /* camelName */ was not found.', async () => {
       const ctx = new Context({
         params: {
-          id: -1
+          /* camelName */Id: -1
         }
       });
       const response = await controller.getById(ctx);
@@ -177,9 +177,9 @@ describe('/* upperFirstCamelName */Controller', () => {
 
   describe('has a "postById" method that', () => {
 
-    it('should handle requests at POST /:id.', () => {
+    it('should handle requests at POST /:/* camelName */Id.', () => {
       strictEqual(getHttpMethod(/* upperFirstCamelName */Controller, 'postById'), 'POST');
-      strictEqual(getPath(/* upperFirstCamelName */Controller, 'postById'), '/:id');
+      strictEqual(getPath(/* upperFirstCamelName */Controller, 'postById'), '/:/* camelName */Id');
     });
 
     it('should return a HttpResponseMethodNotAllowed.', () => {
@@ -203,9 +203,9 @@ describe('/* upperFirstCamelName */Controller', () => {
 
   describe('has a "patchById" method that', () => {
 
-    it('should handle requests at PATCH /:id.', () => {
+    it('should handle requests at PATCH /:/* camelName */Id.', () => {
       strictEqual(getHttpMethod(/* upperFirstCamelName */Controller, 'patchById'), 'PATCH');
-      strictEqual(getPath(/* upperFirstCamelName */Controller, 'patchById'), '/:id');
+      strictEqual(getPath(/* upperFirstCamelName */Controller, 'patchById'), '/:/* camelName */Id');
     });
 
     it('should update the /* camelName */ in the database and return it through an HttpResponseOK object.', async () => {
@@ -214,7 +214,7 @@ describe('/* upperFirstCamelName */Controller', () => {
           text: '/* upperFirstCamelName */ 2 (version 2)',
         },
         params: {
-          id: /* camelName */2.id
+          /* camelName */Id: /* camelName */2.id
         }
       });
       const response = await controller.patchById(ctx);
@@ -241,7 +241,7 @@ describe('/* upperFirstCamelName */Controller', () => {
           text: '/* upperFirstCamelName */ 2 (version 2)',
         },
         params: {
-          id: /* camelName */2.id
+          /* camelName */Id: /* camelName */2.id
         }
       });
       await controller.patchById(ctx);
@@ -261,7 +261,7 @@ describe('/* upperFirstCamelName */Controller', () => {
           text: '',
         },
         params: {
-          id: -1
+          /* camelName */Id: -1
         }
       });
       const response = await controller.patchById(ctx);
@@ -288,9 +288,9 @@ describe('/* upperFirstCamelName */Controller', () => {
 
   describe('has a "putById" method that', () => {
 
-    it('should handle requests at PUT /:id.', () => {
+    it('should handle requests at PUT /:/* camelName */Id.', () => {
       strictEqual(getHttpMethod(/* upperFirstCamelName */Controller, 'putById'), 'PUT');
-      strictEqual(getPath(/* upperFirstCamelName */Controller, 'putById'), '/:id');
+      strictEqual(getPath(/* upperFirstCamelName */Controller, 'putById'), '/:/* camelName */Id');
     });
 
     it('should update the /* camelName */ in the database and return it through an HttpResponseOK object.', async () => {
@@ -299,7 +299,7 @@ describe('/* upperFirstCamelName */Controller', () => {
           text: '/* upperFirstCamelName */ 2 (version 2)',
         },
         params: {
-          id: /* camelName */2.id
+          /* camelName */Id: /* camelName */2.id
         }
       });
       const response = await controller.putById(ctx);
@@ -326,7 +326,7 @@ describe('/* upperFirstCamelName */Controller', () => {
           text: '/* upperFirstCamelName */ 2 (version 2)',
         },
         params: {
-          id: /* camelName */2.id
+          /* camelName */Id: /* camelName */2.id
         }
       });
       await controller.putById(ctx);
@@ -346,7 +346,7 @@ describe('/* upperFirstCamelName */Controller', () => {
           text: '',
         },
         params: {
-          id: -1
+          /* camelName */Id: -1
         }
       });
       const response = await controller.putById(ctx);
@@ -373,15 +373,15 @@ describe('/* upperFirstCamelName */Controller', () => {
 
   describe('has a "deleteById" method that', () => {
 
-    it('should handle requests at DELETE /:id.', () => {
+    it('should handle requests at DELETE /:/* camelName */Id.', () => {
       strictEqual(getHttpMethod(/* upperFirstCamelName */Controller, 'deleteById'), 'DELETE');
-      strictEqual(getPath(/* upperFirstCamelName */Controller, 'deleteById'), '/:id');
+      strictEqual(getPath(/* upperFirstCamelName */Controller, 'deleteById'), '/:/* camelName */Id');
     });
 
     it('should delete the /* camelName */ and return an HttpResponseNoContent object.', async () => {
       const ctx = new Context({
         params: {
-          id: /* camelName */2.id
+          /* camelName */Id: /* camelName */2.id
         }
       });
       const response = await controller.deleteById(ctx);
@@ -398,7 +398,7 @@ describe('/* upperFirstCamelName */Controller', () => {
     it('should not delete the other /* camelName */s.', async () => {
       const ctx = new Context({
         params: {
-          id: /* camelName */2.id
+          /* camelName */Id: /* camelName */2.id
         }
       });
       const response = await controller.deleteById(ctx);
@@ -415,7 +415,7 @@ describe('/* upperFirstCamelName */Controller', () => {
     it('should return an HttpResponseNotFound if the /* camelName */ was not fond.', async () => {
       const ctx = new Context({
         params: {
-          id: -1
+          /* camelName */Id: -1
         }
       });
       const response = await controller.deleteById(ctx);

--- a/packages/cli/src/generate/templates/rest-api/controller.spec.ts
+++ b/packages/cli/src/generate/templates/rest-api/controller.spec.ts
@@ -105,15 +105,15 @@ describe('/* upperFirstCamelName */Controller', () => {
 
   describe('has a "getById" method that', () => {
 
-    it('should handle requests at GET /:id.', () => {
+    it('should handle requests at GET /:/* camelName */Id.', () => {
       strictEqual(getHttpMethod(/* upperFirstCamelName */Controller, 'getById'), 'GET');
-      strictEqual(getPath(/* upperFirstCamelName */Controller, 'getById'), '/:id');
+      strictEqual(getPath(/* upperFirstCamelName */Controller, 'getById'), '/:/* camelName */Id');
     });
 
     it('should return an HttpResponseOK object if the /* camelName */ was found.', async () => {
       const ctx = new Context({
         params: {
-          id: /* camelName */2.id
+          /* camelName */Id: /* camelName */2.id
         }
       });
       const response = await controller.getById(ctx);
@@ -129,7 +129,7 @@ describe('/* upperFirstCamelName */Controller', () => {
     it('should return an HttpResponseNotFound object if the /* camelName */ was not found.', async () => {
       const ctx = new Context({
         params: {
-          id: -1
+          /* camelName */Id: -1
         }
       });
       const response = await controller.getById(ctx);
@@ -177,9 +177,9 @@ describe('/* upperFirstCamelName */Controller', () => {
 
   describe('has a "postById" method that', () => {
 
-    it('should handle requests at POST /:id.', () => {
+    it('should handle requests at POST /:/* camelName */Id.', () => {
       strictEqual(getHttpMethod(/* upperFirstCamelName */Controller, 'postById'), 'POST');
-      strictEqual(getPath(/* upperFirstCamelName */Controller, 'postById'), '/:id');
+      strictEqual(getPath(/* upperFirstCamelName */Controller, 'postById'), '/:/* camelName */Id');
     });
 
     it('should return a HttpResponseMethodNotAllowed.', () => {
@@ -203,9 +203,9 @@ describe('/* upperFirstCamelName */Controller', () => {
 
   describe('has a "patchById" method that', () => {
 
-    it('should handle requests at PATCH /:id.', () => {
+    it('should handle requests at PATCH /:/* camelName */Id.', () => {
       strictEqual(getHttpMethod(/* upperFirstCamelName */Controller, 'patchById'), 'PATCH');
-      strictEqual(getPath(/* upperFirstCamelName */Controller, 'patchById'), '/:id');
+      strictEqual(getPath(/* upperFirstCamelName */Controller, 'patchById'), '/:/* camelName */Id');
     });
 
     it('should update the /* camelName */ in the database and return it through an HttpResponseOK object.', async () => {
@@ -214,7 +214,7 @@ describe('/* upperFirstCamelName */Controller', () => {
           text: '/* upperFirstCamelName */ 2 (version 2)',
         },
         params: {
-          id: /* camelName */2.id
+          /* camelName */Id: /* camelName */2.id
         }
       });
       const response = await controller.patchById(ctx);
@@ -241,7 +241,7 @@ describe('/* upperFirstCamelName */Controller', () => {
           text: '/* upperFirstCamelName */ 2 (version 2)',
         },
         params: {
-          id: /* camelName */2.id
+          /* camelName */Id: /* camelName */2.id
         }
       });
       await controller.patchById(ctx);
@@ -261,7 +261,7 @@ describe('/* upperFirstCamelName */Controller', () => {
           text: '',
         },
         params: {
-          id: -1
+          /* camelName */Id: -1
         }
       });
       const response = await controller.patchById(ctx);
@@ -288,9 +288,9 @@ describe('/* upperFirstCamelName */Controller', () => {
 
   describe('has a "putById" method that', () => {
 
-    it('should handle requests at PUT /:id.', () => {
+    it('should handle requests at PUT /:/* camelName */Id.', () => {
       strictEqual(getHttpMethod(/* upperFirstCamelName */Controller, 'putById'), 'PUT');
-      strictEqual(getPath(/* upperFirstCamelName */Controller, 'putById'), '/:id');
+      strictEqual(getPath(/* upperFirstCamelName */Controller, 'putById'), '/:/* camelName */Id');
     });
 
     it('should update the /* camelName */ in the database and return it through an HttpResponseOK object.', async () => {
@@ -299,7 +299,7 @@ describe('/* upperFirstCamelName */Controller', () => {
           text: '/* upperFirstCamelName */ 2 (version 2)',
         },
         params: {
-          id: /* camelName */2.id
+          /* camelName */Id: /* camelName */2.id
         }
       });
       const response = await controller.putById(ctx);
@@ -326,7 +326,7 @@ describe('/* upperFirstCamelName */Controller', () => {
           text: '/* upperFirstCamelName */ 2 (version 2)',
         },
         params: {
-          id: /* camelName */2.id
+          /* camelName */Id: /* camelName */2.id
         }
       });
       await controller.putById(ctx);
@@ -346,7 +346,7 @@ describe('/* upperFirstCamelName */Controller', () => {
           text: '',
         },
         params: {
-          id: -1
+          /* camelName */Id: -1
         }
       });
       const response = await controller.putById(ctx);
@@ -373,15 +373,15 @@ describe('/* upperFirstCamelName */Controller', () => {
 
   describe('has a "deleteById" method that', () => {
 
-    it('should handle requests at DELETE /:id.', () => {
+    it('should handle requests at DELETE /:/* camelName */Id.', () => {
       strictEqual(getHttpMethod(/* upperFirstCamelName */Controller, 'deleteById'), 'DELETE');
-      strictEqual(getPath(/* upperFirstCamelName */Controller, 'deleteById'), '/:id');
+      strictEqual(getPath(/* upperFirstCamelName */Controller, 'deleteById'), '/:/* camelName */Id');
     });
 
     it('should delete the /* camelName */ and return an HttpResponseNoContent object.', async () => {
       const ctx = new Context({
         params: {
-          id: /* camelName */2.id
+          /* camelName */Id: /* camelName */2.id
         }
       });
       const response = await controller.deleteById(ctx);
@@ -398,7 +398,7 @@ describe('/* upperFirstCamelName */Controller', () => {
     it('should not delete the other /* camelName */s.', async () => {
       const ctx = new Context({
         params: {
-          id: /* camelName */2.id
+          /* camelName */Id: /* camelName */2.id
         }
       });
       const response = await controller.deleteById(ctx);
@@ -415,7 +415,7 @@ describe('/* upperFirstCamelName */Controller', () => {
     it('should return an HttpResponseNotFound if the /* camelName */ was not fond.', async () => {
       const ctx = new Context({
         params: {
-          id: -1
+          /* camelName */Id: -1
         }
       });
       const response = await controller.deleteById(ctx);

--- a/packages/cli/src/generate/templates/rest-api/controller.ts
+++ b/packages/cli/src/generate/templates/rest-api/controller.ts
@@ -34,10 +34,10 @@ export class /* upperFirstCamelName */Controller {
     return new HttpResponseOK(/* camelName */s);
   }
 
-  @Get('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Get('/:/* camelName */Id')
+  @ValidateParams({ properties: { /* camelName */Id: { type: 'number' } }, type: 'object' })
   async getById(ctx: Context) {
-    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params.id);
+    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params./* camelName */Id);
 
     if (!/* camelName */) {
       return new HttpResponseNotFound();
@@ -53,7 +53,7 @@ export class /* upperFirstCamelName */Controller {
     return new HttpResponseCreated(/* camelName */);
   }
 
-  @Post('/:id')
+  @Post('/:/* camelName */Id')
   postById() {
     return new HttpResponseMethodNotAllowed();
   }
@@ -63,11 +63,11 @@ export class /* upperFirstCamelName */Controller {
     return new HttpResponseMethodNotAllowed();
   }
 
-  @Patch('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Patch('/:/* camelName */Id')
+  @ValidateParams({ properties: { /* camelName */Id: { type: 'number' } }, type: 'object' })
   @ValidateBody({ .../* camelName */Schema, required: [] })
   async patchById(ctx: Context) {
-    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params.id);
+    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params./* camelName */Id);
 
     if (!/* camelName */) {
       return new HttpResponseNotFound();
@@ -85,11 +85,11 @@ export class /* upperFirstCamelName */Controller {
     return new HttpResponseMethodNotAllowed();
   }
 
-  @Put('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Put('/:/* camelName */Id')
+  @ValidateParams({ properties: { /* camelName */Id: { type: 'number' } }, type: 'object' })
   @ValidateBody(/* camelName */Schema)
   async putById(ctx: Context) {
-    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params.id);
+    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params./* camelName */Id);
 
     if (!/* camelName */) {
       return new HttpResponseNotFound();
@@ -107,16 +107,16 @@ export class /* upperFirstCamelName */Controller {
     return new HttpResponseMethodNotAllowed();
   }
 
-  @Delete('/:id')
-  @ValidateParams({ properties: { id: { type: 'number' } }, type: 'object' })
+  @Delete('/:/* camelName */Id')
+  @ValidateParams({ properties: { /* camelName */Id: { type: 'number' } }, type: 'object' })
   async deleteById(ctx: Context) {
-    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params.id);
+    const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params./* camelName */Id);
 
     if (!/* camelName */) {
       return new HttpResponseNotFound();
     }
 
-    await getRepository(/* upperFirstCamelName */).delete(ctx.request.params.id);
+    await getRepository(/* upperFirstCamelName */).delete(ctx.request.params./* camelName */Id);
 
     return new HttpResponseNoContent();
   }


### PR DESCRIPTION
# Issue

Currently `foal generate rest-api` generates controllers which paths include a parameter which name is `id`.

- This can lead to parameter name conflicts when doing complex things.
- This name is not very meaningful when generating OpenAPI spec.

# Solution and steps

- [x] Name the id parameter based on the controller name.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
