### PR TITLE
[Bug] Fix 500 errors on invalid JSON

### DIFF
--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -239,4 +239,43 @@ describe('createApp', () => {
     strictEqual(app.foal.services instanceof ServiceManager, true);
   });
 
+  it('should not ignore client errors thrown in express middlewares.', () => {
+    class AppController {
+      @Post('/foo')
+      post(ctx: Context) {
+        return new HttpResponseOK({ body: ctx.request.body });
+      }
+    }
+    const app = createApp(AppController);
+
+    return request(app)
+      .post('/foo')
+      .set('Content-Type', 'text/html; charset=foo')
+      .send('bar')
+      .expect(415)
+      .then(response => {
+        strictEqual(response.text.includes('UnsupportedMediaTypeError: unsupported charset'), true);
+      });
+  });
+
+  it('should send a pretty error if the JSON in the request body is invalid.', () => {
+    class AppController {
+      @Post('/foo')
+      post(ctx: Context) {
+        return new HttpResponseOK({ body: ctx.request.body });
+      }
+    }
+    const app = createApp(AppController);
+
+    return request(app)
+      .post('/foo')
+      .type('application/json')
+      .send('{ "foo": "bar", }')
+      .expect(400)
+      .expect({
+        body: '{ \"foo\": \"bar\", }',
+        message: 'Unexpected token } in JSON at position 16'
+      });
+  });
+
 });

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -47,6 +47,16 @@ export function createApp(rootControllerClass: Class, expressInstance?) {
     express.static(Config.get('settings.staticPath', 'public'))
   );
   app.use(express.json());
+  app.use((err, req, res, next) => {
+    if (err.type !== 'entity.parse.failed') {
+      next(err);
+      return;
+    }
+    res.status(err.status).send({
+      body: err.body,
+      message: err.message
+    });
+  });
   app.use(express.urlencoded({ extended: false }));
   app.use(bodyParser.text({ type: [ 'text/*', 'application/graphql' ] }));
   app.use(cookieParser());

--- a/packages/core/src/express/handle-errors.ts
+++ b/packages/core/src/express/handle-errors.ts
@@ -24,6 +24,11 @@ function renderDebug500(stack): string {
  */
 export function handleErrors(debug: boolean, logFn = console.error) {
   return (err, req, res, next) => {
+    if (err.expose && err.status) {
+      next(err);
+      return;
+    }
+
     logFn(err.stack);
     if (debug) {
       res.status(500)


### PR DESCRIPTION
# Issue

Fixes #457.

- Make the app return a pretty 400 object message if the JSON received is invalid.
- Make the app return the client errors thrown in the internals middlewares.

# Solution and steps

- [x] Update `create-app.ts`
- [x] Update `handle-errors.ts`

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
