### PR TITLE
[Docs] Remove comments on version 0.8

### DIFF
--- a/docs/api-section/openapi-and-swagger-ui.md
+++ b/docs/api-section/openapi-and-swagger-ui.md
@@ -211,8 +211,6 @@ paths:
 
 ### Use Existing Hooks
 
-> This section describes a new feature introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0).
-
 The addition of these decorators can sometimes be quite redundant with existing hooks. For example, if we want to write OpenAPI documentation for authentication and validation of the request body, we may end up with something like this.
 
 ```typescript

--- a/docs/api-section/public-api-and-cors-requests.md
+++ b/docs/api-section/public-api-and-cors-requests.md
@@ -4,10 +4,6 @@ Building an Open API requires to allow Cross-Origin Request Sharing.
 
 ## Enable Cross-Origin Resource Sharing (CORS)
 
-> This section describes changes introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0). Old documentation can be found [here](https://github.com/FoalTS/foal/blob/v0.8/docs/api-section/public-api-and-cors-requests.md).
-
---
-
 > If you are building a web application, **you may not need to enable CORS for your API**. See [here](../frontend-integration/angular-react-vue.md) the section *Origins that Do not Match*.
 
 If you want different origins to make requests to your API from a browser, you need to enable [Cross-Origin Resource Sharing](https://www.html5rocks.com/en/tutorials/cors/).

--- a/docs/api-section/rest-blueprints.md
+++ b/docs/api-section/rest-blueprints.md
@@ -118,8 +118,6 @@ export const productSchhema = {
 
 ## Generate OpenAPI documentation
 
-> This section describes a new feature introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0).
-
 The generated controllers also have OpenAPI decorators on their methods to document the API.
 
 In this way, when the [configuration key](../deployment-and-environments/configuration.md) `settings.openapi.useHooks` is set to `true`, we can get a full documentation of the API using [Swagger UI](./openapi-and-swagger-ui.md)

--- a/docs/architecture/controllers.md
+++ b/docs/architecture/controllers.md
@@ -296,7 +296,7 @@ class AppController {
 }
 ```
 
-> The `maxAge` cookie directive defines the number of **seconds** until the cookie expires. Versions prior to version 1 used milliseconds.
+> The `maxAge` cookie directive defines the number of **seconds** until the cookie expires.
 
 ## Testing Controllers
 

--- a/docs/architecture/hooks.md
+++ b/docs/architecture/hooks.md
@@ -151,8 +151,6 @@ class MyController {
 
 You can also have access to the controller instance through the `this` keyword.
 
-> Note: versions prior to version 1 do not support this feature. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0).
-
 *Example*
 ```typescript
 import { Get, getAjvInstance, Hook, HttpResponseBadRequest, HttpResponseOK } from '@foal/core';
@@ -178,8 +176,6 @@ class MyController {
 ```
 
 ### Executing Logic After the Controller Method
-
-> This section describes changes introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0). Old documentation can be found [here](https://github.com/FoalTS/foal/blob/v0.8/docs/architecture/hooks.md).
 
 A hook can also be used to execute extra logic after the controller method. To do so, you can return a *hook post function* inside the hook. This function will be executed after the controller method. It takes exactly one parameter: the `HttpResponse` object returned by the controller.
 
@@ -225,8 +221,6 @@ class MyController {
 ```
 
 ## Grouping Several Hooks into One
-
-> This section describes a new feature introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0).
 
 In case you need to group several hooks together, the `MergeHooks` function can be used to do this.
 

--- a/docs/authentication-and-access-control/jwt.md
+++ b/docs/authentication-and-access-control/jwt.md
@@ -205,8 +205,6 @@ You can provide your own function (in the case you want to use a cache database 
 
 ## Refresh the tokens
 
-> This section describes changes introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0). Old documentation can be found [here](https://github.com/FoalTS/foal/blob/v0.8/docs/authentication-and-access-control/jwt.md).
-
 Having a too-long expiration date for JSON Web Tokens is not recommend as it increases exposure to attacks based on token hijacking. If an attacker succeeds in stealing a token with an insufficient expiration date, he/she will have plenty of time to make other attacks and harm your application.
 
 In order to minimize the exposure, it is recommend to set a short expiration date (15 minutes for common applications) to quickly invalidate tokens. In this way, even if a token is stolen, it will quickly become unusable since it will have expired.

--- a/docs/authentication-and-access-control/password-management.md
+++ b/docs/authentication-and-access-control/password-management.md
@@ -4,8 +4,6 @@ Every application must store passwords using a cryptographic technique. FoalTS p
 
 ## The `hashPassword` function
 
-> Note: In previous versions of FoalTS (<v1.0.0), this function was named `encryptPassword`. 
-
 The `hashPassword` utility uses the [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2) algorithm with a SHA256 hash. It takes as parameters the password in plain text and an optional `options` object. It returns a promise which value is a password hash.
 
 > The function generates a unique cryptographically-strong random salt for each password. This salt is returned by the function beside the password hash.

--- a/docs/authentication-and-access-control/quick-start.md
+++ b/docs/authentication-and-access-control/quick-start.md
@@ -1,7 +1,5 @@
 # Quick Start
 
-> This document describes changes and new features introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0). Old documentation can be found [here](https://github.com/FoalTS/foal/blob/v0.8/docs/authentication-and-access-control/introduction.md).
-
 *Authentication* is the process of verifying that a user is who he or she claims to be. It answers the question *Who is the user?*. 
 
 > *Example: a user enters their login credentials to connect to the application*.

--- a/docs/authentication-and-access-control/session-tokens.md
+++ b/docs/authentication-and-access-control/session-tokens.md
@@ -1,7 +1,5 @@
 # Session Tokens
 
-> This document describes changes and new features introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0). Old documentation can be found [here](https://github.com/FoalTS/foal/blob/v0.8/docs/authentication-and-access-control/session-and-cookie.md).
-
 ## Introduction
 
 > This document assumes that you have alread read the [Quick Start](./quick-start.md) page.

--- a/docs/cookbook/generate-tokens.md
+++ b/docs/cookbook/generate-tokens.md
@@ -1,7 +1,5 @@
 # Generate (and Verify) Tokens
 
-> This section describes new features introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0).
-
 In many situations, we need to generate tokens and then verify them (for example in the flow of a password reset). This document shows how to do so with FoalTS.
 
 ## Unsigned Tokens (simple case)

--- a/docs/cookbook/limit-repeated-requests.md
+++ b/docs/cookbook/limit-repeated-requests.md
@@ -42,9 +42,7 @@ async function main() {
     }
   }));
     
-  const app = createApp(AppController, expressApp); // For v1
-  // For v0.8
-  // const app = createApp(AppController, { /* ... */ }, expressApp);
+  const app = createApp(AppController, expressApp);
     
   const httpServer = http.createServer(app);
   const port = Config.get('port', 3001);

--- a/docs/databases/generate-and-run-migrations.md
+++ b/docs/databases/generate-and-run-migrations.md
@@ -1,10 +1,6 @@
 # Generate and Run Migrations
 
-> This document describes changes introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0). Old documentation can be found [here](https://github.com/FoalTS/foal/blob/v0.8/docs/databases/generate-and-run-migrations.md).
-
 Database migrations are a way of propagating changes you make to your entities into your database schema. The changes you make to your models (adding a field, deleting an entity, etc.) do not automatically modify your database. You have to do it yourself.
-
-> Versions prior to version 1 used TypeORM `synchronize` option to update the schema on every application launch. This option is considered unsafe (see section below) and is disabled by default in new versions.
 
 You have two options: update the database schema manually (using database software, for example) or run migrations.
 

--- a/docs/databases/typeorm.md
+++ b/docs/databases/typeorm.md
@@ -47,8 +47,6 @@ TypeORM is integrated by default in every new FoalTS project. This lets you quic
 
 ### Initial configuration
 
-> This section describes changes introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0). Old documentation can be found [here](https://github.com/FoalTS/foal/blob/v0.8/docs/databases/typeorm.md).
-
 When creating a new project, an `SQLite` database is used by default as it does not require any additional installation. The connection configuration is stored in `ormconfig.js` and `default.json` located respectively at the root of your project and in the `config/` directory.
 
 *ormconfig.js*

--- a/docs/deployment-and-environments/configuration.md
+++ b/docs/deployment-and-environments/configuration.md
@@ -190,8 +190,6 @@ The `config/` directory files also have a precedence system inside the directory
 
 ## Database Configuration (TypeORM)
 
-> This section describes changes introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0). Old documentation can be found [here](https://github.com/FoalTS/foal/blob/v0.8/docs/deployment-and-environments/configuration.md).
-
 TypeORM uses a [different system](http://typeorm.io/#/using-ormconfig) for its configuration based on the file `ormconfig.js` located at the root of the project directory.
 
 You can however customize the `ormconfig.js` file to make it work with FoalTS configuration system.

--- a/docs/development-environment/vscode.md
+++ b/docs/development-environment/vscode.md
@@ -40,6 +40,6 @@ Now you can add a breakpoint in your code and start the app in debug mode.
 
 ![Debugging demo](./debugger.gif)
 
-The generated files also include configurations to run your unit and end-to-end tests (available since v1.0.0).
+The generated files also include configurations to run your unit and end-to-end tests.
 
 ![Debug configurations](./debug-configurations.png)

--- a/docs/security/csrf-protection.md
+++ b/docs/security/csrf-protection.md
@@ -1,8 +1,5 @@
 # CSRF protection
 
-
-> This document describes changes introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0). Old documentation can be found [here](https://github.com/FoalTS/foal/blob/v0.8/docs/security/csrf-protection.md).
-
 > Cross-Site Request Forgery (CSRF) is a type of attack that occurs when a malicious web site, email, blog, instant message, or program causes a user’s web browser to perform an unwanted action on a trusted site when the user is authenticated.
 >
 > *Source: [OWASP](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md)*

--- a/docs/tutorials/multi-user-todo-list/2-the-user-and-todo-models.md
+++ b/docs/tutorials/multi-user-todo-list/2-the-user-and-todo-models.md
@@ -39,8 +39,6 @@ export class User {
 
 The `setPassword` method uses `hashPassword` to hash passwords before storing them in the database. You must use this method to set a password instead of directly assigning a value to the `password` attribute.
 
-> Note: In previous versions of FoalTS (<v1.0.0), this function was named `encryptPassword`. 
-
 ## The Todo Model
 
 The Todo model defined in the previous tutorial now needs a `owner` property to know which user it belongs to.

--- a/docs/tutorials/multi-user-todo-list/5-auth-controllers-and-hooks.md
+++ b/docs/tutorials/multi-user-todo-list/5-auth-controllers-and-hooks.md
@@ -160,8 +160,6 @@ Great, so far you can authenticate users. But as you have not yet added access c
 
 The usual way to handle authorization is to use a *hook*. In this case, you are going to use the built-in hook `TokenRequired` which returns a 401 error or redirects the user if no user was logged in. 
 
-> FoalTS versions prior to version 1 used the `LoginRequired` hook. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0). Old documentation can be found [here](https://github.com/FoalTS/foal/blob/v0.8/docs/tutorials/multi-user-todo-list/5-auth-controllers-and-hooks.md).
-
 Update the controllers.
 
 ```typescript

--- a/docs/utilities/static-files.md
+++ b/docs/utilities/static-files.md
@@ -32,8 +32,6 @@ You can change the directory where the static files are served using the configu
 }
 ```
 
-> Note: In previous versions of FoalTS (<v1.0.0), this parameter was badly named `staticUrl`.
-
 # Add a virtual prefix path
 
 You can add a virtual prefix path using the configuration key `staticPathPrefix`.

--- a/docs/utilities/templating.md
+++ b/docs/utilities/templating.md
@@ -1,7 +1,5 @@
 # Templates - Server-Side Rendering
 
-> This document describes new features introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0). Old documentation can be found [here](https://github.com/FoalTS/foal/blob/v0.8/docs/utilities/templating.md).
-
 Regular Web Applications rely on _templates_ to dynamically generate HTML pages on the server. These templates are text files that contain static content as well as a special syntax describing how the data should be inserted dynamically. During an HTTP request, the application loads and renders the template using the given contextual data and sends back the page to the client.
 
 This technique is known as _Server-Side Rendering (or SSR)_.

--- a/docs/validation-and-sanitization.md
+++ b/docs/validation-and-sanitization.md
@@ -59,8 +59,6 @@ validate(schema, data);
 
 ### Validation & Sanitization of HTTP Requests
 
-> This section describes changes introduced in version 1.0.0. Instructions to upgrade to the new release can be found [here](https://github.com/FoalTS/foal/releases/tag/v1.0.0). Old documentation can be found [here](https://github.com/FoalTS/foal/blob/v0.8/docs/validation-and-sanitization.md).
-
 FoalTS provides many hooks to validate and sanitize HTTP requests. When validation fails, they return an `HttpResponseBadRequest` object whose body contains the validation errors.
 
 *Example*

--- a/packages/acceptance-tests/src/examples/cookbook/limit-repeated-requests.spec.ts
+++ b/packages/acceptance-tests/src/examples/cookbook/limit-repeated-requests.spec.ts
@@ -20,9 +20,7 @@ it('[Docs] Cookbook > Limit Repeated Requests', () => {
       windowMs: 15 * 60 * 1000, // 15 minutes
     }));
 
-    const app = createApp(AppController, expressApp); // For v1
-    // For v0.8
-    // const app = createApp(AppController, { /* ... */ }, expressApp);
+    const app = createApp(AppController, expressApp);
 
     const httpServer = http.createServer(app);
     const port = Config.get('port', 3001);


### PR DESCRIPTION
It has been five months since version 1 was released. I think we can now reasonably remove comments on version 0.8 from the documentation.