### PR TITLE
Improve createapp CLI by adding options

### DIFF
--- a/packages/cli/src/generate/generators/app/create-app.spec.ts
+++ b/packages/cli/src/generate/generators/app/create-app.spec.ts
@@ -1,3 +1,7 @@
+// std
+import { strictEqual } from 'assert';
+import { mkdirSync, readdirSync } from 'fs';
+
 // FoalTS
 import { TestEnvironment } from '../../utils';
 import { createApp } from './create-app';
@@ -7,6 +11,16 @@ describe('createApp', () => {
   const testEnv = new TestEnvironment('app', 'test-foo-bar');
 
   afterEach(() => testEnv.rmDirAndFilesIfExist('../test-foo-bar'));
+
+  it('should abort the project creation if a directory already exists.', async () => {
+    mkdirSync('test-foo-bar');
+
+    await createApp({ name: 'test-fooBar' });
+
+    const files = readdirSync('test-foo-bar');
+
+    strictEqual(files.length, 0);
+  });
 
   it('should render the config templates.', async () => {
     await createApp({ name: 'test-fooBar' });

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -85,13 +85,13 @@ export async function createApp({ name, autoInstall, initRepo, mongodb = false, 
      // Validating whether if the project-name follows npm naming conventions
   if (!validateProjectName(name)) {
     console.log(
-      red(`\n ${red(`${name} doesn't follow the npm naming conventions. Kindly give a vaild project-name`)}`)
+      `\n ${red(`${name} doesn't follow the npm naming conventions. Kindly give a vaild project-name`)}`
     );
     return;
   }
   if (existsSync(names.kebabName)) {
     console.log(
-      red(`\n ${red(`The target directory "${name}" already exists. Please remove it before proceeding.`)}`)
+      `\n ${red(`The target directory "${name}" already exists. Please remove it before proceeding.`)}`
     )
     return;
   }

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -10,7 +10,6 @@ import {
   Generator,
   getNames,
   initGitRepo,
-  mkdirIfDoesNotExist,
 } from '../../utils';
 
 function isYarnInstalled() {
@@ -92,7 +91,7 @@ export async function createApp({ name, autoInstall, initRepo, mongodb = false, 
   if (existsSync(names.kebabName)) {
     console.log(
       red(`\n The target directory "${names.kebabName}" already exists. Please remove it before proceeding.`)
-    )
+    );
     return;
   }
   mkdirSync(names.kebabName);

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -1,5 +1,6 @@
 // std
 import { execSync, spawn, SpawnOptions } from 'child_process';
+import { existsSync, mkdirSync } from 'fs';
 
 // 3p
 import { cyan, red } from 'colors/safe';
@@ -88,7 +89,13 @@ export async function createApp({ name, autoInstall, initRepo, mongodb = false, 
     );
     return;
   }
-  mkdirIfDoesNotExist(names.kebabName);
+  if (existsSync(names.kebabName)) {
+    console.log(
+      red(`\n ${red(`The target directory "${name}" already exists. Please remove it before proceeding.`)}`)
+    )
+    return;
+  }
+  mkdirSync(names.kebabName);
 
   log('  📂 Creating files...');
   const generator = new Generator('app', names.kebabName, { noLogs: true });

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -85,13 +85,13 @@ export async function createApp({ name, autoInstall, initRepo, mongodb = false, 
      // Validating whether if the project-name follows npm naming conventions
   if (!validateProjectName(name)) {
     console.log(
-      `\n ${red(`${name} doesn't follow the npm naming conventions. Kindly give a vaild project-name`)}`
+      red(`\n ${name} doesn't follow the npm naming conventions. Kindly give a valid project-name.`)
     );
     return;
   }
   if (existsSync(names.kebabName)) {
     console.log(
-      `\n ${red(`The target directory "${name}" already exists. Please remove it before proceeding.`)}`
+      red(`\n The target directory "${names.kebabName}" already exists. Please remove it before proceeding.`)
     )
     return;
   }

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -205,7 +205,7 @@ export async function createApp({ name, autoInstall, initRepo, mongodb = false, 
 
 ` + [
   `cd ${names.kebabName}`,
-  ...!autoInstall ? [`npm install`] : [],
+  ...(autoInstall ? [] : [`npm install`]),
   'npm run develop'
 ].map(cmd => '    $ ' + cyan(cmd)).join('\n') + '\n'
   );

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -188,8 +188,8 @@ export async function createApp({ name, autoInstall, initRepo, mongodb = false, 
     });
   }
 
-  log('  📔 Initializing git repository...');
   if (initRepo) {
+    log('  📔 Initializing git repository...');
     await initGitRepo(names.kebabName);
   }
 

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -166,9 +166,9 @@ export async function createApp({ name, autoInstall, initRepo, mongodb = false, 
         .copyFileFromTemplatesOnlyIf(!mongodb, 'src/scripts/create-user.ts')
         .copyFileFromTemplatesOnlyIf(mongodb, 'src/scripts/create-user.mongodb.ts', 'src/scripts/create-user.ts');
 
-  log('');
-  log('  📦 Installing the dependencies...');
   if (autoInstall) {
+    log('');
+    log('  📦 Installing the dependencies...');
     const packageManager = isYarnInstalled() ? 'yarn' : 'npm';
     const args = [ 'install' ];
     const options: SpawnOptions = {
@@ -196,8 +196,10 @@ export async function createApp({ name, autoInstall, initRepo, mongodb = false, 
   log(`
   👉 Run the following commands to get started:
 
-    $ ${cyan(`cd ${names.kebabName}`)}
-    $ ${cyan('npm run develop')}
-`
+` + [
+  `cd ${names.kebabName}`,
+  ...!autoInstall ? [`npm install`] : [],
+  'npm run develop'
+].map(cmd => '    $ ' + cyan(cmd)).join('\n') + '\n'
   );
 }

--- a/packages/cli/src/generate/utils/init-git-repo.ts
+++ b/packages/cli/src/generate/utils/init-git-repo.ts
@@ -14,14 +14,14 @@ export async function initGitRepo(root: string) {
 
   const hasCommand = await execute(['--version']).then(() => true, () => false);
   if (!hasCommand) {
-    console.log('Git not installed. Skipping initialization of git.');
+    console.log('    Git not installed. Skipping initialization of git.');
     return;
   }
 
   const insideRepo = await execute(['rev-parse', '--is-inside-work-tree'])
     .then(() => true, () => false);
   if (insideRepo) {
-    console.log('Directory is already under version control. Skipping initialization of git.');
+    console.log('     Directory is already under version control. Skipping initialization of git.');
     return;
   }
 
@@ -30,7 +30,7 @@ export async function initGitRepo(root: string) {
     await execute(['add', '.']);
     await execute(['commit', '-m "Initial commit"']);
   } catch {
-    console.log('Initialization of git failed.');
+    console.log('    Initialization of git failed.');
   }
 
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,11 +37,12 @@ program
 program
   .command('createapp <name>')
   .description('Create a new project.')
+  .option('-I, --no-install', "Don't autoinstall packages using yarn or npm (uses first available)")
   .option('-m, --mongodb', 'Generate a new project using Mongoose/MongoDB instead of TypeORM/SQLite')
   .option('-y, --yaml', 'Generate a new project using YAML configuration instead of JSON')
   .action((name: string, options) => {
     createApp({
-      autoInstall: true,
+      autoInstall: options.install,
       initRepo: true,
       mongodb: options.mongodb || false,
       name,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,8 +37,8 @@ program
 program
   .command('createapp <name>')
   .description('Create a new project.')
-  .option('-G, --no-git', "Don't initialize a git repository")
-  .option('-I, --no-install', "Don't autoinstall packages using yarn or npm (uses first available)")
+  .option('-G, --no-git', 'Don\'t initialize a git repository')
+  .option('-I, --no-install', 'Don\'t autoinstall packages using yarn or npm (uses first available)')
   .option('-m, --mongodb', 'Generate a new project using Mongoose/MongoDB instead of TypeORM/SQLite')
   .option('-y, --yaml', 'Generate a new project using YAML configuration instead of JSON')
   .action((name: string, options) => {
@@ -155,6 +155,6 @@ program
 program.parse(process.argv);
 
 // Shows help if no arguments are provided
-if (process.argv.length == 2) {
+if (process.argv.length === 2) {
   program.outputHelp();
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -154,6 +154,6 @@ program
 program.parse(process.argv);
 
 // Shows help if no arguments are provided
-if (!program.args.length) {
+if (process.argv.length == 2) {
   program.outputHelp();
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -43,8 +43,8 @@ program
   .option('-y, --yaml', 'Generate a new project using YAML configuration instead of JSON')
   .action((name: string, options) => {
     createApp({
-      autoInstall: options.install,
-      initRepo: options.git,
+      autoInstall: options.install as boolean,
+      initRepo: options.git as boolean,
       mongodb: options.mongodb || false,
       name,
       yaml: options.yaml || false

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,13 +37,14 @@ program
 program
   .command('createapp <name>')
   .description('Create a new project.')
+  .option('-G, --no-git', "Don't initialize a git repository")
   .option('-I, --no-install', "Don't autoinstall packages using yarn or npm (uses first available)")
   .option('-m, --mongodb', 'Generate a new project using Mongoose/MongoDB instead of TypeORM/SQLite')
   .option('-y, --yaml', 'Generate a new project using YAML configuration instead of JSON')
   .action((name: string, options) => {
     createApp({
       autoInstall: options.install,
-      initRepo: true,
+      initRepo: options.git,
       mongodb: options.mongodb || false,
       name,
       yaml: options.yaml || false


### PR DESCRIPTION
# Issue
* No way to stop createapp from automagically choosing between npm and yarn, and the installing process is quite slow (and may be skipped).
* No way to stop createapp from creating a git repository automagically (other than uninstalling git). Altough git is desirable, you can use others (Mercurial, subversion, who knows).
* No way to stop createapp from overwriting existing directories.
* CLI also has a bug where if you specify options before unnamed options (such as <name>), it shows unneeded usage information, while the command is running.

# Solution and steps
* Add options for these, and for overwriting existing directories, abort the operation if the directory exists.
* Fix CLI bug.

# Checklist
- [ ] Add/update/check tests.

(currently not automatically tested, but has been manually tested, we can discuss this and work on more CLI improvements over time).