### PR TITLE
Upgrade graphql and modify tsconfig

### DIFF
--- a/packages/graphql/package-lock.json
+++ b/packages/graphql/package-lock.json
@@ -721,9 +721,9 @@
 			"dev": true
 		},
 		"graphql": {
-			"version": "14.3.1",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-14.3.1.tgz",
-			"integrity": "sha512-FZm7kAa3FqKdXy8YSSpAoTtyDFMIYSpCDOr+3EqlI1bxmtHu+Vv/I2vrSeT1sBOEnEniX3uo4wFhFdS/8XN6gA==",
+			"version": "14.6.0",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
+			"integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
 			"dev": true,
 			"requires": {
 				"iterall": "^1.2.2"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -48,7 +48,7 @@
     "apollo-cache-inmemory": "~1.5.1",
     "apollo-client": "~2.5.1",
     "apollo-link-http": "~1.5.14",
-    "graphql": "~14.3.0",
+    "graphql": "~14.6.0",
     "graphql-request": "~1.8.2",
     "graphql-tag": "~2.10.1",
     "mocha": "~5.2.0",

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -11,7 +11,8 @@
     "declaration": true,
     "lib": [
       "es2017",
-      "dom"
+      "dom",
+      "ESNext.AsyncIterable"
     ]
   },
   "include": [


### PR DESCRIPTION
# Issue

As pointed out in #614 and #623, new versions of `graphql` needs the `esnext.asynciterable` lib.

# Solution and steps

- [x] Upgrade graphql version to show the build failure.
- [x] Modify the `tsconfig` to fix it.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
