### PR TITLE
Support ExpressOptions.expressInstance in createApp

### DIFF
--- a/docs/cookbook/expressjs.md
+++ b/docs/cookbook/expressjs.md
@@ -20,7 +20,13 @@ import * as express from 'express';
 
 const expressApp = express();
 expressApp.use(/* an Express middleware */)
+
 const app = createApp(AppController, expressApp);
+// OR
+const app = createApp(AppController, {
+  expressInstance: expressApp
+});
+
 ```
 
 ## Pre and Post Express Middlewares

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -233,6 +233,15 @@ describe('createApp', () => {
     strictEqual(actual, expected);
   });
 
+  it('should use the optional options.expressInstance if one is given.', () => {
+    const expected = express();
+    const actual = createApp(class {}, {
+      expressInstance: expected
+    });
+
+    strictEqual(actual, expected);
+  });
+
   it('should use the optional preMiddlewares if they are given.', () => {
     class AppController {
       @Get('/')

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -20,6 +20,7 @@ interface ExpressApplication extends express.Express {
 }
 
 interface ExpressOptions {
+  expressInstance?: ExpressApplication;
   preMiddlewares?: (express.RequestHandler | express.ErrorRequestHandler)[];
   postMiddlewares?: (express.RequestHandler | express.ErrorRequestHandler)[];
 }
@@ -31,6 +32,8 @@ interface ExpressOptions {
  * @param {Class} rootControllerClass - The root controller, usually called `AppController` and located in `src/app`.
  * @param {(ExpressApplication|ExpressOptions)} [expressInstanceOrOptions] - Express instance or options containaining
  * Express middlewares.
+ * @param {ExpressApplication} [expressInstanceOrOptions.expressInstance] - Express instance to be used as base for the
+ * returned application.
  * @param {(express.RequestHandler | express.ErrorRequestHandler)[]} [expressInstanceOrOptions.preMiddlewares] Express
  * middlewares to be executed before the controllers and hooks.
  * @param {(express.RequestHandler | express.ErrorRequestHandler)[]} [expressInstanceOrOptions.postMiddlewares] Express
@@ -47,6 +50,9 @@ export function createApp(
   }
 
   if (expressInstanceOrOptions && typeof expressInstanceOrOptions === 'object') {
+    if (expressInstanceOrOptions.expressInstance) {
+      app = expressInstanceOrOptions.expressInstance;
+    }
     for (const middleware of expressInstanceOrOptions.preMiddlewares || []) {
       app.use(middleware);
     }


### PR DESCRIPTION
# Issue

In some situations, we may need to specify both an `expressInstance` and `postMiddlewares` to `createApp` (for example if we're migrating an application from Express to Foal). This is currently not possible to do it properly.

# Solution and steps

- [x] Support `ExpressOptions.expressInstance` in `createApp`.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.

# Related issue

See this discussion: #370