### PR TITLE
Migrate to TypeScript version 3, fix MariaDB tests & use Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         image: mysql:5.7.10
         ports:
           - 3306:3306
-        environment:
+        env:
           MYSQL_ROOT_PASSWORD: admin
           MYSQL_USER: test
           MYSQL_PASSWORD: test
@@ -26,7 +26,7 @@ jobs:
         image: mariadb:10.1.16
         ports:
           - 3307:3306
-        environment:
+        env:
           MYSQL_ROOT_PASSWORD: admin
           MYSQL_USER: test
           MYSQL_PASSWORD: test
@@ -36,7 +36,7 @@ jobs:
         image: postgres:9.6.1
         ports:
           - 5432:5432
-        environment:
+        env:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test
           POSTGRES_DB: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,3 +73,8 @@ jobs:
       run: lerna run --no-bail test
     - name: Run acceptance tests (Bash)
       run: ./e2e_test.sh
+    - name: Send code coverage report to Codecov
+      uses: codecov/codecov-action@v1.0.3
+      with:
+        token: ${{secrets.CODECOV_TOKEN}}
+        file: packages/core/coverage/*.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,16 +12,16 @@ jobs:
         node-version: [8.x, 10.x]
 
     services:
-      # mysql is already installed on ubuntu
-      # mysql:
-      #   image: mysql:5.7.10
-      #   ports:
-      #     - 3306:3306
-      #   env:
-      #     MYSQL_ROOT_PASSWORD: admin
-      #     MYSQL_USER: test
-      #     MYSQL_PASSWORD: test
-      #     MYSQL_DATABASE: test
+      mysql:
+        image: mysql:5.7.10
+        ports:
+          # Another version of MySQL is installed on the vm and already uses the port 3306.
+          - 3308:3306
+        env:
+          MYSQL_ROOT_PASSWORD: admin
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+          MYSQL_DATABASE: test
 
       mariadb:
         image: mariadb:10.1.16
@@ -63,9 +63,10 @@ jobs:
     - name: Install project dependencies
       run: npm install
     - name: Install package dependencies and build packages
-      run: |
-        lerna bootstrap
-        cd packages/cli && npm link && cd ../..
+      run: lerna bootstrap
+    - name: Create CLI symlink in the global folder
+      run: npm link
+      working-directory: packages/cli
     - name: Check package linting
       run: npm run lint
     - name: Run unit and acceptance tests (TypeScript)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,12 @@ jobs:
       matrix:
         node-version: [8.x, 10.x]
 
+    services:
+      redis:
+        image: "redis:4.0.14"
+        ports:
+          - 6379:6379
+
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    container:
-      image:  ${{ matrix.node-version }}
-
     strategy:
       matrix:
-        node-version: ["node:8", "node:10"]
+        node-version: [8.x, 10.x]
 
     services:
       # mysql is already installed on ubuntu
@@ -57,6 +54,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
     - name: Install global dependencies (lerna, pm2, codecov)
       run: npm install -g lerna pm2 codecov
     - name: Install project dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,42 @@ jobs:
         node-version: [8.x, 10.x]
 
     services:
+      mysql:
+        image: mysql:5.7.10
+        ports:
+          - 3306:3306
+        environment:
+          MYSQL_ROOT_PASSWORD: admin
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+          MYSQL_DATABASE: test
+
+      mariadb:
+        image: mariadb:10.1.16
+        ports:
+          - 3307:3306
+        environment:
+          MYSQL_ROOT_PASSWORD: admin
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+          MYSQL_DATABASE: test
+
+      postgres:
+        image: postgres:9.6.1
+        ports:
+          - 5432:5432
+        environment:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+
+      mongodb:
+        image: mongo:3.4.1
+        ports:
+          - 27017:27017
+
       redis:
-        image: "redis:4.0.14"
+        image: redis:4.0.14
         ports:
           - 6379:6379
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [node:8, node:10]
+        node-version: ["node:8", "node:10"]
 
     services:
       mysql:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    container:
+      image:  ${{ matrix.node-version }}
+
     strategy:
       matrix:
-        node-version: [8.x, 10.x]
+        node-version: [node:8, node:10]
 
     services:
       mysql:
@@ -53,10 +56,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
     - name: Install global dependencies (lerna, pm2, codecov)
       run: npm install -g lerna pm2 codecov
     - name: Install project dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,15 +15,16 @@ jobs:
         node-version: ["node:8", "node:10"]
 
     services:
-      mysql:
-        image: mysql:5.7.10
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_ROOT_PASSWORD: admin
-          MYSQL_USER: test
-          MYSQL_PASSWORD: test
-          MYSQL_DATABASE: test
+      # mysql is already installed on ubuntu
+      # mysql:
+      #   image: mysql:5.7.10
+      #   ports:
+      #     - 3306:3306
+      #   env:
+      #     MYSQL_ROOT_PASSWORD: admin
+      #     MYSQL_USER: test
+      #     MYSQL_PASSWORD: test
+      #     MYSQL_DATABASE: test
 
       mariadb:
         image: mariadb:10.1.16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
   mysql:
     image: "mysql:5.7.10"
     ports:
-      - "3306:3306"
+      # Another version of MySQL is installed on the vm and already uses the port 3306.
+      - "3308:3306"
     environment:
       MYSQL_ROOT_PASSWORD: "admin"
       MYSQL_USER: "test"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "lerna": "^2.11.0",
     "mocha": "^4.1.0",
     "tslint": "^5.11.0",
-    "typescript": "^2.9.2"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/acceptance-tests/package-lock.json
+++ b/packages/acceptance-tests/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foal/acceptance-tests",
-	"version": "1.0.1",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -9231,9 +9231,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
 		},
 		"ua-parser-js": {
 			"version": "0.7.20",
@@ -9756,8 +9756,7 @@
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -9775,13 +9774,11 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -9794,18 +9791,15 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -9908,8 +9902,7 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -9919,7 +9912,6 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -9932,20 +9924,17 @@
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -9962,7 +9951,6 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -10035,8 +10023,7 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -10046,7 +10033,6 @@
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -10122,8 +10108,7 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -10153,7 +10138,6 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -10171,7 +10155,6 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -10210,13 +10193,11 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						}
 					}
 				},

--- a/packages/acceptance-tests/package.json
+++ b/packages/acceptance-tests/package.json
@@ -39,7 +39,7 @@
     "supertest": "^3.3.0",
     "ts-node": "^3.3.0",
     "typeorm": "^0.2.14",
-    "typescript": "^2.5.2",
+    "typescript": "~3.5.3",
     "yamljs": "^0.3.0"
   }
 }

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foal/cli",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -786,9 +786,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
 		},
 		"uri-js": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,6 +61,6 @@
     "mocha": "^5.2.0",
     "rimraf": "^2.6.2",
     "ts-node": "^3.3.0",
-    "typescript": "^2.5.2"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foal/core",
-	"version": "1.0.1",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1859,7 +1859,6 @@
 					"version": "0.1.4",
 					"bundled": true,
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"kind-of": "^3.0.2",
 						"longest": "^1.0.1",
@@ -2802,8 +2801,7 @@
 				"longest": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"lru-cache": {
 					"version": "4.1.3",
@@ -4844,9 +4842,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -104,7 +104,7 @@
     "twig": "^1.13.3",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
-    "typescript": "^2.5.2",
+    "typescript": "~3.5.3",
     "yamljs": "^0.3.0"
   }
 }

--- a/packages/csrf/package-lock.json
+++ b/packages/csrf/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foal/csrf",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1302,9 +1302,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/packages/csrf/package.json
+++ b/packages/csrf/package.json
@@ -47,7 +47,7 @@
     "ts-node": "^3.3.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
-    "typescript": "^2.5.2"
+    "typescript": "~3.5.3"
   },
   "dependencies": {
     "@foal/core": "^1.2.0"

--- a/packages/ejs/package-lock.json
+++ b/packages/ejs/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foal/ejs",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1307,9 +1307,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/packages/ejs/package.json
+++ b/packages/ejs/package.json
@@ -50,6 +50,6 @@
     "ts-node": "^3.3.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
-    "typescript": "^2.5.2"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/examples/package-lock.json
+++ b/packages/examples/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foal/examples",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2165,9 +2165,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
 		},
 		"unc-path-regex": {

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -59,6 +59,6 @@
     "copy": "^0.3.2",
     "mocha": "^5.2.0",
     "supervisor": "^0.12.0",
-    "typescript": "^2.5.3"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/formidable/package.json
+++ b/packages/formidable/package.json
@@ -48,7 +48,7 @@
     "ts-node": "^3.3.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
-    "typescript": "^2.5.2"
+    "typescript": "~3.5.3"
   },
   "dependencies": {
     "@foal/core": "^1.2.0",

--- a/packages/graphql/package-lock.json
+++ b/packages/graphql/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foal/graphql",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1508,9 +1508,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -56,7 +56,7 @@
     "ts-node": "^3.3.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
-    "typescript": "^2.5.2"
+    "typescript": "~3.5.3"
   },
   "peerDependencies": {
     "graphql": "^14.3.0"

--- a/packages/jwks-rsa/package-lock.json
+++ b/packages/jwks-rsa/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foal/jwks-rsa",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1879,9 +1879,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/packages/jwks-rsa/package.json
+++ b/packages/jwks-rsa/package.json
@@ -58,6 +58,6 @@
     "ts-node": "^3.3.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
-    "typescript": "^2.5.2"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/jwt/package-lock.json
+++ b/packages/jwt/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foal/jwt",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1770,9 +1770,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -53,6 +53,6 @@
     "ts-node": "^3.3.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
-    "typescript": "^2.5.2"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/mongodb/package-lock.json
+++ b/packages/mongodb/package-lock.json
@@ -1,27 +1,28 @@
 {
-	"name": "@foal/formidable",
+	"name": "@foal/mongodb",
 	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@types/events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
-		},
-		"@types/formidable": {
-			"version": "1.0.31",
-			"resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-1.0.31.tgz",
-			"integrity": "sha512-dIhM5t8lRP0oWe2HF8MuPvdd1TpPTjhDMAqemcq6oIZQCBQTovhBAdTQ5L5veJB4pdQChadmHuxtB0YzqvfU3Q==",
+		"@types/bson": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.0.tgz",
+			"integrity": "sha512-pq/rqJwJWkbS10crsG5bgnrisL8pML79KlMKQMoQwLUjlPAkrUHMvHJ3oGwE7WHR61Lv/nadMwXVAD2b+fpD8Q==",
+			"dev": true,
 			"requires": {
-				"@types/events": "*",
 				"@types/node": "*"
 			}
 		},
+		"@types/events": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+			"dev": true
+		},
 		"@types/fs-extra": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.5.tgz",
-			"integrity": "sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
+			"integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -54,9 +55,9 @@
 			"dev": true
 		},
 		"@types/lodash": {
-			"version": "4.14.123",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
-			"integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
+			"version": "4.14.136",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
+			"integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==",
 			"dev": true
 		},
 		"@types/marked": {
@@ -77,10 +78,21 @@
 			"integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
 			"dev": true
 		},
+		"@types/mongodb": {
+			"version": "3.1.31",
+			"resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.1.31.tgz",
+			"integrity": "sha512-0l6z2ARkyAkgdtzF/Hqx3cRoADDQK/7VHvESikhLXjanSpIo1EJt2JL4NpM+jIqLWzn5P1IxRBSIIOqs5ZKBOQ==",
+			"dev": true,
+			"requires": {
+				"@types/bson": "*",
+				"@types/node": "*"
+			}
+		},
 		"@types/node": {
-			"version": "10.14.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
-			"integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg=="
+			"version": "10.14.14",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.14.tgz",
+			"integrity": "sha512-xXD08vZsvpv4xptQXj1+ky22f7ZoKu5ZNI/4l+/BXG3X+XaeZsmaFbbTKuhSE3NjjvRuZFxFf9sQBMXIcZNFMQ==",
+			"dev": true
 		},
 		"@types/shelljs": {
 			"version": "0.8.5",
@@ -105,9 +117,9 @@
 			"dev": true
 		},
 		"acorn-globals": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
-			"integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
+			"integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.1",
@@ -115,29 +127,38 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
+					"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
 					"dev": true
 				}
 			}
 		},
 		"acorn-walk": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
-			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
 			"dev": true
 		},
 		"ajv": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"version": "6.10.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
+			}
+		},
+		"ansi-green": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+			"integrity": "sha1-il2al55FjVfEDjNYCzc5C44Q0Pc=",
+			"dev": true,
+			"requires": {
+				"ansi-wrap": "0.1.0"
 			}
 		},
 		"ansi-styles": {
@@ -148,6 +169,18 @@
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
+		},
+		"ansi-wrap": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+			"dev": true
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -176,10 +209,22 @@
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 			"dev": true
 		},
+		"async-array-reduce": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/async-array-reduce/-/async-array-reduce-0.2.1.tgz",
+			"integrity": "sha1-yL4BCitc0A3qlsgRFgNGk9/dgtE=",
+			"dev": true
+		},
+		"async-each": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+			"dev": true
+		},
 		"async-limiter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
 			"dev": true
 		},
 		"asynckit": {
@@ -215,6 +260,12 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
+		"bluebird": {
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+			"integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+			"dev": true
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -237,6 +288,11 @@
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
 		},
+		"bson": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
+			"integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
+		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -254,6 +310,18 @@
 				"supports-color": "^5.3.0"
 			}
 		},
+		"clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+			"dev": true
+		},
+		"clone-stats": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+			"dev": true
+		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -270,9 +338,9 @@
 			"dev": true
 		},
 		"combined-stream": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
@@ -290,6 +358,28 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
+		"copy": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/copy/-/copy-0.3.2.tgz",
+			"integrity": "sha512-drDFuUZctIuvSuvL9dOF/v5GxrwB1Q8eMIRlYONC0lSMEq+L2xabXP3jme8cQFdDO8cgP8JsuYhQg7JtTwezmg==",
+			"dev": true,
+			"requires": {
+				"async-each": "^1.0.0",
+				"bluebird": "^3.4.1",
+				"extend-shallow": "^2.0.1",
+				"file-contents": "^0.3.1",
+				"glob-parent": "^2.0.0",
+				"graceful-fs": "^4.1.4",
+				"has-glob": "^0.1.1",
+				"is-absolute": "^0.2.5",
+				"lazy-cache": "^2.0.1",
+				"log-ok": "^0.1.1",
+				"matched": "^0.4.1",
+				"mkdirp": "^0.5.1",
+				"resolve-dir": "^0.1.0",
+				"to-file": "^0.2.0"
+			}
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -297,15 +387,15 @@
 			"dev": true
 		},
 		"cssom": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
-			"integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
 			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
@@ -358,6 +448,15 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
 			"dev": true
+		},
+		"define-property": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+			"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+			"dev": true,
+			"requires": {
+				"is-descriptor": "^0.1.0"
+			}
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
@@ -431,16 +530,34 @@
 			"dev": true
 		},
 		"esutils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
+		},
+		"expand-tilde": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+			"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+			"dev": true,
+			"requires": {
+				"os-homedir": "^1.0.1"
+			}
 		},
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"dev": true
+		},
+		"extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"dev": true,
+			"requires": {
+				"is-extendable": "^0.1.0"
+			}
 		},
 		"extsprintf": {
 			"version": "1.3.0",
@@ -466,6 +583,38 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
+		"file-contents": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/file-contents/-/file-contents-0.3.2.tgz",
+			"integrity": "sha1-oJOf7RuM2hWAJm/Gt1OiMvtG3lM=",
+			"dev": true,
+			"requires": {
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"file-stat": "^0.2.3",
+				"fs-exists-sync": "^0.1.0",
+				"graceful-fs": "^4.1.4",
+				"is-buffer": "^1.1.3",
+				"isobject": "^2.1.0",
+				"lazy-cache": "^2.0.1",
+				"strip-bom-buffer": "^0.1.1",
+				"strip-bom-string": "^0.1.2",
+				"through2": "^2.0.1",
+				"vinyl": "^1.1.1"
+			}
+		},
+		"file-stat": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/file-stat/-/file-stat-0.2.3.tgz",
+			"integrity": "sha1-Rpp+kn1pMAeWJM2zgQlAVFbLBqk=",
+			"dev": true,
+			"requires": {
+				"fs-exists-sync": "^0.1.0",
+				"graceful-fs": "^4.1.4",
+				"lazy-cache": "^2.0.1",
+				"through2": "^2.0.1"
+			}
+		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -483,11 +632,22 @@
 				"mime-types": "^2.1.12"
 			}
 		},
-		"formidable": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-			"integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
+		"fs-exists-sync": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
 			"dev": true
+		},
+		"fs-extra": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			}
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -505,9 +665,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -518,10 +678,41 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
+		"glob-parent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
+			"requires": {
+				"is-glob": "^2.0.0"
+			}
+		},
+		"global-modules": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+			"integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+			"dev": true,
+			"requires": {
+				"global-prefix": "^0.1.4",
+				"is-windows": "^0.2.0"
+			}
+		},
+		"global-prefix": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+			"integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+			"dev": true,
+			"requires": {
+				"homedir-polyfill": "^1.0.0",
+				"ini": "^1.3.4",
+				"is-windows": "^0.2.0",
+				"which": "^1.2.12"
+			}
+		},
 		"graceful-fs": {
-			"version": "4.1.15",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
+			"integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==",
 			"dev": true
 		},
 		"growl": {
@@ -572,6 +763,15 @@
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
+		"has-glob": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
+			"integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
+			"dev": true,
+			"requires": {
+				"is-glob": "^2.0.1"
+			}
+		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -579,9 +779,9 @@
 			"dev": true
 		},
 		"highlight.js": {
-			"version": "9.15.6",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
-			"integrity": "sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ==",
+			"version": "9.15.9",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.9.tgz",
+			"integrity": "sha512-M0zZvfLr5p0keDMCAhNBp03XJbKBxUx5AfyfufMdFMEP4N/Xj6dh0IqC75ys7BAzceR34NgcvXjupRVaHBPPVQ==",
 			"dev": true
 		},
 		"homedir-polyfill": {
@@ -633,9 +833,15 @@
 			}
 		},
 		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 			"dev": true
 		},
 		"interpret": {
@@ -644,11 +850,156 @@
 			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
 			"dev": true
 		},
+		"is-absolute": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+			"integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+			"dev": true,
+			"requires": {
+				"is-relative": "^0.2.1",
+				"is-windows": "^0.2.0"
+			}
+		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
+		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"dev": true,
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-extglob": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
+		},
+		"is-glob": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "^1.0.0"
+			}
+		},
+		"is-relative": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+			"integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+			"dev": true,
+			"requires": {
+				"is-unc-path": "^0.1.1"
+			}
+		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
+		},
+		"is-unc-path": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+			"integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+			"dev": true,
+			"requires": {
+				"unc-path-regex": "^0.1.0"
+			}
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
+		},
+		"is-valid-glob": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+			"dev": true
+		},
+		"is-windows": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+			"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
+			"requires": {
+				"isarray": "1.0.0"
+			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -735,6 +1086,21 @@
 				"verror": "1.10.0"
 			}
 		},
+		"kind-of": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+			"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+			"dev": true
+		},
+		"lazy-cache": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+			"integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+			"dev": true,
+			"requires": {
+				"set-getter": "^0.1.0"
+			}
+		},
 		"left-pad": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -752,9 +1118,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
 			"dev": true
 		},
 		"lodash.sortby": {
@@ -762,6 +1128,16 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
+		},
+		"log-ok": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/log-ok/-/log-ok-0.1.1.tgz",
+			"integrity": "sha1-vqPdNqzQuKckDXhza1uXxlREozQ=",
+			"dev": true,
+			"requires": {
+				"ansi-green": "^0.1.1",
+				"success-symbol": "^0.1.0"
+			}
 		},
 		"make-error": {
 			"version": "1.3.5",
@@ -774,6 +1150,29 @@
 			"resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
 			"integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
 			"dev": true
+		},
+		"matched": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
+			"integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"async-array-reduce": "^0.2.0",
+				"extend-shallow": "^2.0.1",
+				"fs-exists-sync": "^0.1.0",
+				"glob": "^7.0.5",
+				"has-glob": "^0.1.1",
+				"is-valid-glob": "^0.3.0",
+				"lazy-cache": "^2.0.1",
+				"resolve-dir": "^0.1.0"
+			}
+		},
+		"memory-pager": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+			"optional": true
 		},
 		"mime-db": {
 			"version": "1.40.0",
@@ -831,6 +1230,42 @@
 				"minimatch": "3.0.4",
 				"mkdirp": "0.5.1",
 				"supports-color": "5.4.0"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
+			}
+		},
+		"mongodb": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.2.7.tgz",
+			"integrity": "sha512-2YdWrdf1PJgxcCrT1tWoL6nHuk6hCxhddAAaEh8QJL231ci4+P9FLyqopbTm2Z2sAU6mhCri+wd9r1hOcHdoMw==",
+			"requires": {
+				"mongodb-core": "3.2.7",
+				"safe-buffer": "^5.1.2"
+			}
+		},
+		"mongodb-core": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.2.7.tgz",
+			"integrity": "sha512-WypKdLxFNPOH/Jy6i9z47IjG2wIldA54iDZBmHMINcgKOUcWJh8og+Wix76oGd7EyYkHJKssQ2FAOw5Su/n4XQ==",
+			"requires": {
+				"bson": "^1.1.1",
+				"require_optional": "^1.0.1",
+				"safe-buffer": "^5.1.2",
+				"saslprep": "^1.0.0"
 			}
 		},
 		"ms": {
@@ -840,9 +1275,9 @@
 			"dev": true
 		},
 		"neo-async": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
 			"dev": true
 		},
 		"nwsapi": {
@@ -898,6 +1333,12 @@
 				}
 			}
 		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
+		},
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -940,6 +1381,12 @@
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
 		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
+		},
 		"progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -947,9 +1394,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
+			"integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==",
 			"dev": true
 		},
 		"punycode": {
@@ -964,6 +1411,29 @@
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
 		},
+		"readable-stream": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
+			}
+		},
 		"rechoir": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -972,6 +1442,12 @@
 			"requires": {
 				"resolve": "^1.1.6"
 			}
+		},
+		"replace-ext": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+			"dev": true
 		},
 		"request": {
 			"version": "2.88.0",
@@ -1039,14 +1515,38 @@
 				"tough-cookie": "^2.3.3"
 			}
 		},
+		"require_optional": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+			"integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+			"requires": {
+				"resolve-from": "^2.0.0",
+				"semver": "^5.1.0"
+			}
+		},
 		"resolve": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
 			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
+		},
+		"resolve-dir": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+			"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+			"dev": true,
+			"requires": {
+				"expand-tilde": "^1.2.2",
+				"global-modules": "^0.2.3"
+			}
+		},
+		"resolve-from": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+			"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
 		},
 		"rimraf": {
 			"version": "2.6.3",
@@ -1055,29 +1555,12 @@
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
 			}
 		},
 		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -1085,11 +1568,34 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
+		"saslprep": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+			"optional": true,
+			"requires": {
+				"sparse-bitfield": "^3.0.3"
+			}
+		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 			"dev": true
+		},
+		"semver": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+		},
+		"set-getter": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+			"integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+			"dev": true,
+			"requires": {
+				"to-object-path": "^0.3.0"
+			}
 		},
 		"shelljs": {
 			"version": "0.8.3",
@@ -1117,6 +1623,15 @@
 				"source-map": "^0.5.6"
 			}
 		},
+		"sparse-bitfield": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+			"integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+			"optional": true,
+			"requires": {
+				"memory-pager": "^1.0.2"
+			}
+		},
 		"sshpk": {
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -1140,16 +1655,55 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
+			}
+		},
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
 			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
 			"dev": true
 		},
+		"strip-bom-buffer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/strip-bom-buffer/-/strip-bom-buffer-0.1.1.tgz",
+			"integrity": "sha1-yj3cSRnBP5/d8wsd/xAKmDUki00=",
+			"dev": true,
+			"requires": {
+				"is-buffer": "^1.1.0",
+				"is-utf8": "^0.2.0"
+			}
+		},
+		"strip-bom-string": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-0.1.2.tgz",
+			"integrity": "sha1-nG5yCjE7qYNliVGEBcz7iKX0G5w=",
+			"dev": true
+		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
+		},
+		"success-symbol": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
+			"integrity": "sha1-JAIuSG878c3KCUKDt2nEctO3KJc=",
 			"dev": true
 		},
 		"supports-color": {
@@ -1162,10 +1716,100 @@
 			}
 		},
 		"symbol-tree": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
+		},
+		"through2": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
+			}
+		},
+		"to-file": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/to-file/-/to-file-0.2.0.tgz",
+			"integrity": "sha1-I2xsCIBl5XDe+9Fc9LTlZb5G6pM=",
+			"dev": true,
+			"requires": {
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"file-contents": "^0.2.4",
+				"glob-parent": "^2.0.0",
+				"is-valid-glob": "^0.3.0",
+				"isobject": "^2.1.0",
+				"lazy-cache": "^2.0.1",
+				"vinyl": "^1.1.1"
+			},
+			"dependencies": {
+				"file-contents": {
+					"version": "0.2.4",
+					"resolved": "https://registry.npmjs.org/file-contents/-/file-contents-0.2.4.tgz",
+					"integrity": "sha1-BQb3uO/2KvpFrkXaTfnp1H30U8s=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.0",
+						"file-stat": "^0.1.0",
+						"graceful-fs": "^4.1.2",
+						"is-buffer": "^1.1.0",
+						"is-utf8": "^0.2.0",
+						"lazy-cache": "^0.2.3",
+						"through2": "^2.0.0"
+					},
+					"dependencies": {
+						"lazy-cache": {
+							"version": "0.2.7",
+							"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+							"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+							"dev": true
+						}
+					}
+				},
+				"file-stat": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/file-stat/-/file-stat-0.1.3.tgz",
+					"integrity": "sha1-0PGWHX0QcykoEgpuaVVHHCpbVBE=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"lazy-cache": "^0.2.3",
+						"through2": "^2.0.0"
+					},
+					"dependencies": {
+						"lazy-cache": {
+							"version": "0.2.7",
+							"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+							"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+							"dev": true
+						}
+					}
+				}
+			}
+		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
 		},
 		"tough-cookie": {
 			"version": "2.5.0",
@@ -1280,17 +1924,6 @@
 				"typescript": "3.2.x"
 			},
 			"dependencies": {
-				"fs-extra": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
 				"typescript": {
 					"version": "3.2.4",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
@@ -1306,9 +1939,9 @@
 			"dev": true
 		},
 		"typedoc-plugin-markdown": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-1.2.0.tgz",
-			"integrity": "sha512-M3M9bx8q5u9VppIQ4ATjYV233ZyhRNbxkgTsjy7WVo4UY38dj1JWg90335ZCYktqkNkobSzE2OhVkmbQFGvi2g==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-1.2.1.tgz",
+			"integrity": "sha512-zOjoCaCWvgVca920IDSytkGQd1sFSztNKGGWWcYq4JWqmeklOWvYy5QODIeTeAcUeYsP9FZ5Ov7BU8WJk5Ypig==",
 			"dev": true,
 			"requires": {
 				"turndown": "^5.0.3"
@@ -1321,9 +1954,9 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.5.10",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.10.tgz",
-			"integrity": "sha512-/GTF0nosyPLbdJBd+AwYiZ+Hu5z8KXWnO0WCGt1BQ/u9Iamhejykqmz5o1OHJ53+VAk6xVxychonnApDjuqGsw==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+			"integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -1347,6 +1980,12 @@
 				}
 			}
 		},
+		"unc-path-regex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+			"dev": true
+		},
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -1362,6 +2001,12 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
 		"uuid": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -1369,9 +2014,9 @@
 			"dev": true
 		},
 		"v8flags": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.2.tgz",
-			"integrity": "sha512-MtivA7GF24yMPte9Rp/BWGCYQNaUj86zeYxV/x2RRJMKagImbbv3u8iJC57lNhWLPcGLJmHcHmFWkNsplbbLWw==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+			"integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
 			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
@@ -1386,6 +2031,17 @@
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
+			}
+		},
+		"vinyl": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+			"dev": true,
+			"requires": {
+				"clone": "^1.0.0",
+				"clone-stats": "^0.0.1",
+				"replace-ext": "0.0.1"
 			}
 		},
 		"w3c-hr-time": {
@@ -1429,6 +2085,15 @@
 				"webidl-conversions": "^4.0.2"
 			}
 		},
+		"which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
 		"wordwrap": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -1454,6 +2119,12 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
+		},
+		"xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
 			"dev": true
 		},
 		"yn": {

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -56,6 +56,6 @@
     "ts-node": "^3.3.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
-    "typescript": "^2.5.2"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/mongoose/package-lock.json
+++ b/packages/mongoose/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foal/mongoose",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2036,9 +2036,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -57,6 +57,6 @@
     "ts-node": "^3.3.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
-    "typescript": "^2.5.2"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/password/package-lock.json
+++ b/packages/password/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foal/password",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1846,9 +1846,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -46,6 +46,6 @@
     "ts-node": "^3.3.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
-    "typescript": "^2.5.2"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/password/src/is-common.util.ts
+++ b/packages/password/src/is-common.util.ts
@@ -2,7 +2,7 @@
 import { readFile } from 'fs';
 import { join } from 'path';
 import { promisify } from 'util';
-import { gunzip } from 'zlib';
+import { gunzip, InputType } from 'zlib';
 
 let list: string[];
 
@@ -16,7 +16,7 @@ let list: string[];
 export async function isCommon(password: string): Promise<boolean> {
   if (!list) {
     const fileContent = await promisify(readFile)(join(__dirname, './10-million-password-list-top-10000.txt.gz'));
-    list =  (await promisify(gunzip)(fileContent)).toString().split('\n');
+    list =  (await promisify<InputType, Buffer>(gunzip)(fileContent)).toString().split('\n');
   }
   return list.includes(password);
 }

--- a/packages/redis/package-lock.json
+++ b/packages/redis/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foal/redis",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1327,9 +1327,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -50,6 +50,6 @@
     "ts-node": "^3.3.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
-    "typescript": "^2.5.2"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/swagger/package-lock.json
+++ b/packages/swagger/package-lock.json
@@ -1,65 +1,14 @@
 {
 	"name": "@foal/swagger",
-	"version": "1.0.1",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@foal/core": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@foal/core/-/core-1.0.1.tgz",
-			"integrity": "sha512-PfTfnTiRcOMsTV23NsytVShlxOk0Saz1lIjs95I+fI/kFctWot77niYiVRtf/5h3giM8gJrEqSX6S/aZgJfuOg==",
-			"requires": {
-				"@types/express": "^4.16.1",
-				"ajv": "^6.5.0",
-				"body-parser": "^1.19.0",
-				"cookie-parser": "^1.4.3",
-				"express": "^4.16.3",
-				"mime": "^2.4.0",
-				"morgan": "^1.9.0",
-				"reflect-metadata": "^0.1.10"
-			}
-		},
-		"@types/body-parser": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
-			"integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
-			"requires": {
-				"@types/connect": "*",
-				"@types/node": "*"
-			}
-		},
-		"@types/connect": {
-			"version": "3.4.32",
-			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
-			"integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
 			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
 			"dev": true
-		},
-		"@types/express": {
-			"version": "4.17.0",
-			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz",
-			"integrity": "sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==",
-			"requires": {
-				"@types/body-parser": "*",
-				"@types/express-serve-static-core": "*",
-				"@types/serve-static": "*"
-			}
-		},
-		"@types/express-serve-static-core": {
-			"version": "4.16.7",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
-			"integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
-			"requires": {
-				"@types/node": "*",
-				"@types/range-parser": "*"
-			}
 		},
 		"@types/fs-extra": {
 			"version": "5.0.5",
@@ -108,11 +57,6 @@
 			"integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
 			"dev": true
 		},
-		"@types/mime": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-			"integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
-		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -128,21 +72,8 @@
 		"@types/node": {
 			"version": "10.14.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
-			"integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg=="
-		},
-		"@types/range-parser": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
-		},
-		"@types/serve-static": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
-			"requires": {
-				"@types/express-serve-static-core": "*",
-				"@types/mime": "*"
-			}
+			"integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg==",
+			"dev": true
 		},
 		"@types/shelljs": {
 			"version": "0.8.5",
@@ -159,15 +90,6 @@
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
 			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
 			"dev": true
-		},
-		"accepts": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-			"requires": {
-				"mime-types": "~2.1.24",
-				"negotiator": "0.6.2"
-			}
 		},
 		"acorn": {
 			"version": "5.7.3",
@@ -203,6 +125,7 @@
 			"version": "6.10.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
 			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -245,11 +168,6 @@
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
 			"dev": true
-		},
-		"array-flatten": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
 		"arrify": {
 			"version": "1.0.1",
@@ -314,14 +232,6 @@
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
-		"basic-auth": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-			"integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-			"requires": {
-				"safe-buffer": "5.1.2"
-			}
-		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -336,38 +246,6 @@
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
 			"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
 			"dev": true
-		},
-		"body-parser": {
-			"version": "1.19.0",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-			"requires": {
-				"bytes": "3.1.0",
-				"content-type": "~1.0.4",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"on-finished": "~2.3.0",
-				"qs": "6.7.0",
-				"raw-body": "2.4.0",
-				"type-is": "~1.6.17"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"qs": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-				}
-			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -390,11 +268,6 @@
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
-		},
-		"bytes": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
 		},
 		"caseless": {
 			"version": "0.12.0",
@@ -460,38 +333,6 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
-		},
-		"content-disposition": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-			"integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-			"requires": {
-				"safe-buffer": "5.1.2"
-			}
-		},
-		"content-type": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-		},
-		"cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-		},
-		"cookie-parser": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
-			"integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
-			"requires": {
-				"cookie": "0.3.1",
-				"cookie-signature": "1.0.6"
-			}
-		},
-		"cookie-signature": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"copy": {
 			"version": "0.3.2",
@@ -599,16 +440,6 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
-		"depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-		},
-		"destroy": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-		},
 		"diff": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -633,21 +464,6 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
-		},
-		"ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-		},
-		"encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-		},
-		"escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -695,11 +511,6 @@
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
 			"dev": true
 		},
-		"etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-		},
 		"expand-tilde": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
@@ -707,63 +518,6 @@
 			"dev": true,
 			"requires": {
 				"os-homedir": "^1.0.1"
-			}
-		},
-		"express": {
-			"version": "4.17.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-			"integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
-			"requires": {
-				"accepts": "~1.3.7",
-				"array-flatten": "1.1.1",
-				"body-parser": "1.19.0",
-				"content-disposition": "0.5.3",
-				"content-type": "~1.0.4",
-				"cookie": "0.4.0",
-				"cookie-signature": "1.0.6",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.1.2",
-				"fresh": "0.5.2",
-				"merge-descriptors": "1.0.1",
-				"methods": "~1.1.2",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.7",
-				"proxy-addr": "~2.0.5",
-				"qs": "6.7.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.1.2",
-				"send": "0.17.1",
-				"serve-static": "1.14.1",
-				"setprototypeof": "1.1.1",
-				"statuses": "~1.5.0",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"dependencies": {
-				"cookie": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-					"integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"qs": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-				}
 			}
 		},
 		"extend": {
@@ -790,12 +544,14 @@
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"dev": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -835,30 +591,6 @@
 				"through2": "^2.0.1"
 			}
 		},
-		"finalhandler": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-			"requires": {
-				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"on-finished": "~2.3.0",
-				"parseurl": "~1.3.3",
-				"statuses": "~1.5.0",
-				"unpipe": "~1.0.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -875,16 +607,6 @@
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
-		},
-		"forwarded": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
-		},
-		"fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
 		"fs-exists-sync": {
 			"version": "0.1.0",
@@ -1045,18 +767,6 @@
 				"whatwg-encoding": "^1.0.1"
 			}
 		},
-		"http-errors": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-			"requires": {
-				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.1",
-				"statuses": ">= 1.5.0 < 2",
-				"toidentifier": "1.0.0"
-			}
-		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -1072,6 +782,7 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -1089,7 +800,8 @@
 		"inherits": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -1102,11 +814,6 @@
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
 			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
 			"dev": true
-		},
-		"ipaddr.js": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
 		},
 		"is-absolute": {
 			"version": "0.2.6",
@@ -1314,7 +1021,8 @@
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
@@ -1425,35 +1133,17 @@
 				"resolve-dir": "^0.1.0"
 			}
 		},
-		"media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-		},
-		"merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-		},
-		"methods": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-		},
-		"mime": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-			"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
-		},
 		"mime-db": {
 			"version": "1.40.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.24",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
 			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+			"dev": true,
 			"requires": {
 				"mime-db": "1.40.0"
 			}
@@ -1501,37 +1191,11 @@
 				"supports-color": "5.4.0"
 			}
 		},
-		"morgan": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
-			"integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
-			"requires": {
-				"basic-auth": "~2.0.0",
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"on-finished": "~2.3.0",
-				"on-headers": "~1.0.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-		},
-		"negotiator": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"neo-async": {
 			"version": "2.6.0",
@@ -1550,19 +1214,6 @@
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
-		},
-		"on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"requires": {
-				"ee-first": "1.1.1"
-			}
-		},
-		"on-headers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
 		},
 		"once": {
 			"version": "1.4.0",
@@ -1623,11 +1274,6 @@
 			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
 			"dev": true
 		},
-		"parseurl": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1639,11 +1285,6 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
-		},
-		"path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
 		"performance-now": {
 			"version": "2.1.0",
@@ -1675,15 +1316,6 @@
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
-		"proxy-addr": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-			"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
-			"requires": {
-				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.9.0"
-			}
-		},
 		"psl": {
 			"version": "1.1.31",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
@@ -1693,29 +1325,14 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
 		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
-		},
-		"range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-		},
-		"raw-body": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-			"requires": {
-				"bytes": "3.1.0",
-				"http-errors": "1.7.2",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			}
 		},
 		"readable-stream": {
 			"version": "2.3.6",
@@ -1740,11 +1357,6 @@
 			"requires": {
 				"resolve": "^1.1.6"
 			}
-		},
-		"reflect-metadata": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
 		},
 		"replace-ext": {
 			"version": "0.0.1",
@@ -1865,76 +1477,20 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 			"dev": true
-		},
-		"send": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-			"integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-			"requires": {
-				"debug": "2.6.9",
-				"depd": "~1.1.2",
-				"destroy": "~1.0.4",
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "~1.7.2",
-				"mime": "1.6.0",
-				"ms": "2.1.1",
-				"on-finished": "~2.3.0",
-				"range-parser": "~1.2.1",
-				"statuses": "~1.5.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-						}
-					}
-				},
-				"mime": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-				},
-				"ms": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-				}
-			}
-		},
-		"serve-static": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-			"integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-			"requires": {
-				"encodeurl": "~1.0.2",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.3",
-				"send": "0.17.1"
-			}
 		},
 		"set-getter": {
 			"version": "0.1.0",
@@ -1944,11 +1500,6 @@
 			"requires": {
 				"to-object-path": "^0.3.0"
 			}
-		},
-		"setprototypeof": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
 		},
 		"shelljs": {
 			"version": "0.8.3",
@@ -1992,11 +1543,6 @@
 				"safer-buffer": "^2.0.2",
 				"tweetnacl": "~0.14.0"
 			}
-		},
-		"statuses": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
@@ -2157,11 +1703,6 @@
 				}
 			}
 		},
-		"toidentifier": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
-		},
 		"tough-cookie": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -2250,15 +1791,6 @@
 				"prelude-ls": "~1.1.2"
 			}
 		},
-		"type-is": {
-			"version": "1.6.18",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-			"requires": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.24"
-			}
-		},
 		"typedoc": {
 			"version": "0.14.2",
 			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.14.2.tgz",
@@ -2319,9 +1851,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
 		},
 		"uglify-js": {
@@ -2363,15 +1895,11 @@
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
 		},
-		"unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-		},
 		"uri-js": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -2381,11 +1909,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true
-		},
-		"utils-merge": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
 			"version": "3.3.2",
@@ -2401,11 +1924,6 @@
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
 			}
-		},
-		"vary": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		},
 		"verror": {
 			"version": "1.10.0",

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -53,6 +53,6 @@
     "ts-node": "^3.3.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
-    "typescript": "^2.5.2"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/typeorm/package-lock.json
+++ b/packages/typeorm/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@foal/typeorm",
-	"version": "1.0.0",
+	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2568,9 +2568,9 @@
 			}
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -63,6 +63,6 @@
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
     "typeorm": "0.2.14",
-    "typescript": "^2.5.2"
+    "typescript": "~3.5.3"
   }
 }

--- a/packages/typeorm/src/entities/group.entity.spec.ts
+++ b/packages/typeorm/src/entities/group.entity.spec.ts
@@ -15,6 +15,7 @@ describe('Group', () => {
     dropSchema: true,
     entities: [Group, Permission],
     password: 'test',
+    port: 3308,
     synchronize: true,
     type: 'mysql',
     username: 'test',

--- a/packages/typeorm/src/entities/permission.entity.spec.ts
+++ b/packages/typeorm/src/entities/permission.entity.spec.ts
@@ -14,6 +14,7 @@ describe('Permission', () => {
     dropSchema: true,
     entities: [Permission],
     password: 'test',
+    port: 3308,
     synchronize: true,
     type: 'mysql',
     username: 'test',

--- a/packages/typeorm/src/entities/user-with-permissions.entity.spec.ts
+++ b/packages/typeorm/src/entities/user-with-permissions.entity.spec.ts
@@ -19,6 +19,7 @@ describe('UserWithPermissions', () => {
     dropSchema: true,
     entities: [User, Group, Permission],
     password: 'test',
+    port: 3308,
     synchronize: true,
     type: 'mysql',
     username: 'test',

--- a/packages/typeorm/src/entities/user-with-permissions.entity.spec.ts
+++ b/packages/typeorm/src/entities/user-with-permissions.entity.spec.ts
@@ -14,16 +14,20 @@ describe('UserWithPermissions', () => {
   @Entity()
   class User extends UserWithPermissions {}
 
-  beforeEach(() => createConnection({
-    database: 'test',
-    dropSchema: true,
-    entities: [User, Group, Permission],
-    password: 'test',
-    port: 3308,
-    synchronize: true,
-    type: 'mysql',
-    username: 'test',
-  }));
+  beforeEach(function() {
+    // Increase timeout to make the test pass on Github Actions VM.
+    this.timeout(4000);
+    return createConnection({
+      database: 'test',
+      dropSchema: true,
+      entities: [User, Group, Permission],
+      password: 'test',
+      port: 3308,
+      synchronize: true,
+      type: 'mysql',
+      username: 'test',
+    });
+  });
 
   afterEach(() => getConnection().close());
 

--- a/packages/typeorm/src/typeorm-store.service.spec.ts
+++ b/packages/typeorm/src/typeorm-store.service.spec.ts
@@ -60,6 +60,7 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
             database: 'test',
             dropSchema: true,
             password: 'test',
+            port: type === 'mysql' ? 3308 : 3307,
             type,
             username: 'test',
           });

--- a/packages/typeorm/src/utils/fetch-user-with-permissions.util.spec.ts
+++ b/packages/typeorm/src/utils/fetch-user-with-permissions.util.spec.ts
@@ -26,6 +26,7 @@ function testSuite(type: 'mysql' | 'mariadb' | 'postgres' | 'sqlite') {
             dropSchema: true,
             entities: [User, Group, Permission],
             password: 'test',
+            port: type === 'mysql' ? 3308 : 3307,
             synchronize: true,
             type,
             username: 'test',

--- a/packages/typeorm/src/utils/fetch-user-with-permissions.util.spec.ts
+++ b/packages/typeorm/src/utils/fetch-user-with-permissions.util.spec.ts
@@ -17,10 +17,12 @@ function testSuite(type: 'mysql' | 'mariadb' | 'postgres' | 'sqlite') {
 
     let user: User;
 
-    before(async () => {
+    before(async function() {
       switch (type) {
         case 'mysql':
         case 'mariadb':
+          // Increase timeout to make the test pass on Github Actions VM.
+          this.timeout(4000);
           await createConnection({
             database: 'test',
             dropSchema: true,

--- a/packages/typeorm/src/utils/fetch-user.util.spec.ts
+++ b/packages/typeorm/src/utils/fetch-user.util.spec.ts
@@ -31,6 +31,7 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
             dropSchema: true,
             entities: [ User ],
             password: 'test',
+            port: type === 'mysql' ? 3308 : 3307,
             synchronize: true,
             type,
             username: 'test',

--- a/packages/typestack/package-lock.json
+++ b/packages/typestack/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "@foal/formidable",
+	"name": "@foal/typestack",
 	"version": "1.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
@@ -7,21 +7,13 @@
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
-		},
-		"@types/formidable": {
-			"version": "1.0.31",
-			"resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-1.0.31.tgz",
-			"integrity": "sha512-dIhM5t8lRP0oWe2HF8MuPvdd1TpPTjhDMAqemcq6oIZQCBQTovhBAdTQ5L5veJB4pdQChadmHuxtB0YzqvfU3Q==",
-			"requires": {
-				"@types/events": "*",
-				"@types/node": "*"
-			}
+			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+			"dev": true
 		},
 		"@types/fs-extra": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.5.tgz",
-			"integrity": "sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
+			"integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -54,9 +46,9 @@
 			"dev": true
 		},
 		"@types/lodash": {
-			"version": "4.14.123",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
-			"integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
+			"version": "4.14.144",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.144.tgz",
+			"integrity": "sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg==",
 			"dev": true
 		},
 		"@types/marked": {
@@ -78,9 +70,10 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.14.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
-			"integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg=="
+			"version": "10.17.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.0.tgz",
+			"integrity": "sha512-wuJwN2KV4tIRz1bu9vq5kSPasJ8IsEjZaP1ZR7KlmdUZvGF/rXy8DmXOVwUD0kAtvtJ7aqMKPqUXC0NUTDbrDg==",
+			"dev": true
 		},
 		"@types/shelljs": {
 			"version": "0.8.5",
@@ -92,10 +85,16 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/validator": {
+			"version": "10.11.3",
+			"resolved": "https://registry.npmjs.org/@types/validator/-/validator-10.11.3.tgz",
+			"integrity": "sha512-GKF2VnEkMmEeEGvoo03ocrP9ySMuX1ypKazIYMlsjfslfBMhOAtC5dmEWKdJioW4lJN7MZRS88kalTsVClyQ9w==",
+			"dev": true
+		},
 		"abab": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
-			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.2.tgz",
+			"integrity": "sha512-2scffjvioEmNz0OyDSLGWDfKCVwaKc6l9Pm9kOIREU13ClXZvHpg/nRL5xyjSSSLhOnXqft2HpsAzNEEA8cFFg==",
 			"dev": true
 		},
 		"acorn": {
@@ -105,9 +104,9 @@
 			"dev": true
 		},
 		"acorn-globals": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
-			"integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.1",
@@ -115,29 +114,38 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-					"integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+					"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
 					"dev": true
 				}
 			}
 		},
 		"acorn-walk": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
-			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
 			"dev": true
 		},
 		"ajv": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"version": "6.10.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
+			}
+		},
+		"ansi-green": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+			"integrity": "sha1-il2al55FjVfEDjNYCzc5C44Q0Pc=",
+			"dev": true,
+			"requires": {
+				"ansi-wrap": "0.1.0"
 			}
 		},
 		"ansi-styles": {
@@ -148,6 +156,18 @@
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
+		},
+		"ansi-wrap": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+			"dev": true
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -176,10 +196,22 @@
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 			"dev": true
 		},
+		"async-array-reduce": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/async-array-reduce/-/async-array-reduce-0.2.1.tgz",
+			"integrity": "sha1-yL4BCitc0A3qlsgRFgNGk9/dgtE=",
+			"dev": true
+		},
+		"async-each": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+			"dev": true
+		},
 		"async-limiter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
 			"dev": true
 		},
 		"asynckit": {
@@ -214,6 +246,12 @@
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
+		},
+		"bluebird": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
+			"dev": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -254,6 +292,35 @@
 				"supports-color": "^5.3.0"
 			}
 		},
+		"class-transformer": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.2.3.tgz",
+			"integrity": "sha512-qsP+0xoavpOlJHuYsQJsN58HXSl8Jvveo+T37rEvCEeRfMWoytAyR0Ua/YsFgpM6AZYZ/og2PJwArwzJl1aXtQ==",
+			"dev": true
+		},
+		"class-validator": {
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.10.2.tgz",
+			"integrity": "sha512-57bGDjoFXizqGZBHe/uHn5/K0MSjBkToaHpDhAXR6DIwjaoET37a0Uug4F5RZR7WF31/7SqzKFIvd+ZspszGUA==",
+			"dev": true,
+			"requires": {
+				"@types/validator": "10.11.3",
+				"google-libphonenumber": "^3.1.6",
+				"validator": "11.1.0"
+			}
+		},
+		"clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+			"dev": true
+		},
+		"clone-stats": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+			"dev": true
+		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -270,9 +337,9 @@
 			"dev": true
 		},
 		"combined-stream": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
@@ -290,6 +357,28 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
 		},
+		"copy": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/copy/-/copy-0.3.2.tgz",
+			"integrity": "sha512-drDFuUZctIuvSuvL9dOF/v5GxrwB1Q8eMIRlYONC0lSMEq+L2xabXP3jme8cQFdDO8cgP8JsuYhQg7JtTwezmg==",
+			"dev": true,
+			"requires": {
+				"async-each": "^1.0.0",
+				"bluebird": "^3.4.1",
+				"extend-shallow": "^2.0.1",
+				"file-contents": "^0.3.1",
+				"glob-parent": "^2.0.0",
+				"graceful-fs": "^4.1.4",
+				"has-glob": "^0.1.1",
+				"is-absolute": "^0.2.5",
+				"lazy-cache": "^2.0.1",
+				"log-ok": "^0.1.1",
+				"matched": "^0.4.1",
+				"mkdirp": "^0.5.1",
+				"resolve-dir": "^0.1.0",
+				"to-file": "^0.2.0"
+			}
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -297,15 +386,15 @@
 			"dev": true
 		},
 		"cssom": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
-			"integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
 			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
@@ -332,9 +421,9 @@
 			},
 			"dependencies": {
 				"whatwg-url": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
 					"dev": true,
 					"requires": {
 						"lodash.sortby": "^4.7.0",
@@ -358,6 +447,15 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
 			"dev": true
+		},
+		"define-property": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+			"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+			"dev": true,
+			"requires": {
+				"is-descriptor": "^0.1.0"
+			}
 		},
 		"delayed-stream": {
 			"version": "1.0.0",
@@ -397,9 +495,9 @@
 			"dev": true
 		},
 		"escodegen": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
-			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+			"integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
 			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
@@ -425,22 +523,40 @@
 			"dev": true
 		},
 		"estraverse": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true
 		},
 		"esutils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
+		},
+		"expand-tilde": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+			"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+			"dev": true,
+			"requires": {
+				"os-homedir": "^1.0.1"
+			}
 		},
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"dev": true
+		},
+		"extend-shallow": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+			"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+			"dev": true,
+			"requires": {
+				"is-extendable": "^0.1.0"
+			}
 		},
 		"extsprintf": {
 			"version": "1.3.0",
@@ -466,6 +582,38 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
+		"file-contents": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/file-contents/-/file-contents-0.3.2.tgz",
+			"integrity": "sha1-oJOf7RuM2hWAJm/Gt1OiMvtG3lM=",
+			"dev": true,
+			"requires": {
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"file-stat": "^0.2.3",
+				"fs-exists-sync": "^0.1.0",
+				"graceful-fs": "^4.1.4",
+				"is-buffer": "^1.1.3",
+				"isobject": "^2.1.0",
+				"lazy-cache": "^2.0.1",
+				"strip-bom-buffer": "^0.1.1",
+				"strip-bom-string": "^0.1.2",
+				"through2": "^2.0.1",
+				"vinyl": "^1.1.1"
+			}
+		},
+		"file-stat": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/file-stat/-/file-stat-0.2.3.tgz",
+			"integrity": "sha1-Rpp+kn1pMAeWJM2zgQlAVFbLBqk=",
+			"dev": true,
+			"requires": {
+				"fs-exists-sync": "^0.1.0",
+				"graceful-fs": "^4.1.4",
+				"lazy-cache": "^2.0.1",
+				"through2": "^2.0.1"
+			}
+		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -483,11 +631,22 @@
 				"mime-types": "^2.1.12"
 			}
 		},
-		"formidable": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-			"integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
+		"fs-exists-sync": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
 			"dev": true
+		},
+		"fs-extra": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			}
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -505,9 +664,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+			"integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -518,10 +677,47 @@
 				"path-is-absolute": "^1.0.0"
 			}
 		},
+		"glob-parent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
+			"requires": {
+				"is-glob": "^2.0.0"
+			}
+		},
+		"global-modules": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+			"integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+			"dev": true,
+			"requires": {
+				"global-prefix": "^0.1.4",
+				"is-windows": "^0.2.0"
+			}
+		},
+		"global-prefix": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+			"integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+			"dev": true,
+			"requires": {
+				"homedir-polyfill": "^1.0.0",
+				"ini": "^1.3.4",
+				"is-windows": "^0.2.0",
+				"which": "^1.2.12"
+			}
+		},
+		"google-libphonenumber": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.6.tgz",
+			"integrity": "sha512-6QCQAaKJlSd/1dUqvdQf7zzfb3uiZHsG8yhCfOdCVRfMuPZ/VDIEB47y5SYwjPQJPs7ebfW5jj6PeobB9JJ4JA==",
+			"dev": true
+		},
 		"graceful-fs": {
-			"version": "4.1.15",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 			"dev": true
 		},
 		"growl": {
@@ -531,9 +727,9 @@
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
+			"integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
@@ -572,6 +768,15 @@
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true
 		},
+		"has-glob": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/has-glob/-/has-glob-0.1.1.tgz",
+			"integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
+			"dev": true,
+			"requires": {
+				"is-glob": "^2.0.1"
+			}
+		},
 		"he": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -579,9 +784,9 @@
 			"dev": true
 		},
 		"highlight.js": {
-			"version": "9.15.6",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
-			"integrity": "sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ==",
+			"version": "9.15.10",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+			"integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
 			"dev": true
 		},
 		"homedir-polyfill": {
@@ -633,9 +838,15 @@
 			}
 		},
 		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 			"dev": true
 		},
 		"interpret": {
@@ -644,11 +855,156 @@
 			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
 			"dev": true
 		},
+		"is-absolute": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+			"integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+			"dev": true,
+			"requires": {
+				"is-relative": "^0.2.1",
+				"is-windows": "^0.2.0"
+			}
+		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
+		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"dev": true,
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-extglob": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
+		},
+		"is-glob": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "^1.0.0"
+			}
+		},
+		"is-relative": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+			"integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+			"dev": true,
+			"requires": {
+				"is-unc-path": "^0.1.1"
+			}
+		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
+		},
+		"is-unc-path": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+			"integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+			"dev": true,
+			"requires": {
+				"unc-path-regex": "^0.1.0"
+			}
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+			"dev": true
+		},
+		"is-valid-glob": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+			"integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+			"dev": true
+		},
+		"is-windows": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+			"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
+			"requires": {
+				"isarray": "1.0.0"
+			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -735,6 +1091,21 @@
 				"verror": "1.10.0"
 			}
 		},
+		"kind-of": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+			"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+			"dev": true
+		},
+		"lazy-cache": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+			"integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+			"dev": true,
+			"requires": {
+				"set-getter": "^0.1.0"
+			}
+		},
 		"left-pad": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -752,9 +1123,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
 			"dev": true
 		},
 		"lodash.sortby": {
@@ -762,6 +1133,16 @@
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
+		},
+		"log-ok": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/log-ok/-/log-ok-0.1.1.tgz",
+			"integrity": "sha1-vqPdNqzQuKckDXhza1uXxlREozQ=",
+			"dev": true,
+			"requires": {
+				"ansi-green": "^0.1.1",
+				"success-symbol": "^0.1.0"
+			}
 		},
 		"make-error": {
 			"version": "1.3.5",
@@ -774,6 +1155,23 @@
 			"resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
 			"integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
 			"dev": true
+		},
+		"matched": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/matched/-/matched-0.4.4.tgz",
+			"integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"async-array-reduce": "^0.2.0",
+				"extend-shallow": "^2.0.1",
+				"fs-exists-sync": "^0.1.0",
+				"glob": "^7.0.5",
+				"has-glob": "^0.1.1",
+				"is-valid-glob": "^0.3.0",
+				"lazy-cache": "^2.0.1",
+				"resolve-dir": "^0.1.0"
+			}
 		},
 		"mime-db": {
 			"version": "1.40.0",
@@ -831,6 +1229,22 @@
 				"minimatch": "3.0.4",
 				"mkdirp": "0.5.1",
 				"supports-color": "5.4.0"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.2",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
 			}
 		},
 		"ms": {
@@ -840,9 +1254,9 @@
 			"dev": true
 		},
 		"neo-async": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
 			"dev": true
 		},
 		"nwsapi": {
@@ -898,6 +1312,12 @@
 				}
 			}
 		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
+		},
 		"parse-passwd": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -940,6 +1360,12 @@
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
 		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
+		},
 		"progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -947,9 +1373,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.1.31",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-			"integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
 			"dev": true
 		},
 		"punycode": {
@@ -964,6 +1390,21 @@
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
 		},
+		"readable-stream": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"dev": true,
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
 		"rechoir": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -972,6 +1413,12 @@
 			"requires": {
 				"resolve": "^1.1.6"
 			}
+		},
+		"replace-ext": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+			"dev": true
 		},
 		"request": {
 			"version": "2.88.0",
@@ -1040,37 +1487,31 @@
 			}
 		},
 		"resolve": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
 			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
 		},
+		"resolve-dir": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+			"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+			"dev": true,
+			"requires": {
+				"expand-tilde": "^1.2.2",
+				"global-modules": "^0.2.3"
+			}
+		},
 		"rimraf": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
 			}
 		},
 		"safe-buffer": {
@@ -1090,6 +1531,15 @@
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 			"dev": true
+		},
+		"set-getter": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+			"integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+			"dev": true,
+			"requires": {
+				"to-object-path": "^0.3.0"
+			}
 		},
 		"shelljs": {
 			"version": "0.8.3",
@@ -1140,16 +1590,47 @@
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
 			"dev": true
 		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
 			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
 			"dev": true
 		},
+		"strip-bom-buffer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/strip-bom-buffer/-/strip-bom-buffer-0.1.1.tgz",
+			"integrity": "sha1-yj3cSRnBP5/d8wsd/xAKmDUki00=",
+			"dev": true,
+			"requires": {
+				"is-buffer": "^1.1.0",
+				"is-utf8": "^0.2.0"
+			}
+		},
+		"strip-bom-string": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-0.1.2.tgz",
+			"integrity": "sha1-nG5yCjE7qYNliVGEBcz7iKX0G5w=",
+			"dev": true
+		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
+		},
+		"success-symbol": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
+			"integrity": "sha1-JAIuSG878c3KCUKDt2nEctO3KJc=",
 			"dev": true
 		},
 		"supports-color": {
@@ -1162,10 +1643,100 @@
 			}
 		},
 		"symbol-tree": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
+		},
+		"through2": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
+			}
+		},
+		"to-file": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/to-file/-/to-file-0.2.0.tgz",
+			"integrity": "sha1-I2xsCIBl5XDe+9Fc9LTlZb5G6pM=",
+			"dev": true,
+			"requires": {
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"file-contents": "^0.2.4",
+				"glob-parent": "^2.0.0",
+				"is-valid-glob": "^0.3.0",
+				"isobject": "^2.1.0",
+				"lazy-cache": "^2.0.1",
+				"vinyl": "^1.1.1"
+			},
+			"dependencies": {
+				"file-contents": {
+					"version": "0.2.4",
+					"resolved": "https://registry.npmjs.org/file-contents/-/file-contents-0.2.4.tgz",
+					"integrity": "sha1-BQb3uO/2KvpFrkXaTfnp1H30U8s=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.0",
+						"file-stat": "^0.1.0",
+						"graceful-fs": "^4.1.2",
+						"is-buffer": "^1.1.0",
+						"is-utf8": "^0.2.0",
+						"lazy-cache": "^0.2.3",
+						"through2": "^2.0.0"
+					},
+					"dependencies": {
+						"lazy-cache": {
+							"version": "0.2.7",
+							"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+							"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+							"dev": true
+						}
+					}
+				},
+				"file-stat": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/file-stat/-/file-stat-0.1.3.tgz",
+					"integrity": "sha1-0PGWHX0QcykoEgpuaVVHHCpbVBE=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"lazy-cache": "^0.2.3",
+						"through2": "^2.0.0"
+					},
+					"dependencies": {
+						"lazy-cache": {
+							"version": "0.2.7",
+							"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+							"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+							"dev": true
+						}
+					}
+				}
+			}
+		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
 		},
 		"tough-cookie": {
 			"version": "2.5.0",
@@ -1280,17 +1851,6 @@
 				"typescript": "3.2.x"
 			},
 			"dependencies": {
-				"fs-extra": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
 				"typescript": {
 					"version": "3.2.4",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
@@ -1306,9 +1866,9 @@
 			"dev": true
 		},
 		"typedoc-plugin-markdown": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-1.2.0.tgz",
-			"integrity": "sha512-M3M9bx8q5u9VppIQ4ATjYV233ZyhRNbxkgTsjy7WVo4UY38dj1JWg90335ZCYktqkNkobSzE2OhVkmbQFGvi2g==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-1.2.1.tgz",
+			"integrity": "sha512-zOjoCaCWvgVca920IDSytkGQd1sFSztNKGGWWcYq4JWqmeklOWvYy5QODIeTeAcUeYsP9FZ5Ov7BU8WJk5Ypig==",
 			"dev": true,
 			"requires": {
 				"turndown": "^5.0.3"
@@ -1321,20 +1881,20 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.5.10",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.10.tgz",
-			"integrity": "sha512-/GTF0nosyPLbdJBd+AwYiZ+Hu5z8KXWnO0WCGt1BQ/u9Iamhejykqmz5o1OHJ53+VAk6xVxychonnApDjuqGsw==",
+			"version": "3.6.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.4.tgz",
+			"integrity": "sha512-9Yc2i881pF4BPGhjteCXQNaXx1DCwm3dtOyBaG2hitHjLWOczw/ki8vD1bqyT3u6K0Ms/FpCShkmfg+FtlOfYA==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"commander": "~2.20.0",
+				"commander": "~2.20.3",
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"commander": {
-					"version": "2.20.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 					"dev": true,
 					"optional": true
 				},
@@ -1346,6 +1906,12 @@
 					"optional": true
 				}
 			}
+		},
+		"unc-path-regex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+			"dev": true
 		},
 		"universalify": {
 			"version": "0.1.2",
@@ -1362,20 +1928,32 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
 			"dev": true
 		},
 		"v8flags": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.2.tgz",
-			"integrity": "sha512-MtivA7GF24yMPte9Rp/BWGCYQNaUj86zeYxV/x2RRJMKagImbbv3u8iJC57lNhWLPcGLJmHcHmFWkNsplbbLWw==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+			"integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
 			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
 			}
+		},
+		"validator": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
+			"integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg==",
+			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -1386,6 +1964,17 @@
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
+			}
+		},
+		"vinyl": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+			"dev": true,
+			"requires": {
+				"clone": "^1.0.0",
+				"clone-stats": "^0.0.1",
+				"replace-ext": "0.0.1"
 			}
 		},
 		"w3c-hr-time": {
@@ -1429,6 +2018,15 @@
 				"webidl-conversions": "^4.0.2"
 			}
 		},
+		"which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
 		"wordwrap": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -1454,6 +2052,12 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+			"dev": true
+		},
+		"xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
 			"dev": true
 		},
 		"yn": {

--- a/packages/typestack/package.json
+++ b/packages/typestack/package.json
@@ -59,6 +59,6 @@
     "ts-node": "^3.3.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-markdown": "^1.2.0",
-    "typescript": "^2.5.2"
+    "typescript": "~3.5.3"
   }
 }


### PR DESCRIPTION
# Issue

- The new version of [class-validator](https://www.npmjs.com/package/class-validator), version 0.10.2, only supports TS@v3 (type `unknown` required). This makes the build of `@foal/typestack` fail with TS@v2.
- MariaDB unit tests actually test MySQL database since the default port 3306 is used.
- For some reason, the Travis pipeline is not triggered anymore when pushing a commit to a PR. It seems that FoalTS project is not detected anymore on Travis website.

# Solution and steps

Starting from v1.3.0, FoalTS will only support TS@3.5 and beyond. This should not break current applications because most of them use TS@3.5 and beyond and the others that use TS@2.9 will only need to run `npm run typescript@3` to go to the new version without breaking changes (TS@3 is highly compatible with TS@2.9).

- [x] Build the packages with TypeScript 3.
- [x] Make MariaDB tests use the right database.
- [x] Set up a new CI pipeline with Github Actions (beta).

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
