### PR TITLE
[Bug] Make `foal generate` not fail if index.ts does not exist

### DIFF
--- a/packages/cli/src/generate/generators/controller/create-controller.spec.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.spec.ts
@@ -62,6 +62,11 @@ describe('createController', () => {
           .validateSpec('index.ts', 'index.ts');
       });
 
+      it('should not throw an error if index.ts does not exist.', () => {
+        testEnv.rmfileIfExists('index.ts');
+        createController({ name: 'test-fooBar', type: 'Empty', register: false });
+      });
+
     });
 
   }

--- a/packages/cli/src/generate/generators/controller/create-controller.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.ts
@@ -26,7 +26,7 @@ export function createController({ name, type, register }: { name: string, type:
     .updateFile('index.ts', content => {
       content += `export { ${names.upperFirstCamelName}Controller } from './${names.kebabName}.controller';\n`;
       return content;
-    });
+    }, { allowFailure: true });
 
   if (register) {
     const path = `/${names.kebabName}${type === 'REST' ? 's' : ''}`;

--- a/packages/cli/src/generate/generators/entity/create-entity.spec.ts
+++ b/packages/cli/src/generate/generators/entity/create-entity.spec.ts
@@ -36,6 +36,11 @@ describe('createEntity', () => {
           .validateSpec('index.ts', 'index.ts');
       });
 
+      it('should not throw an error if index.ts does not exist.', () => {
+        testEnv.rmfileIfExists('index.ts');
+        createEntity({ name: 'test-fooBar' });
+      });
+
     });
 
   }

--- a/packages/cli/src/generate/generators/entity/create-entity.ts
+++ b/packages/cli/src/generate/generators/entity/create-entity.ts
@@ -20,5 +20,5 @@ export function createEntity({ name }: { name: string }) {
     .updateFile('index.ts', content => {
       content += `export { ${names.upperFirstCamelName} } from './${names.kebabName}.entity';\n`;
       return content;
-    });
+    }, { allowFailure: true });
 }

--- a/packages/cli/src/generate/generators/hook/create-hook.spec.ts
+++ b/packages/cli/src/generate/generators/hook/create-hook.spec.ts
@@ -36,6 +36,11 @@ describe('createHook', () => {
           .validateSpec('index.ts', 'index.ts');
       });
 
+      it('should not throw an error if index.ts does not exist.', () => {
+        testEnv.rmfileIfExists('index.ts');
+        createHook({ name: 'test-fooBar' });
+      });
+
     });
 
   }

--- a/packages/cli/src/generate/generators/hook/create-hook.ts
+++ b/packages/cli/src/generate/generators/hook/create-hook.ts
@@ -20,5 +20,5 @@ export function createHook({ name }: { name: string }) {
     .updateFile('index.ts', content => {
       content += `export { ${names.upperFirstCamelName} } from './${names.kebabName}.hook';\n`;
       return content;
-    });
+    }, { allowFailure: true });
 }

--- a/packages/cli/src/generate/generators/model/create-model.spec.ts
+++ b/packages/cli/src/generate/generators/model/create-model.spec.ts
@@ -37,6 +37,11 @@ describe('createModel', () => {
           .validateSpec('index.ts', 'index.ts');
       });
 
+      it('should not throw an error if index.ts does not exist.', () => {
+        testEnv.rmfileIfExists('index.ts');
+        createModel({ name: 'test-fooBar' });
+      });
+
       it('should should order the export in index.ts.', () => {
         createModel({ name: 'a-test-fooBar' });
 

--- a/packages/cli/src/generate/generators/model/create-model.ts
+++ b/packages/cli/src/generate/generators/model/create-model.ts
@@ -38,5 +38,5 @@ export function createModel({ name, checkMongoose }: { name: string, checkMongoo
       const exportNames = [ `I${names.upperFirstCamelName}`, names.upperFirstCamelName ].sort();
       content += `export { ${exportNames.join(', ')} } from './${names.kebabName}.model';\n`;
       return content;
-    });
+    }, { allowFailure: true });
 }

--- a/packages/cli/src/generate/generators/service/create-service.spec.ts
+++ b/packages/cli/src/generate/generators/service/create-service.spec.ts
@@ -38,6 +38,11 @@ describe('createService', () => {
           .validateSpec('index.ts', 'index.ts');
       });
 
+      it('should not throw an error if index.ts does not exist.', () => {
+        testEnv.rmfileIfExists('index.ts');
+        createService({ name: 'test-fooBar' });
+      });
+
     });
 
   }

--- a/packages/cli/src/generate/generators/service/create-service.ts
+++ b/packages/cli/src/generate/generators/service/create-service.ts
@@ -20,6 +20,6 @@ export function createService({ name }: { name: string }) {
     .updateFile('index.ts', content => {
       content += `export { ${names.upperFirstCamelName} } from './${names.kebabName}.service';\n`;
       return content;
-    });
+    }, { allowFailure: true });
 
 }


### PR DESCRIPTION
# Issue

Currently `foal generate controller` fails if there is no `index.ts` file in `src/app/controllers`, `controllers` or in the current directory. This a bit annoying when organizing the directory structure by functionality.

# Solution and steps

- [x] `create-controller`
- [x] `create-entity`
- [x] `create-hook`
- [x] `create-model`

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
