### PR TITLE
[CLI] Set default CSRF protection for sessions in the configuration

### DIFF
--- a/packages/cli/src/generate/specs/app/config/default.json
+++ b/packages/cli/src/generate/specs/app/config/default.json
@@ -4,7 +4,11 @@
     "csrf": false,
     "debug": false,
     "loggerFormat": "tiny",
-    "staticPath": "public/"
+    "session": {
+      "cookie": {
+        "sameSite": "lax"
+      }
+    }
   },
   "database": {
     "database": "./db.sqlite3",

--- a/packages/cli/src/generate/specs/app/config/default.mongodb.json
+++ b/packages/cli/src/generate/specs/app/config/default.mongodb.json
@@ -4,7 +4,11 @@
     "csrf": false,
     "debug": false,
     "loggerFormat": "tiny",
-    "staticPath": "public/"
+    "session": {
+      "cookie": {
+        "sameSite": "lax"
+      }
+    }
   },
   "mongodb": {
     "uri": "mongodb://localhost:27017/test-foo-bar"

--- a/packages/cli/src/generate/specs/app/config/default.mongodb.yml
+++ b/packages/cli/src/generate/specs/app/config/default.mongodb.yml
@@ -4,7 +4,9 @@ settings:
   csrf: false
   debug: false
   loggerFormat: tiny
-  staticPath: public/
+  session:
+    cookie:
+      sameSite: lax
 
 mongodb:
   uri: mongodb://localhost:27017/test-foo-bar

--- a/packages/cli/src/generate/specs/app/config/default.yml
+++ b/packages/cli/src/generate/specs/app/config/default.yml
@@ -4,7 +4,9 @@ settings:
   csrf: false
   debug: false
   loggerFormat: tiny
-  staticPath: public/
+  session:
+    cookie:
+      sameSite: lax
 
 database:
   database: './db.sqlite3'

--- a/packages/cli/src/generate/templates/app/config/default.json
+++ b/packages/cli/src/generate/templates/app/config/default.json
@@ -4,7 +4,11 @@
     "csrf": false,
     "debug": false,
     "loggerFormat": "tiny",
-    "staticPath": "public/"
+    "session": {
+      "cookie": {
+        "sameSite": "lax"
+      }
+    }
   },
   "database": {
     "database": "./db.sqlite3",

--- a/packages/cli/src/generate/templates/app/config/default.mongodb.json
+++ b/packages/cli/src/generate/templates/app/config/default.mongodb.json
@@ -4,7 +4,11 @@
     "csrf": false,
     "debug": false,
     "loggerFormat": "tiny",
-    "staticPath": "public/"
+    "session": {
+      "cookie": {
+        "sameSite": "lax"
+      }
+    }
   },
   "mongodb": {
     "uri": "mongodb://localhost:27017//* kebabName */"

--- a/packages/cli/src/generate/templates/app/config/default.mongodb.yml
+++ b/packages/cli/src/generate/templates/app/config/default.mongodb.yml
@@ -4,7 +4,9 @@ settings:
   csrf: false
   debug: false
   loggerFormat: tiny
-  staticPath: public/
+  session:
+    cookie:
+      sameSite: lax
 
 mongodb:
   uri: mongodb://localhost:27017//* kebabName */

--- a/packages/cli/src/generate/templates/app/config/default.yml
+++ b/packages/cli/src/generate/templates/app/config/default.yml
@@ -4,7 +4,9 @@ settings:
   csrf: false
   debug: false
   loggerFormat: tiny
-  staticPath: public/
+  session:
+    cookie:
+      sameSite: lax
 
 database:
   database: './db.sqlite3'

--- a/packages/core/src/core/http/http-responses.ts
+++ b/packages/core/src/core/http/http-responses.ts
@@ -21,7 +21,7 @@ export interface CookieOptions {
   maxAge?: number;
   path?: string;
   secure?: boolean;
-  sameSite?: 'strict'|'lax';
+  sameSite?: 'strict'|'lax'|'none';
 }
 
 /**


### PR DESCRIPTION
# Issues

- Since v4.17.0, ExpressJS has supported the `none` option for the `SameSite` cookie attribute. Developers should be able to use this value.
- Developers using cookies (for example with `@TokenRequired({ cookie: true })`) might not be aware of CSRF attacks and how to protect against them. We should set up a default protection for this in every new project.

# Solutions and steps

- [x] Update the `CookieOptions` interface.
- [x] Configuration generated with the command `createapp` will include a default CSRF protection for sessions : the cookie attribute `SameSite` will be set to `lax`.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
