### PR TITLE
[Docs] Adds CORS example for rate limiting

### DIFF
--- a/docs/api-section/public-api-and-cors-requests.md
+++ b/docs/api-section/public-api-and-cors-requests.md
@@ -28,6 +28,7 @@ export class ApiController {
   @Options('*')
   options(ctx: Context) {
     const response = new HttpResponseNoContent();
+    response.setHeader('Access-Control-Allow-Methods', 'HEAD, GET, POST, PUT, PATCH, DELETE');
     // You may need to allow other headers depending on what you need.
     response.setHeader('Access-Control-Allow-Headers', 'Content-Type');
     return response;
@@ -46,6 +47,7 @@ If your API requires a token to be sent in the `Authorization` header, then the 
   @Options('*')
   options(ctx: Context) {
     const response = new HttpResponseNoContent();
+    response.setHeader('Access-Control-Allow-Methods', 'HEAD, GET, POST, PUT, PATCH, DELETE');
     response.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization');
     return response;
   }

--- a/docs/cookbook/limit-repeated-requests.md
+++ b/docs/cookbook/limit-repeated-requests.md
@@ -33,7 +33,7 @@ async function main() {
   const httpServer = http.createServer(app);
   const port = Config.get('port', 3001);
   httpServer.listen(port, () => {
-      console.log(`Listening on port ${port}...`);
+    console.log(`Listening on port ${port}...`);
   });
 }
 

--- a/docs/cookbook/limit-repeated-requests.md
+++ b/docs/cookbook/limit-repeated-requests.md
@@ -18,24 +18,58 @@ import * as rateLimit from 'express-rate-limit';
 import { AppController } from './app/app.controller';
 
 async function main() {
-    // Connection to the database(s)...
+  // Connection to the database(s)...
     
-    const expressApp = express();
-    expressApp.use(rateLimit({
-      max: 100, // limit each IP to 100 requests per windowMs
-      windowMs: 15 * 60 * 1000, // 15 minutes
-    }));
+  const expressApp = express();
+  expressApp.use(rateLimit({
+    max: 100, // limit each IP to 100 requests per windowMs
+    windowMs: 15 * 60 * 1000, // 15 minutes
+  }));
     
-    const app = createApp(AppController, expressApp); // For v1
-    // For v0.8
-    // const app = createApp(AppController, { /* ... */ }, expressApp);
+  const app = createApp(AppController, expressApp); // For v1
+  // For v0.8
+  // const app = createApp(AppController, { /* ... */ }, expressApp);
     
-    const httpServer = http.createServer(app);
-    const port = Config.get('port', 3001);
-    httpServer.listen(port, () => {
-        console.log(`Listening on port ${port}...`);
-    });
+  const httpServer = http.createServer(app);
+  const port = Config.get('port', 3001);
+  httpServer.listen(port, () => {
+      console.log(`Listening on port ${port}...`);
+  });
 }
 
 main();
 ```
+
+
+**Rate limiting with CORS**
+
+If you need CORS headers to be send back in a response, you will need to manually set the headers on the rate limiter response because it does not get handled by FoalTS hooks. If you don't manually set any headers only the default Express.js headers will be set in the response.
+
+> Note: Because the rate limiter response does not get handled by FoalTS, you should also set the default FoalTS headers manually.
+
+```typescript
+expressApp.use(rateLimit({
+  max: 100,
+  windowMs: 15 * 60 * 1000,
+  handler: function (req, res, next) {
+    // Set default FoalTS headers
+    res.removeHeader('X-Powered-By');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('X-DNS-Prefetch-Control', 'off');
+    res.setHeader('X-Download-Options', 'noopen');
+    res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+    res.setHeader('X-XSS-Protection', '1; mode=block');
+    res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+
+    // Set CORS headers
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Origin', '*');
+
+    // Send the response with the default statusCode and message from rateLimit
+    res.status(this.statusCode).send(this.message);
+  }
+}));
+```
+
+You can find more options for [express-rate-limit](https://www.npmjs.com/package/express-rate-limit) in the [documentation](https://github.com/nfriedly/express-rate-limit).

--- a/docs/cookbook/limit-repeated-requests.md
+++ b/docs/cookbook/limit-repeated-requests.md
@@ -15,7 +15,7 @@ import * as http from 'http';
 // 3p
 import { Config, createApp } from '@foal/core';
 import * as express from 'express';
-import rateLimit from 'express-rate-limit';
+import * as rateLimit from 'express-rate-limit';
 
 // App
 import { AppController } from './app/app.controller';

--- a/docs/cookbook/limit-repeated-requests.md
+++ b/docs/cookbook/limit-repeated-requests.md
@@ -4,6 +4,9 @@ To prevent brute force attacks or overloads on your application, you need to imp
 
 In FoalTS you can implement a rate limiter like the [express-rate-limit](https://github.com/nfriedly/express-rate-limit) package by creating a customized `express` object and passing it as a parameter to the FoalTS `createApp` function.
 
+> Note: Because the rate limiter response for rate limited requests does not get handled by FoalTS and its hooks, you need to manually set the default FoalTS headers to the response object of the rate limiter in its `handle` function.
+> If you don't manually set any headers only the default Express.js headers will be set in the response.
+
 *src/index.ts*
 ```typescript
 // std
@@ -12,7 +15,7 @@ import * as http from 'http';
 // 3p
 import { Config, createApp } from '@foal/core';
 import * as express from 'express';
-import * as rateLimit from 'express-rate-limit';
+import rateLimit from 'express-rate-limit';
 
 // App
 import { AppController } from './app/app.controller';
@@ -24,6 +27,19 @@ async function main() {
   expressApp.use(rateLimit({
     max: 100, // limit each IP to 100 requests per windowMs
     windowMs: 15 * 60 * 1000, // 15 minutes
+    handler: function (req, res, next) {
+      // Set default FoalTS headers to the response of limited requests
+      res.removeHeader('X-Powered-By');
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      res.setHeader('X-DNS-Prefetch-Control', 'off');
+      res.setHeader('X-Download-Options', 'noopen');
+      res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+      res.setHeader('X-XSS-Protection', '1; mode=block');
+      res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+      
+      // Send the response with the default statusCode and message from rateLimit
+      res.status(this.statusCode).send(this.message);
+    }
   }));
     
   const app = createApp(AppController, expressApp); // For v1
@@ -43,16 +59,14 @@ main();
 
 **Rate limiting with CORS**
 
-If you need CORS headers to be send back in a response, you will need to manually set the headers on the rate limiter response because it does not get handled by FoalTS hooks. If you don't manually set any headers only the default Express.js headers will be set in the response.
-
-> Note: Because the rate limiter response does not get handled by FoalTS, you should also set the default FoalTS headers manually.
+If you need CORS headers in a rate limited response, you will need to manually add the headers in the rate limiter `handler` function accordingly.
 
 ```typescript
 expressApp.use(rateLimit({
   max: 100,
   windowMs: 15 * 60 * 1000,
   handler: function (req, res, next) {
-    // Set default FoalTS headers
+    // Set default FoalTS headers to the response of limited requests
     res.removeHeader('X-Powered-By');
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('X-DNS-Prefetch-Control', 'off');
@@ -62,9 +76,12 @@ expressApp.use(rateLimit({
     res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
 
     // Set CORS headers
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
     res.setHeader('Access-Control-Allow-Origin', '*');
+    if (req.method === 'OPTIONS') {
+      // You may want to allow other headers depending on what you need.
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+      res.setHeader('Access-Control-Allow-Methods', 'HEAD, GET, POST, PUT, PATCH, DELETE');
+    }
 
     // Send the response with the default statusCode and message from rateLimit
     res.status(this.statusCode).send(this.message);


### PR DESCRIPTION
# Issue
Resolves #485

# Solution and steps
Added example code to the docs to show how to set headers to a response from `express-rate-limit`.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [ ] Add/update/check tests.
- [ ] Update/check the cli generators.
