### PR TITLE
[jwks-rsa] Update insecure package-lock.json

### DIFF
--- a/packages/jwks-rsa/package-lock.json
+++ b/packages/jwks-rsa/package-lock.json
@@ -2,10 +2,63 @@
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
+		"@types/body-parser": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
+			"integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
+			"requires": {
+				"@types/connect": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/connect": {
+			"version": "3.4.32",
+			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+			"integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
 			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+		},
+		"@types/express": {
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz",
+			"integrity": "sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==",
+			"requires": {
+				"@types/body-parser": "*",
+				"@types/express-serve-static-core": "*",
+				"@types/serve-static": "*"
+			}
+		},
+		"@types/express-jwt": {
+			"version": "0.0.42",
+			"resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-0.0.42.tgz",
+			"integrity": "sha512-WszgUddvM1t5dPpJ3LhWNH8kfNN8GPIBrAGxgIYXVCEGx6Bx4A036aAuf/r5WH9DIEdlmp7gHOYvSM6U87B0ag==",
+			"requires": {
+				"@types/express": "*",
+				"@types/express-unless": "*"
+			}
+		},
+		"@types/express-serve-static-core": {
+			"version": "4.16.7",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
+			"integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
+			"requires": {
+				"@types/node": "*",
+				"@types/range-parser": "*"
+			}
+		},
+		"@types/express-unless": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.1.tgz",
+			"integrity": "sha512-5fuvg7C69lemNgl0+v+CUxDYWVPSfXHhJPst4yTLcqi4zKJpORCxnDrnnilk3k0DTq/WrAUdvXFs01+vUqUZHw==",
+			"requires": {
+				"@types/express": "*"
+			}
 		},
 		"@types/fs-extra": {
 			"version": "5.1.0",
@@ -39,14 +92,19 @@
 			"integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ=="
 		},
 		"@types/lodash": {
-			"version": "4.14.132",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.132.tgz",
-			"integrity": "sha512-RNUU1rrh85NgUJcjOOr96YXr+RHwInGbaQCZmlitqOaCKXffj8bh+Zxwuq5rjDy5OgzFldDVoqk4pyLEDiwxIw=="
+			"version": "4.14.136",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
+			"integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA=="
 		},
 		"@types/marked": {
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
 			"integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg=="
+		},
+		"@types/mime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+			"integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -59,9 +117,23 @@
 			"integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw=="
 		},
 		"@types/node": {
-			"version": "10.14.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
-			"integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A=="
+			"version": "10.14.12",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.12.tgz",
+			"integrity": "sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg=="
+		},
+		"@types/range-parser": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+		},
+		"@types/serve-static": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
+			"integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
+			"requires": {
+				"@types/express-serve-static-core": "*",
+				"@types/mime": "*"
+			}
 		},
 		"@types/shelljs": {
 			"version": "0.8.5",
@@ -97,21 +169,21 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA=="
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
+					"integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw=="
 				}
 			}
 		},
 		"acorn-walk": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
-			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
 		},
 		"ajv": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"version": "6.10.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -242,9 +314,9 @@
 			}
 		},
 		"chownr": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+			"integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
 		},
 		"code-point-at": {
 			"version": "1.1.0",
@@ -293,14 +365,14 @@
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cssom": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A=="
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
 		},
 		"cssstyle": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
-			"integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
 			"requires": {
 				"cssom": "0.3.x"
 			}
@@ -545,9 +617,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.1.15",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+			"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
 		},
 		"growl": {
 			"version": "1.10.5",
@@ -602,9 +674,9 @@
 			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
 		},
 		"highlight.js": {
-			"version": "9.15.6",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
-			"integrity": "sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ=="
+			"version": "9.15.8",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.8.tgz",
+			"integrity": "sha512-RrapkKQWwE+wKdF73VsOa2RQdIoO3mxwJ4P8mhbI6KYJUraUHRKM5w5zQQKXNk0xNL4UVRdulV9SBJcmzJNzVA=="
 		},
 		"homedir-polyfill": {
 			"version": "1.0.3",
@@ -658,9 +730,9 @@
 			}
 		},
 		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -795,10 +867,11 @@
 			}
 		},
 		"jwks-rsa": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.5.1.tgz",
-			"integrity": "sha512-FcH0mrrfS/5CDArzw7y4AIsNJ15SkAb8XTmfEnpUDmEsUf/4KfSQifff7hYEyrZuKnhisn4L9Pme4fb/ZoHKqQ==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-1.6.0.tgz",
+			"integrity": "sha512-gLhpd7Ka7Jy8ofm9OVj0PFPtSdx3+W2dncF3UCA1wDTAbvfiB1GhHbbyQlz8bqLF5+rge7pgD/DALRfgZi8Fgg==",
 			"requires": {
+				"@types/express-jwt": "0.0.42",
 				"debug": "^2.6.9",
 				"jsonwebtoken": "^8.5.1",
 				"limiter": "^1.1.4",
@@ -841,9 +914,9 @@
 			"integrity": "sha1-/sfervF+fDoKVeHaBCgD4l2RdF0="
 		},
 		"lodash": {
-			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+			"version": "4.17.14",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+			"integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
 		},
 		"lodash.includes": {
 			"version": "4.3.0",
@@ -895,9 +968,9 @@
 			}
 		},
 		"lru-memoizer": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-1.12.0.tgz",
-			"integrity": "sha1-7+ZXBsyKnMZT+A8NWm6jitlQ41I=",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-1.13.0.tgz",
+			"integrity": "sha512-q0wMolfI7yimhZ36kBAfMLOIuDBpRkieN9do0YPjSzCaiy6r73s8wOEq7Ue/B95VSRbXzfnOr1O1QdJc5UIqaw==",
 			"requires": {
 				"lock": "~0.1.2",
 				"lodash": "^4.17.4",
@@ -1007,9 +1080,9 @@
 			}
 		},
 		"ms": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"nan": {
 			"version": "2.14.0",
@@ -1073,9 +1146,9 @@
 			"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
 		},
 		"npm-packlist": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-			"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.4.tgz",
+			"integrity": "sha512-zTLo8UcVYtDU3gdeaFu2Xu0n0EvelfHDGuqtNIn5RO7yQj4H1TqNdBc/yZjxnWA0PVB8D3Woyp0i5B43JwQ6Vw==",
 			"requires": {
 				"ignore-walk": "^3.0.1",
 				"npm-bundled": "^1.0.1"
@@ -1204,9 +1277,9 @@
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
 		"process-nextick-args": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -1219,9 +1292,9 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"psl": {
-			"version": "1.1.32",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-			"integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
+			"integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA=="
 		},
 		"punycode": {
 			"version": "2.1.1",
@@ -1263,6 +1336,13 @@
 				"safe-buffer": "~5.1.1",
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
 			}
 		},
 		"rechoir": {
@@ -1319,9 +1399,9 @@
 			}
 		},
 		"resolve": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-			"integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+			"integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -1350,9 +1430,9 @@
 			}
 		},
 		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -1403,9 +1483,9 @@
 			}
 		},
 		"sqlite3": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.8.tgz",
-			"integrity": "sha512-kgwHu4j10KhpCHtx//dejd/tVQot7jc3sw+Sn0vMuKOw0X00Ckyg9VceKgzPyGmmz+zEoYue9tOLriWTvYy0ww==",
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.9.tgz",
+			"integrity": "sha512-IkvzjmsWQl9BuBiM4xKpl5X8WCR4w0AeJHRdobCdXZ8dT/lNc1XS6WqvY35N6+YzIIgzSBeY5prdFObID9F9tA==",
 			"requires": {
 				"nan": "^2.12.1",
 				"node-pre-gyp": "^0.11.0",
@@ -1449,6 +1529,13 @@
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
 				"safe-buffer": "~5.1.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
 			}
 		},
 		"strip-ansi": {
@@ -1478,22 +1565,22 @@
 			}
 		},
 		"symbol-tree": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
 		},
 		"tar": {
-			"version": "4.4.8",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-			"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+			"version": "4.4.10",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz",
+			"integrity": "sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==",
 			"requires": {
 				"chownr": "^1.1.1",
 				"fs-minipass": "^1.2.5",
-				"minipass": "^2.3.4",
-				"minizlib": "^1.1.1",
+				"minipass": "^2.3.5",
+				"minizlib": "^1.2.1",
 				"mkdirp": "^0.5.0",
 				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.2"
+				"yallist": "^3.0.3"
 			},
 			"dependencies": {
 				"yallist": {
@@ -1639,9 +1726,9 @@
 			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
 		},
 		"uglify-js": {
-			"version": "3.5.15",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.15.tgz",
-			"integrity": "sha512-fe7aYFotptIddkwcm6YuA0HmknBZ52ZzOsUxZEdhhkSsz7RfjHDX2QDxwKTiv4JQ5t5NhfmpgAK+J7LiDhKSqg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+			"integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
 			"optional": true,
 			"requires": {
 				"commander": "~2.20.0",


### PR DESCRIPTION
# Issue

Snyk reported that the current `package-lock.json` in the package `@foal/jwks-rsa` has a prototype pollution. This PR fixes the version of `lodash` that is responsible for this.

# Solution and steps

- [x] Update the `package-lock.json`

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
