### PR TITLE
Implement route param injection

### DIFF
--- a/packages/core/src/express/create-middleware.ts
+++ b/packages/core/src/express/create-middleware.ts
@@ -9,6 +9,8 @@ import {
   ServiceManager
 } from '../core';
 
+import { utils } from 'realm-utils';
+
 /**
  * Create an express middleware from a Route and the application services.
  *
@@ -36,7 +38,19 @@ export function createMiddleware(route: Route, services: ServiceManager): (...ar
       }
 
       if (!isHttpResponse(response)) {
-        response = await route.controller[route.propertyKey](ctx);
+        const requiredParams = utils.getParameterNamesFromFunction(route.controller[route.propertyKey]);
+        const params = {
+            ctx,
+            context: ctx,
+            ...ctx.request.params
+        };
+
+        let args = requiredParams.map(param => params[param]);
+        if (args.length === 0) {
+            args = [ctx]
+        }
+
+        response = await route.controller[route.propertyKey](...args);
       }
 
       if (!isHttpResponse(response)) {


### PR DESCRIPTION
Quick implementation of #507 
Make sure to run `npm i realm-utils`

`getParameterNamesFromFunction` from `realm-utils` is used to obtain kinda reflect method names from implementation.

- [ ] Caching: `requiredParams` should be cached ideally somewhere in order to avoid `getParameterNamesFromFunction` more that once for an endpoint
- [ ] Tests
- [ ] Compatibility
- [ ] Maybe check a boolean setting before doing that like `injectMethodParams`

Let me know what you guys are thinking. 