### PR TITLE
Support AppController.init to initialize the application

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -84,6 +84,7 @@
   * [Templates (SSR)](./utilities/templating.md)
   * [Logging & Debugging](./utilities/logging-and-debugging.md)
 * Cookbook
+  * [Initialization](./cookbook/initialization.md)
   * [Upload & Download Files](./cookbook/upload-and-download-files.md)
   * [Generate Tokens](./cookbook/generate-tokens.md)
   * [Scheduling Jobs](./cookbook/scheduling-jobs.md)

--- a/docs/cookbook/initialization.md
+++ b/docs/cookbook/initialization.md
@@ -1,0 +1,97 @@
+# Initialization
+
+In many situations, we need to initialize the application (i.e perform certain actions) before listening to incoming HTTP requests. This is the case, for example, if you need to establish a connection to the database.
+
+There are two ways to achieve this in FoalTS.
+
+## The `main` function
+
+The most straightforward way to do it, which is used by default, is to add the initialization commands in the `main` function before `createApp` is called.
+
+If your application uses TypeORM, your project should have a file `src/index.ts` that looks like this:
+
+```typescript
+async function main() {
+  // Initialization
+  await createConnection();
+
+  // Creation of the application
+  const app = createApp(AppController);
+
+  // ...
+}
+
+main();
+```
+
+## The `AppController.init` method
+
+Sometimes, however, this approach is not sufficient because we need to call the methods of some services. In this case, you can add an `init` method to the root controller class that will be called before the application is fully created. This method can be synchronous or asynchronous.
+
+*Example 1*
+```typescript
+export class AppController {
+
+  @dependency
+  serviceA: ServiceA;
+
+  async init() {
+    await this.serviceA.doSomething();
+  }
+
+}
+```
+
+*Example 2*
+```typescript
+export class AppController {
+
+  @dependency
+  serviceA: ServiceA;
+
+  @dependency
+  serviceB: ServiceB;
+
+  async init() {
+    this.serviceA.init();
+    this.serviceB.init();
+  }
+
+}
+```
+
+For this to work, you need to update your `src/index.ts` file and create the application with the asynchronous function `createAndInitApp`.
+
+```typescript
+import { createAndInitApp } from '@foal/core';
+
+async function main() {
+  const app = await createAndInitApp(AppController);
+
+  // ...
+}
+
+main();
+```
+
+## Best Practices
+
+If your initialization consists of several asynchronous tasks, you may want to perform them in *parallel*. This will reduce the initialization time, which has a real impact if you use a serverless architecture.
+
+```typescript
+export class AppController {
+
+  async init() {
+    // Don't do
+    await createConnection();
+    await createAnotherConnection();
+
+    // Do
+    await Promise.all([
+      createConnection(),
+      createAnotherConnection()
+    ])
+  }
+
+}
+```

--- a/docs/cookbook/initialization.md
+++ b/docs/cookbook/initialization.md
@@ -26,7 +26,7 @@ main();
 
 ## The `AppController.init` method
 
-Sometimes, however, this approach is not sufficient because we need to call the methods of some services. In this case, you can add an `init` method to the root controller class that will be called before the application is fully created. This method can be synchronous or asynchronous.
+Sometimes, however, this approach is not sufficient because we need to call the methods of some services. In this case, you can add an `init` method to the root controller class which will be called before the application is fully created. This method can be synchronous or asynchronous.
 
 *Example 1*
 ```typescript
@@ -76,7 +76,7 @@ main();
 
 ## Best Practices
 
-If your initialization consists of several asynchronous tasks, you may want to perform them in *parallel*. This will reduce the initialization time, which has a real impact if you use a serverless architecture.
+If your initialization consists of several asynchronous tasks, you may want to perform them in *parallel*. This will reduce the initialization time, which has an impact if you use a serverless architecture.
 
 ```typescript
 export class AppController {

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -8,7 +8,7 @@ import * as request from 'supertest';
 // FoalTS
 import { existsSync, mkdirSync, rmdirSync, unlinkSync, writeFileSync } from 'fs';
 import { Context, Delete, Get, Head, HttpResponseOK, Options, Patch, Post, Put, ServiceManager } from '../core';
-import { createApp } from './create-app';
+import { createAndInitApp, createApp } from './create-app';
 
 describe('createApp', () => {
 
@@ -345,6 +345,78 @@ describe('createApp', () => {
         body: '{ \"foo\": \"bar\", }',
         message: 'Unexpected token } in JSON at position 16'
       });
+  });
+
+});
+
+describe('createAndInitApp', () => {
+
+  it('should call createApp and return asynchronously its express instance.', async () => {
+    class AppController {
+      @Get('/ping')
+      ping() {
+        return new HttpResponseOK('pong');
+      }
+    }
+
+    const app = await createAndInitApp(AppController, {
+      postMiddlewares: [
+        express.Router().get('/ping2', (req, res) => res.send('pong'))
+      ]
+    });
+
+    await request(app)
+      .get('/ping')
+      .expect('pong');
+
+    await request(app)
+      .get('/ping2')
+      .expect('pong');
+  });
+
+  it('should call AppController.init if it exists.', () => {
+    let called = false;
+
+    class AppController {
+      init() {
+        called = true;
+      }
+    }
+
+    createAndInitApp(AppController);
+
+    strictEqual(called, true);
+  });
+
+  it('should wait until the end of AppController.init execution before returning the express instance.', async () => {
+    let called = false;
+
+    class AppController {
+      async init() {
+        await 1;
+        await 1;
+        called = true;
+      }
+    }
+
+    await createAndInitApp(AppController);
+
+    strictEqual(called, true);
+  });
+
+  it('should throw any errors rejected in AppController.init.', async () => {
+    class AppController {
+      init() {
+        return Promise.reject(new Error('Initialization failed.'));
+      }
+    }
+
+    try {
+      await createAndInitApp(AppController);
+      throw new Error('An error should have been thrown');
+    } catch (error) {
+      strictEqual(error.message, 'Initialization failed.');
+    }
   });
 
 });

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -35,9 +35,11 @@ interface ExpressOptions {
  * middlewares to be executed before the controllers and hooks.
  * @param {(express.RequestHandler | express.ErrorRequestHandler)[]} [expressInstanceOrOptions.postMiddlewares] Express
  * middlewares to be executed after the controllers and hooks, but before the 500 or 404 handler get called.
- * @returns The express application.
+ * @returns {ExpressApplication} The express application.
  */
-export function createApp(rootControllerClass: Class, expressInstanceOrOptions?: ExpressApplication|ExpressOptions) {
+export function createApp(
+  rootControllerClass: Class, expressInstanceOrOptions?: ExpressApplication|ExpressOptions
+): ExpressApplication {
   let app: ExpressApplication = express();
 
   if (expressInstanceOrOptions && typeof expressInstanceOrOptions === 'function') {
@@ -128,6 +130,32 @@ export function createApp(rootControllerClass: Class, expressInstanceOrOptions?:
 
   app.use(notFound());
   app.use(handleErrors(Config.get('settings.debug', false), console.error));
+
+  return app;
+}
+
+/**
+ * Create an Express application from the root controller and call its "init" method if it exists.
+ *
+ * @export
+ * @param {Class} rootControllerClass - The root controller, usually called `AppController` and located in `src/app`.
+ * @param {(ExpressApplication|ExpressOptions)} [expressInstanceOrOptions] - Express instance or options containaining
+ * Express middlewares.
+ * @param {(express.RequestHandler | express.ErrorRequestHandler)[]} [expressInstanceOrOptions.preMiddlewares] Express
+ * middlewares to be executed before the controllers and hooks.
+ * @param {(express.RequestHandler | express.ErrorRequestHandler)[]} [expressInstanceOrOptions.postMiddlewares] Express
+ * middlewares to be executed after the controllers and hooks, but before the 500 or 404 handler get called.
+ * @returns {Promise<ExpressApplication>} The express application.
+ */
+export async function createAndInitApp(
+  rootControllerClass: Class, expressInstanceOrOptions?: ExpressApplication|ExpressOptions
+): Promise<ExpressApplication> {
+  const app = createApp(rootControllerClass, expressInstanceOrOptions);
+
+  const controller = app.foal.services.get(rootControllerClass);
+  if (controller.init) {
+    await controller.init();
+  }
 
   return app;
 }

--- a/packages/core/src/express/index.ts
+++ b/packages/core/src/express/index.ts
@@ -1,1 +1,1 @@
-export { createApp } from './create-app';
+export { createApp, createAndInitApp } from './create-app';


### PR DESCRIPTION
# Issue

Resolves #517.

# Solution and steps

- [x] Add a new `createAndInitApp` function which returns `Promise<ExpressApplication>`.

This function is the same as `createApp` except that it calls `AppController.init` if it exists and it returns a promise (to allow `AppController.init` to be asynchronous).

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
