### PR TITLE
Expose isFileDoesNotExist and improve CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,45 +78,45 @@ jobs:
     - name: Check package linting
       run: npm run lint
     - name: Run unit tests of @foal/acceptance-tests
-      run: cd acceptance-tests && npm run test
+      run: cd packages/acceptance-tests && npm run test
     - name: Run unit tests of @foal/aws-s3
-      run: cd aws-s3 && npm run test
+      run: cd packages/aws-s3 && npm run test
     - name: Run unit tests of @foal/cli
-      run: cd cli && npm run test
+      run: cd packages/cli && npm run test
     - name: Run unit tests of @foal/csrf
-      run: cd csrf && npm run test
+      run: cd packages/csrf && npm run test
     - name: Run unit tests of @foal/ejs
-      run: cd ejs && npm run test
+      run: cd packages/ejs && npm run test
     - name: Run unit tests of @foal/examples
-      run: cd examples && npm run test
+      run: cd packages/examples && npm run test
     - name: Run unit tests of @foal/formidable
-      run: cd formidable && npm run test
+      run: cd packages/formidable && npm run test
     - name: Run unit tests of @foal/graphql
-      run: cd graphql && npm run test
+      run: cd packages/graphql && npm run test
     - name: Run unit tests of @foal/jwks-rsa
-      run: cd jwks-rsa && npm run test
+      run: cd packages/jwks-rsa && npm run test
     - name: Run unit tests of @foal/jwt
-      run: cd jwt && npm run test
+      run: cd packages/jwt && npm run test
     - name: Run unit tests of @foal/mongodb
-      run: cd mongodb && npm run test
+      run: cd packages/mongodb && npm run test
     - name: Run unit tests of @foal/mongoose
-      run: cd mongoose && npm run test
+      run: cd packages/mongoose && npm run test
     - name: Run unit tests of @foal/password
-      run: cd password && npm run test
+      run: cd packages/password && npm run test
     - name: Run unit tests of @foal/redis
-      run: cd redis && npm run test
+      run: cd packages/redis && npm run test
     - name: Run unit tests of @foal/social
-      run: cd social && npm run test
+      run: cd packages/social && npm run test
     - name: Run unit tests of @foal/storage
-      run: cd storage && npm run test
+      run: cd packages/storage && npm run test
     - name: Run unit tests of @foal/swagger
-      run: cd swagger && npm run test
+      run: cd packages/swagger && npm run test
     - name: Run unit tests of @foal/typeorm
-      run: cd typeorm && npm run test
+      run: cd packages/typeorm && npm run test
     - name: Run unit tests of @foal/typestack
-      run: cd typestack && npm run test
+      run: cd packages/typestack && npm run test
     - name: Run unit tests of @foal/core
-      run: cd core && npm run test
+      run: cd packages/core && npm run test
     - name: Run acceptance tests (Bash)
       run: ./e2e_test.sh
     - name: Send code coverage report to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,8 +77,46 @@ jobs:
       working-directory: packages/cli
     - name: Check package linting
       run: npm run lint
-    - name: Run unit and acceptance tests (TypeScript)
-      run: lerna run --no-bail test
+    - name: Run unit tests of @foal/acceptance-tests
+      run: cd acceptance-tests && npm run test
+    - name: Run unit tests of @foal/aws-s3
+      run: cd aws-s3 && npm run test
+    - name: Run unit tests of @foal/cli
+      run: cd cli && npm run test
+    - name: Run unit tests of @foal/csrf
+      run: cd csrf && npm run test
+    - name: Run unit tests of @foal/ejs
+      run: cd ejs && npm run test
+    - name: Run unit tests of @foal/examples
+      run: cd examples && npm run test
+    - name: Run unit tests of @foal/formidable
+      run: cd formidable && npm run test
+    - name: Run unit tests of @foal/graphql
+      run: cd graphql && npm run test
+    - name: Run unit tests of @foal/jwks-rsa
+      run: cd jwks-rsa && npm run test
+    - name: Run unit tests of @foal/jwt
+      run: cd jwt && npm run test
+    - name: Run unit tests of @foal/mongodb
+      run: cd mongodb && npm run test
+    - name: Run unit tests of @foal/mongoose
+      run: cd mongoose && npm run test
+    - name: Run unit tests of @foal/password
+      run: cd password && npm run test
+    - name: Run unit tests of @foal/redis
+      run: cd redis && npm run test
+    - name: Run unit tests of @foal/social
+      run: cd social && npm run test
+    - name: Run unit tests of @foal/storage
+      run: cd storage && npm run test
+    - name: Run unit tests of @foal/swagger
+      run: cd swagger && npm run test
+    - name: Run unit tests of @foal/typeorm
+      run: cd typeorm && npm run test
+    - name: Run unit tests of @foal/typestack
+      run: cd typestack && npm run test
+    - name: Run unit tests of @foal/core
+      run: cd core && npm run test
     - name: Run acceptance tests (Bash)
       run: ./e2e_test.sh
     - name: Send code coverage report to Codecov

--- a/docs/file-system/local-and-cloud-storage.md
+++ b/docs/file-system/local-and-cloud-storage.md
@@ -160,6 +160,8 @@ class FileService {
 } 
 ```
 
+> To check whether an error is an instance of `FileDoesNotExist`, you can call the `isFileDoesNotExist` function. Using `error instanceof FileDoesNotExist` may not work if you have multiple nested packages because of the way *npm* handles its dependencies.
+
 ### Write files
 
 Files can be saved using the asynchronous `write` method. This method accepts a buffer or a readable stream. If no name is provided, it is automatically generated and used to save the file in the given directory. In this case, a file extension can also be provided to the method.

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -4,6 +4,6 @@
  * Released under the MIT License.
  */
 
-export { AbstractDisk, FileDoesNotExist } from './abstract-disk.service';
+export { AbstractDisk, FileDoesNotExist, isFileDoesNotExist } from './abstract-disk.service';
 export { Disk } from './disk.service';
 export { LocalDisk } from './local-disk.service';


### PR DESCRIPTION
# Issue

- `isFileDoesNotExist` is not exported in `@foal/storage`.
- `lerna run test` is a bit slow and, when a test fails in Github Actions, it is difficult to know which one it is.

# Solution and steps

- [x] Export `isFileDoesNotExist`
- [x] Do not use `lerna run test` in Github Actions

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
