### PR TITLE
[CLI] Set default TS version to 3.5 in new projects (foal createapp)

### DIFF
--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -50,6 +50,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^3.3.3"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/cli/src/generate/specs/app/package.mongodb.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.json
@@ -45,6 +45,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^3.3.3"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
@@ -46,6 +46,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^3.3.3"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/cli/src/generate/specs/app/package.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.yaml.json
@@ -51,6 +51,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^3.3.3"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -50,6 +50,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^3.3.3"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/cli/src/generate/templates/app/package.mongodb.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.json
@@ -45,6 +45,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^3.3.3"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/cli/src/generate/templates/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.yaml.json
@@ -46,6 +46,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^3.3.3"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/cli/src/generate/templates/app/package.yaml.json
+++ b/packages/cli/src/generate/templates/app/package.yaml.json
@@ -51,6 +51,6 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "tslint": "^5.10.0",
-    "typescript": "^3.3.3"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/swagger/src/swagger-controller.ts
+++ b/packages/swagger/src/swagger-controller.ts
@@ -50,7 +50,7 @@ export abstract class SwaggerController {
 
   /**
    * Extend Swagger UI options.
-   * 
+   *
    * See https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/.
    *
    * @type {object}


### PR DESCRIPTION
# Issue

Resolves #528.

Theoretically, minor releases of TypeScript (3.4, 3.5, 3.6, etc) should not break code compatibility. In practice, when TS releases a new version, they often introduce a small breaking change / bug that libraries need to fix to make them work with the new version. We had this issue twice with TypeORM in Foal history.

This is annoying because when a new TS version is released, the command `foal createapp` installs this last version and `foal develop` (or other build commands) might not work (that make us loose people that might give the framework a try).

# Solution and steps
 
Make `foal createapp` generate every new project with TypeScript version 3.5 (and its patches).

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
