### PR TITLE
fixes #634 - set todo.ownerId field as nullable in tutorial 02

### DIFF
--- a/docs/tutorials/multi-user-todo-list/2-the-user-and-todo-models.md
+++ b/docs/tutorials/multi-user-todo-list/2-the-user-and-todo-models.md
@@ -58,7 +58,7 @@ export class Todo {
   @Column()
   text: string;
 
-  @ManyToOne(type => User, { nullable: false })
+  @ManyToOne(type => User)
   owner: User;
 
 }

--- a/samples/tutorials/02-multi-user-todo-list-mpa/src/app/entities/todo.entity.ts
+++ b/samples/tutorials/02-multi-user-todo-list-mpa/src/app/entities/todo.entity.ts
@@ -10,7 +10,7 @@ export class Todo {
   @Column()
   text: string;
 
-  @ManyToOne(type => User, { nullable: false })
+  @ManyToOne(type => User)
   owner: User;
 
 }

--- a/samples/tutorials/02-multi-user-todo-list-mpa/src/migrations/1581664021032-user-and-todo.ts
+++ b/samples/tutorials/02-multi-user-todo-list-mpa/src/migrations/1581664021032-user-and-todo.ts
@@ -1,17 +1,17 @@
 import {MigrationInterface, QueryRunner} from "typeorm";
 
-export class userAndTodo1562860801825 implements MigrationInterface {
+export class userAndTodo1581664021032 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<any> {
         await queryRunner.query(`CREATE TABLE "temporary_user" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "email" varchar NOT NULL, "password" varchar NOT NULL, CONSTRAINT "UQ_ed766a9782779b8390a2a81f444" UNIQUE ("email"))`);
         await queryRunner.query(`INSERT INTO "temporary_user"("id") SELECT "id" FROM "user"`);
         await queryRunner.query(`DROP TABLE "user"`);
         await queryRunner.query(`ALTER TABLE "temporary_user" RENAME TO "user"`);
-        await queryRunner.query(`CREATE TABLE "temporary_todo" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "text" varchar NOT NULL, "ownerId" integer NOT NULL)`);
+        await queryRunner.query(`CREATE TABLE "temporary_todo" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "text" varchar NOT NULL, "ownerId" integer)`);
         await queryRunner.query(`INSERT INTO "temporary_todo"("id", "text") SELECT "id", "text" FROM "todo"`);
         await queryRunner.query(`DROP TABLE "todo"`);
         await queryRunner.query(`ALTER TABLE "temporary_todo" RENAME TO "todo"`);
-        await queryRunner.query(`CREATE TABLE "temporary_todo" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "text" varchar NOT NULL, "ownerId" integer NOT NULL, CONSTRAINT "FK_05552e862619dc4ad7ec8fc9cb8" FOREIGN KEY ("ownerId") REFERENCES "user" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)`);
+        await queryRunner.query(`CREATE TABLE "temporary_todo" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "text" varchar NOT NULL, "ownerId" integer, CONSTRAINT "FK_05552e862619dc4ad7ec8fc9cb8" FOREIGN KEY ("ownerId") REFERENCES "user" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)`);
         await queryRunner.query(`INSERT INTO "temporary_todo"("id", "text", "ownerId") SELECT "id", "text", "ownerId" FROM "todo"`);
         await queryRunner.query(`DROP TABLE "todo"`);
         await queryRunner.query(`ALTER TABLE "temporary_todo" RENAME TO "todo"`);
@@ -19,7 +19,7 @@ export class userAndTodo1562860801825 implements MigrationInterface {
 
     public async down(queryRunner: QueryRunner): Promise<any> {
         await queryRunner.query(`ALTER TABLE "todo" RENAME TO "temporary_todo"`);
-        await queryRunner.query(`CREATE TABLE "todo" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "text" varchar NOT NULL, "ownerId" integer NOT NULL)`);
+        await queryRunner.query(`CREATE TABLE "todo" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "text" varchar NOT NULL, "ownerId" integer)`);
         await queryRunner.query(`INSERT INTO "todo"("id", "text", "ownerId") SELECT "id", "text", "ownerId" FROM "temporary_todo"`);
         await queryRunner.query(`DROP TABLE "temporary_todo"`);
         await queryRunner.query(`ALTER TABLE "todo" RENAME TO "temporary_todo"`);


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue #634 

Migration fail in multi-user-todo-list tutorial because of todo records not having a user #634

# Solution and steps

Set Todo.OwnerId field as nullable, update docs and tutorial application

# Checklist

- [ ] Add/update/check docs (code comments and docs/ folder).
- [ ] Add/update/check tests.
- [ ] Update/check the cli generators.
