### PR TITLE
Update user-class.md

### DIFF
--- a/docs/authentication-and-access-control/user-class.md
+++ b/docs/authentication-and-access-control/user-class.md
@@ -67,30 +67,28 @@ Go to `src/app/entities/user.entity.ts` and add two new columns: an email and a 
 
 ```typescript
 import { hashPassword } from '@foal/core';
-import { UserWithPermissions } from '@foal/typeorm';
 import { Column, Entity, PrimaryGeneratedColumn, BeforeInsert, BeforeUpdate } from 'typeorm';
-​
+
 @Entity()
-export class User extends UserWithPermissions {
-​
+export class User {
+
   @PrimaryGeneratedColumn()
   id: number;
-​
+
   @Column({ unique: true })
   email: string;
-​
+
   @Column()
   password: string;
-​
+
   @BeforeInsert()
   @BeforeUpdate()
   async hashPassword() {
     // Hash the password before storing it in the database
-    this.password = await hashPassword(this.password, { legacy: true });
-  }​
-}
+    this.password = await hashPassword(this.password);
+  }
 
-export { Group, Permission } from '@foal/typeorm';
+}
 
 ```
 

--- a/docs/authentication-and-access-control/user-class.md
+++ b/docs/authentication-and-access-control/user-class.md
@@ -68,7 +68,7 @@ Go to `src/app/entities/user.entity.ts` and add two new columns: an email and a 
 ```typescript
 import { hashPassword } from '@foal/core';
 import { UserWithPermissions } from '@foal/typeorm';
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn, BeforeInsert, BeforeUpdate } from 'typeorm';
 ​
 @Entity()
 export class User extends UserWithPermissions {
@@ -82,9 +82,11 @@ export class User extends UserWithPermissions {
   @Column()
   password: string;
 ​
-  async setPassword(password: string) {
+  @BeforeInsert()
+  @BeforeUpdate()
+  async hashPassword() {
     // Hash the password before storing it in the database
-    this.password = await hashPassword(password, { legacy: true });
+    this.password = await hashPassword(this.password, { legacy: true });
   }​
 }
 
@@ -92,7 +94,7 @@ export { Group, Permission } from '@foal/typeorm';
 
 ```
 
-> Note: When creating a new user programmatically you should use the `setPassword` method instead of assigning directly the `password` property. Otherwise the password will be stored in clear text in the database.
+> Note: The `BeforeInsert` and `BeforeUpdate` are typeORM decorators for Entity Listeners that run before the entity is saved in the db. In this example they take care of hashing the password. More info about `Entity Listeners` in the [typeORM docs](https://typeorm.io/#/listeners-and-subscribers)
 
 ### The create-user Shell Script
 


### PR DESCRIPTION
The example for hashing the password now make use of typeORM Entity Listeners  so that the `password` property can be populated like any others and it'll be hashed before being saved. 

This way each property can be treated the same way and the developers doesn't have to worry about forgetting to invoking specific methods.