### PR TITLE
[GraphQL] Make TypeGraphQL a dev dep

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -40,8 +40,7 @@
   "dependencies": {
     "@foal/core": "^1.3.1",
     "ajv": "~6.10.0",
-    "glob": "~7.1.4",
-    "type-graphql": "^0.17.5"
+    "glob": "~7.1.4"
   },
   "devDependencies": {
     "@types/mocha": "~2.2.43",
@@ -57,7 +56,8 @@
     "ts-node": "~3.3.0",
     "typedoc": "~0.14.2",
     "typedoc-plugin-markdown": "~1.2.0",
-    "typescript": "~3.5.3"
+    "typescript": "~3.5.3",
+    "type-graphql": "~0.17.5"
   },
   "peerDependencies": {
     "graphql": "^14.3.0"


### PR DESCRIPTION
# Issue

Version 1.3.1 added `type-graphql` by mistake as dependency of the `@foal/graphql` package.

# Solution and steps

- [x] Make it a dev dependency.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
