### PR TITLE
Accept null as graphql query variables

### DIFF
--- a/packages/graphql/src/graphql.controller.spec.ts
+++ b/packages/graphql/src/graphql.controller.spec.ts
@@ -834,9 +834,9 @@ describe('GraphQLController', () => {
           deepStrictEqual(response.body, [{
             dataPath: '.variables',
             keyword: 'type',
-            message: 'should be object',
+            message: 'should be object,null',
             params: {
-              type: 'object'
+              type: 'object,null'
             },
             schemaPath: '#/properties/variables/type'
           }]);
@@ -883,6 +883,26 @@ describe('GraphQLController', () => {
           const query = `{ hello }`;
           const ctx = new Context({
             body: { query },
+            get: () => 'application/json',
+            query: {}
+          });
+          const response = await controller.post(ctx);
+
+          if (!isHttpResponseOK(response)) {
+            throw new Error('The controller should have returned an HttpResponseOK instance.');
+          }
+
+          deepStrictEqual(response.body, {
+            data: {
+              hello: null
+            }
+          });
+        });
+
+        it('with a "data" property if the GraphQL schema validates the body (with variables === null).', async () => {
+          const query = `{ hello }`;
+          const ctx = new Context({
+            body: { query, variables: null },
             get: () => 'application/json',
             query: {}
           });

--- a/packages/graphql/src/graphql.controller.ts
+++ b/packages/graphql/src/graphql.controller.ts
@@ -17,7 +17,7 @@ const postBodySchema = {
   properties: {
     operationName: { type: 'string' },
     query: { type: 'string' },
-    variables: { type: 'object' },
+    variables: { type: ['object', 'null'] },
   },
   required: ['query'],
   type: 'object',


### PR DESCRIPTION
# Issue
Ajv schema validation fails if graphql query variables is `null`. 
For example `{"query":"{ users { email } }","variables":null}` returns 
```js
[
  {
    "keyword": "type",
    "dataPath": ".variables",
    "schemaPath": "#/properties/variables/type",
    "params": {
      "type": "object"
    },
    "message": "should be object"
  }
]
```

# Solution and steps
Update Ajv schema to accept `null` for variables.