### PR TITLE
Suggest matching commands if the user mistypes

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,8 @@
   "dependencies": {
     "ajv": "^6.5.0",
     "colors": "^1.3.2",
-    "commander": "^2.15.1"
+    "commander": "^2.15.1",
+    "didyoumean": "^1.2.1"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,6 +8,7 @@
 // 3p
 import { red, yellow } from 'colors/safe';
 import * as program from 'commander';
+const didYouMean = require('didyoumean'); // tslint:disable-line 
 
 // FoalTS
 import { createSecret } from './create-secret';
@@ -27,6 +28,17 @@ import {
   createVSCodeConfig,
 } from './generate';
 import { runScript } from './run-script';
+
+const suggestCommands = (cmd: any) => {
+  const availableCommands = program.commands.map(cmd => {
+    return cmd._name;
+  });
+
+  const suggestion = didYouMean(cmd, availableCommands);
+  if (suggestion) {
+    console.log(`  ` + red(`Did you mean ${yellow(suggestion)}?`));
+  }
+};
 
 // tslint:disable-next-line:no-var-requires
 const pkg = require('../package.json');
@@ -150,6 +162,7 @@ program
     program.outputHelp();
     console.log(red(`\n  Unknown command ${yellow(cmd)}.`));
     console.log();
+    suggestCommands(cmd);
   });
 
 program.parse(process.argv);


### PR DESCRIPTION
Suggests matching commands to the user utilising the [didyoumean.js](https://npmjs.com/package/didyoumean) library.

### Proposed API

`foal createa`

```bash
Usage: foal [options] [command] <command>

Options:
  -v, --version                       output the version number
  -h, --help                          output usage information

Commands:
  createapp [options] <name>          Create a new project.
  createsecret                        Create a 256-bit random secret encoded in base64.
  run|run-script <name>               Run a shell script.
  connect <framework> <path>          Configure your frontend to interact with your application.
  generate|g [options] <type> [name]  Generate and/or modify files.

  Unknown command createa.

  Did you mean createapp?
```