### PR TITLE
Add @MergeHooks to be able to group several hooks into one.

### DIFF
--- a/docs/architecture/hooks.md
+++ b/docs/architecture/hooks.md
@@ -19,7 +19,7 @@ They improve code readability and make unit testing easier.
 
 Foal provides a number of hooks to handle the most common scenarios.
 
-- `ValidateBody`, `ValidateHeaders`, `ValidateParams` and `ValidateQuery` validate the format of the incoming HTTP requests (see [Validation](../validation.md)).
+- `ValidateBody`, `ValidateHeaders`, `ValidateParams`, `ValidateCookies` and `ValidateQuery` validate the format of the incoming HTTP requests (see [Validation](../validation.md)).
 - `Log` displays information on the request (see [Logging & Debugging](../utilities/logging-and-debugging.md)).
 - `JWTRequired`, `JWTOptional`, `LoginRequired`, `LoginOptional` authenticate the user by filling the `ctx.user` property.
 - `PermissionRequired` restricts the route access to certain users.
@@ -165,9 +165,45 @@ class MyController {
 
 A *hook post function* accepts three parameters: the context, the service manager and the response returned by the controller method.
 
+## Grouping Several Hooks into One
+
+In case you need to group several hooks together, the `MergeHooks` function can be used to do this.
+
+```typescript
+// Before
+
+class MyController {
+  @Post('/products')
+  @ValidateBody({...})
+  @ValidateHeaders({...})
+  @ValidateCookie({...})
+  addProduct() {
+    // ...
+  }
+}
+
+// After
+
+function ValidateAll() {
+  return MergeHooks(
+    ValidateBody({...}),
+    ValidateHeaders({...}),
+    ValidateCookie({...})
+  )
+}
+
+class MyController {
+  @Post('/products')
+  @ValidateAll()
+  addProduct() {
+    // ...
+  }
+}
+```
+
 ## Testing Hooks
 
-Hooks can be tested thanks to the `getHookFunction`.
+Hooks can be tested thanks to the utility `getHookFunction` (or `getHookFunctions` if the hook was made from several functions).
 
 ```typescript
 // validate-body.hook.ts

--- a/packages/core/src/core/hooks.spec.ts
+++ b/packages/core/src/core/hooks.spec.ts
@@ -5,12 +5,13 @@ import { deepStrictEqual, strictEqual } from 'assert';
 import 'reflect-metadata';
 
 // FoalTS
-import { getHookFunction, Hook, HookFunction } from './hooks';
+import { getHookFunction, getHookFunctions, Hook, HookFunction, MergeHooks } from './hooks';
 
 describe('Hook', () => {
 
   const hook1: HookFunction = () => { return; };
   const hook2: HookFunction = () => undefined;
+  const hook3: HookFunction = () => undefined;
 
   it('should add the hook to the metadata hooks on the method class.', () => {
     class Foobar {
@@ -23,6 +24,16 @@ describe('Hook', () => {
     deepStrictEqual(actual, [ hook1, hook2 ]);
   });
 
+  it('should add the hooks to the metadata hooks on the method class.', () => {
+    class Foobar {
+      @Hook(hook1, hook2, hook3)
+      barfoo() {}
+    }
+
+    const actual = Reflect.getOwnMetadata('hooks', Foobar.prototype, 'barfoo');
+    deepStrictEqual(actual, [ hook1, hook2, hook3 ]);
+  });
+
   it('should add the hook to the metadata hooks on the class.', () => {
     @Hook(hook1)
     @Hook(hook2)
@@ -30,6 +41,16 @@ describe('Hook', () => {
 
     const actual = Reflect.getOwnMetadata('hooks', Foobar);
     deepStrictEqual(actual, [ hook1, hook2 ]);
+  });
+
+  it('should add the hooks to the metadata hooks on the method class.', () => {
+    @Hook(hook1, hook2, hook3)
+    class Foobar {
+      barfoo() {}
+    }
+
+    const actual = Reflect.getOwnMetadata('hooks', Foobar);
+    deepStrictEqual(actual, [ hook1, hook2, hook3 ]);
   });
 
 });
@@ -41,6 +62,45 @@ describe('getHookFunction', () => {
     const hook = Hook(hookFunction);
 
     strictEqual(getHookFunction(hook), hookFunction);
+  });
+
+});
+
+describe('getHookFunctions', () => {
+
+  it('should take a hook decorator and return its hook functions.', () => {
+    const hookFunction = () => {};
+    const hookFunction2 = () => {};
+    const hookFunction3 = () => {};
+    const hook = Hook(hookFunction, hookFunction2, hookFunction3);
+
+    deepStrictEqual(
+      getHookFunctions(hook),
+      [ hookFunction, hookFunction2, hookFunction3 ]
+    );
+  });
+
+});
+
+describe('MergeHooks', () => {
+
+  const hook1: HookFunction = () => { return; };
+  const hook2: HookFunction = () => undefined;
+  const hook3: HookFunction = () => undefined;
+  const hook4: HookFunction = () => undefined;
+
+  it('should create a new hook decorator from the hook functions of the given decorators.', () => {
+    @MergeHooks(
+      Hook(hook1),
+      Hook(hook2, hook3),
+      Hook(hook4),
+    )
+    class Foobar {
+      barfoo() {}
+    }
+
+    const actual = Reflect.getOwnMetadata('hooks', Foobar);
+    deepStrictEqual(actual, [ hook1, hook2, hook3, hook4 ]);
   });
 
 });

--- a/packages/core/src/core/hooks.ts
+++ b/packages/core/src/core/hooks.ts
@@ -29,17 +29,17 @@ export type HookFunction = (ctx: Context, services: ServiceManager) =>
 export type HookDecorator = (target: any, propertyKey?: string) => any;
 
 /**
- * Create a hook from a function.
+ * Create a hook from one or several functions.
  *
  * @export
- * @param {HookFunction} hookFunction - The function from which the hook should be created.
+ * @param {...HookFunction[]} hookFunctions - The function(s) from which the hook should be created.
  * @returns {HookDecorator} - The hook decorator.
  */
-export function Hook(hookFunction: HookFunction): HookDecorator {
+export function Hook(...hookFunctions: HookFunction[]): HookDecorator {
   return (target: any, propertyKey?: string) => {
     // Note that propertyKey can be undefined as it's an optional parameter in getMetadata.
     const hooks: HookFunction[] = Reflect.getOwnMetadata('hooks', target, propertyKey as string) || [];
-    hooks.unshift(hookFunction);
+    hooks.unshift(...hookFunctions);
     Reflect.defineMetadata('hooks', hooks, target, propertyKey as string);
   };
 }
@@ -49,11 +49,40 @@ export function Hook(hookFunction: HookFunction): HookDecorator {
  *
  * @export
  * @param {HookDecorator} hook - The hook decorator.
- * @returns {HookFunction} - The hook function.
+ * @returns {HookFunction} The hook function.
  */
 export function getHookFunction(hook: HookDecorator): HookFunction {
   @hook
   class Foo {}
 
   return Reflect.getOwnMetadata('hooks', Foo)[0];
+}
+
+/**
+ * Get the functions from which the hook was made.
+ *
+ * @export
+ * @param {HookDecorator} hook - The hook decorator.
+ * @returns {HookFunction[]} The hook functions.
+ */
+export function getHookFunctions(hook: HookDecorator): HookFunction[] {
+  @hook
+  class Foo {}
+
+  return Reflect.getOwnMetadata('hooks', Foo);
+}
+
+/**
+ * Group multiple hooks into a new one.
+ *
+ * @export
+ * @param {...HookDecorator[]} hookDecorators - The hooks to merge.
+ * @returns {HookDecorator} The new hook.
+ */
+export function MergeHooks(...hookDecorators: HookDecorator[]): HookDecorator {
+  const hookFunctions: HookFunction[] = [];
+  for (const hook of hookDecorators) {
+    hookFunctions.push(...getHookFunctions(hook));
+  }
+  return Hook(...hookFunctions);
 }


### PR DESCRIPTION
# Issue

Resolves #446.

# Solution and steps

- [x] Extend `@Hook`
- [x] Add `getHookFunction`
- [x] Add `@MergeHooks`

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
