### PR TITLE
[@foal/cli] Fix --register failure when no imports

### DIFF
--- a/packages/cli/src/generate/generators/controller/create-controller.spec.ts
+++ b/packages/cli/src/generate/generators/controller/create-controller.spec.ts
@@ -84,6 +84,17 @@ describe('createController', () => {
       testEnv.copyFileFromMocks('index.ts');
     });
 
+    // TODO: refactor these tests and their mock and spec files.
+
+    it('should add all the imports if none exists.', () => {
+      testEnv.copyFileFromMocks('app.controller.no-import.ts', '../app.controller.ts');
+
+      createController({ name: 'test-fooBar', type: 'Empty', register: true });
+
+      testEnv
+        .validateSpec('app.controller.no-import.ts', '../app.controller.ts');
+    });
+
     it('should update the "subControllers" import in src/app/app.controller.ts if it exists.', () => {
       testEnv.copyFileFromMocks('app.controller.controller-import.ts', '../app.controller.ts');
 

--- a/packages/cli/src/generate/mocks/controller/app.controller.no-import.ts
+++ b/packages/cli/src/generate/mocks/controller/app.controller.no-import.ts
@@ -1,0 +1,1 @@
+export class MyController {}

--- a/packages/cli/src/generate/specs/controller/app.controller.controller-import.ts
+++ b/packages/cli/src/generate/specs/controller/app.controller.controller-import.ts
@@ -1,4 +1,5 @@
 // App
 import { TestFooBarController, ViewController } from './controllers';
+import { controller } from '@foal/core';
 
 export class MyController {}

--- a/packages/cli/src/generate/specs/controller/app.controller.empty-property.ts
+++ b/packages/cli/src/generate/specs/controller/app.controller.empty-property.ts
@@ -1,6 +1,7 @@
 // 3p
 import {} from 'somewhere';
 import { TestFooBarController } from './controllers';
+import { controller } from '@foal/core';
 
 export class MyController {
   subControllers = [

--- a/packages/cli/src/generate/specs/controller/app.controller.empty-spaced-property.ts
+++ b/packages/cli/src/generate/specs/controller/app.controller.empty-spaced-property.ts
@@ -1,6 +1,7 @@
 // 3p
 import {} from 'somewhere';
 import { TestFooBarController } from './controllers';
+import { controller } from '@foal/core';
 
 export class MyController {
   subControllers = [

--- a/packages/cli/src/generate/specs/controller/app.controller.no-import.ts
+++ b/packages/cli/src/generate/specs/controller/app.controller.no-import.ts
@@ -1,5 +1,3 @@
-// 3p
-import { Something } from '@somewhere';
 import { TestFooBarController } from './controllers';
 import { controller } from '@foal/core';
 

--- a/packages/cli/src/generate/specs/controller/app.controller.rest.ts
+++ b/packages/cli/src/generate/specs/controller/app.controller.rest.ts
@@ -1,6 +1,7 @@
 // 3p
 import {} from 'somewhere';
 import { TestFooBarController } from './controllers';
+import { controller } from '@foal/core';
 
 export class MyController {
   subControllers = [

--- a/packages/cli/src/generate/specs/rest-api/app.controller.controller-import.ts
+++ b/packages/cli/src/generate/specs/rest-api/app.controller.controller-import.ts
@@ -1,4 +1,5 @@
 // App
 import { TestFooBarController, ViewController } from './controllers';
+import { controller } from '@foal/core';
 
 export class MyController {}

--- a/packages/cli/src/generate/specs/rest-api/app.controller.empty-property.ts
+++ b/packages/cli/src/generate/specs/rest-api/app.controller.empty-property.ts
@@ -1,6 +1,7 @@
 // 3p
 import {} from 'somewhere';
 import { TestFooBarController } from './controllers';
+import { controller } from '@foal/core';
 
 export class MyController {
   subControllers = [

--- a/packages/cli/src/generate/specs/rest-api/app.controller.empty-spaced-property.ts
+++ b/packages/cli/src/generate/specs/rest-api/app.controller.empty-spaced-property.ts
@@ -1,6 +1,7 @@
 // 3p
 import {} from 'somewhere';
 import { TestFooBarController } from './controllers';
+import { controller } from '@foal/core';
 
 export class MyController {
   subControllers = [

--- a/packages/cli/src/generate/specs/rest-api/app.controller.no-controller-import.ts
+++ b/packages/cli/src/generate/specs/rest-api/app.controller.no-controller-import.ts
@@ -1,5 +1,6 @@
 // 3p
 import { Something } from '@somewhere';
 import { TestFooBarController } from './controllers';
+import { controller } from '@foal/core';
 
 export class MyController {}


### PR DESCRIPTION
# Issue

Resolves #606: when the file `app.controller.ts` does have any imports, the command `foal generate controller --register` fails.

# Solution and steps

- [x] Fix the bug
- [x] Improve code

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
