### PR TITLE
Fix virtual prefix path example

### DIFF
--- a/docs/utilities/static-files.md
+++ b/docs/utilities/static-files.md
@@ -40,7 +40,7 @@ You can add a virtual prefix path using the configuration key `staticPathPrefix`
 ```json
 {
   "settings": {
-    "staticPathPrefix": "static/"
+    "staticPathPrefix": "/static"
   }
 }
 ```


### PR DESCRIPTION
The current example does not work, as the forward slash must precede the pathname, not follow it

<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue
The path prefix "static/" does not work - content does not load.

# Solution and steps
The path "/static" works instead. 

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [ ] Add/update/check tests.
- [ ] Update/check the cli generators.
