### PR TITLE
[V2] [Sessions] Simplify logout

### DIFF
--- a/docs/authentication-and-access-control/quick-start.md
+++ b/docs/authentication-and-access-control/quick-start.md
@@ -97,6 +97,8 @@ You may need to enable [CORS](../api-section/public-api-and-cors-requests.md) or
 
 ### Sessions Tokens
 
+> warning: version 2
+
 First generate a secret:
 
 ```
@@ -111,7 +113,7 @@ SETTINGS_SESSION_SECRET=my-secret
 
 *src/app/controllers/auth.controller.ts*
 ```typescript
-import { dependency, Get, Post, Session, TokenRequired, ValidateBody } from '@foal/core';
+import { dependency, Get, Post, TokenOptional, TokenRequired, ValidateBody } from '@foal/core';
 import { TypeORMStore } from '@foal/typeorm';
 // ... to complete
 
@@ -163,9 +165,12 @@ export class AuthController {
   }
 
     @Post('/logout')
-    @TokenRequired({ store: TypeORMStore, extendLifeTimeOrUpdate: false })
-    async logout(ctx: Context<any, Session>) {
-      await this.store.destroy(ctx.session.sessionID);
+    @TokenOptional({ store: TypeORMStore })
+    async logout(ctx: Context) {
+      if (ctx.session) {
+        await ctx.session.destroy();
+      }
+
       return new HttpResponseNoContent();
     }
 }
@@ -281,6 +286,8 @@ You may need to enable [CORS](../api-section/public-api-and-cors-requests.md) or
 
 ### Session Tokens
 
+> warning: version 2
+
 First generate a secret:
 
 ```
@@ -345,16 +352,16 @@ export class AuthController {
   }
 
   @Post('/logout')
-  @TokenRequired({
+  @TokenOptional({
     cookie: true,
-    extendLifeTimeOrUpdate: false,
     store: TypeORMStore,
   })
-  async logout(ctx: Context<any, Session>) {
-    await this.store.destroy(ctx.session.sessionID);
-    const response = new HttpResponseNoContent();
-    removeSessionCookie(response);
-    return response;
+  async logout(ctx: Context) {
+    if (ctx.session) {
+      await ctx.session.destroy();
+    }
+
+    return new HttpResponseNoContent();
   }
 }
 ```
@@ -371,6 +378,8 @@ export class ApiController {
 ```
 
 ## Regular Web Applications (with cookies and redirections)
+
+> warning: version 2
 
 > As you use cookies, you must add a [CSRF protection](../security/csrf-protection.md) to your application.
 
@@ -454,17 +463,17 @@ export class AuthController {
   }
 
   @Post('/logout')
-  @TokenRequired({
+  @TokenOptional({
     cookie: true,
-    extendLifeTimeOrUpdate: false,
     redirectTo: '/login',
     store: TypeORMStore,
   })
-  async logout(ctx: Context<any, Session>) {
-    await this.store.destroy(ctx.session.sessionID);
-    const response = new HttpResponseRedirect('/login');
-    removeSessionCookie(response);
-    return response;
+  async logout(ctx: Context) {
+    if (ctx.session) {
+      await ctx.session.destroy();
+    }
+
+    return new HttpResponseRedirect('/login');
   }
 }
 ```

--- a/docs/authentication-and-access-control/session-tokens.md
+++ b/docs/authentication-and-access-control/session-tokens.md
@@ -149,10 +149,12 @@ class ApiController {
 
 ### Destroy the Session (Log Out)
 
-Sessions are can be destroyed (i.e users can be logged out) using the `destroy` method of the session store.
+> warning: version 2
+
+Sessions are can be destroyed (i.e users can be logged out) using their `destroy` method.
 
 ```typescript
-import { Context, dependency, HttpResponseNoContent, TokenRequired, Session } from '@foal/core';
+import { Context, dependency, HttpResponseNoContent, TokenOptional } from '@foal/core';
 import { TypeORMStore } from '@foal/typeorm';
 
 export class AuthController {
@@ -160,9 +162,11 @@ export class AuthController {
   store: TypeORMStore;
 
   @Post('/logout')
-  @TokenRequired({ store: TypeORMStore, extendLifeTimeOrUpdate: false })
-  async logout(ctx: Context<any, Session>) {
-    await this.store.destroy(ctx.session.sessionID);
+  @TokenOptional({ store: TypeORMStore })
+  async logout(ctx: Context) {
+    if (ctx.session) {
+      await ctx.session.destroy();
+    }
     return new HttpResponseNoContent();
   }
 

--- a/docs/tutorials/multi-user-todo-list/5-auth-controllers-and-hooks.md
+++ b/docs/tutorials/multi-user-todo-list/5-auth-controllers-and-hooks.md
@@ -82,8 +82,8 @@ Open the new file `auth.controller.ts` and replace its content.
 ```typescript
 // 3p
 import {
-  Context, dependency, HttpResponseRedirect, Post, removeSessionCookie,
-  Session, setSessionCookie, TokenRequired, ValidateBody, verifyPassword
+  Context, dependency, HttpResponseRedirect, Post,
+  setSessionCookie, TokenOptional, TokenRequired, ValidateBody, verifyPassword
 } from '@foal/core';
 import { TypeORMStore } from '@foal/typeorm';
 import { getRepository } from 'typeorm';
@@ -130,21 +130,19 @@ export class AuthController {
   }
 
   @Post('/logout')
-  @TokenRequired({
+  @TokenOptional({
     cookie: true,
-    extendLifeTimeOrUpdate: false,
     redirectTo: '/signin',
     store: TypeORMStore,
   })
-  async logout(ctx: Context<User, Session>) {
+  async logout(ctx: Context) {
     // Destroy the user session.
-    await this.store.destroy(ctx.session.sessionID);
+    if (ctx.session) {
+      await ctx.session.destroy();
+    }
 
     // Redirect the user to the home page on success.
-    const response = new HttpResponseRedirect('/signin');
-    // Remove the cookie where the session token is stored.
-    removeSessionCookie(response);
-    return response;
+    return new HttpResponseRedirect('/signin');
   }
 }
 

--- a/packages/acceptance-tests/src/authentication/session-token.cookie.redirection.spec.ts
+++ b/packages/acceptance-tests/src/authentication/session-token.cookie.redirection.spec.ts
@@ -11,8 +11,8 @@ import * as request from 'supertest';
 // FoalTS
 import {
   Context, controller, createApp, dependency, ExpressApplication, Get, hashPassword,
-  HttpResponseOK, HttpResponseRedirect, Post, removeSessionCookie,
-  Session, setSessionCookie, TokenRequired, ValidateBody, verifyPassword
+  HttpResponseOK, HttpResponseRedirect, Post,
+  setSessionCookie, TokenOptional, TokenRequired, ValidateBody, verifyPassword
 } from '@foal/core';
 import { TypeORMStore } from '@foal/typeorm';
 
@@ -91,17 +91,17 @@ describe('[Authentication|session token|cookie|redirection] Users', () => {
     }
 
     @Post('/logout')
-    @TokenRequired({
+    @TokenOptional({
       cookie: true,
-      extendLifeTimeOrUpdate: false,
       redirectTo: '/login',
       store: TypeORMStore,
     })
-    async logout(ctx: Context<any, Session>) {
-      await this.store.destroy(ctx.session.sessionID);
-      const response = new HttpResponseRedirect('/login');
-      removeSessionCookie(response);
-      return response;
+    async logout(ctx: Context) {
+      if (ctx.session) {
+        await ctx.session.destroy();
+      }
+
+      return new HttpResponseRedirect('/login');
     }
 
     @Get('/home')

--- a/packages/acceptance-tests/src/authentication/session-token.cookie.spec.ts
+++ b/packages/acceptance-tests/src/authentication/session-token.cookie.spec.ts
@@ -12,8 +12,8 @@ import * as request from 'supertest';
 import {
   Context, controller, createApp, dependency, ExpressApplication, Get,
   hashPassword, HttpResponseNoContent, HttpResponseOK,
-  HttpResponseUnauthorized, Post, removeSessionCookie, Session,
-  setSessionCookie, TokenRequired, ValidateBody, verifyPassword
+  HttpResponseUnauthorized, Post,
+  setSessionCookie, TokenOptional, TokenRequired, ValidateBody, verifyPassword
 } from '@foal/core';
 import { TypeORMStore } from '@foal/typeorm';
 
@@ -92,16 +92,16 @@ describe('[Authentication|session token|cookie|no redirection] Users', () => {
     }
 
     @Post('/logout')
-    @TokenRequired({
+    @TokenOptional({
       cookie: true,
-      extendLifeTimeOrUpdate: false,
       store: TypeORMStore,
     })
-    async logout(ctx: Context<any, Session>) {
-      await this.store.destroy(ctx.session.sessionID);
-      const response = new HttpResponseNoContent();
-      removeSessionCookie(response);
-      return response;
+    async logout(ctx: Context) {
+      if (ctx.session) {
+        await ctx.session.destroy();
+      }
+
+      return new HttpResponseNoContent();
     }
   }
 

--- a/packages/acceptance-tests/src/authentication/session-token.token.spec.ts
+++ b/packages/acceptance-tests/src/authentication/session-token.token.spec.ts
@@ -12,7 +12,7 @@ import * as request from 'supertest';
 import {
   Context, controller, createApp, dependency, ExpressApplication, Get,
   hashPassword, HttpResponseNoContent, HttpResponseOK,
-  HttpResponseUnauthorized, Post, Session, TokenRequired, ValidateBody, verifyPassword
+  HttpResponseUnauthorized, Post, TokenOptional, TokenRequired, ValidateBody, verifyPassword
 } from '@foal/core';
 import { TypeORMStore } from '@foal/typeorm';
 
@@ -89,9 +89,12 @@ describe('[Authentication|session token|no cookie|no redirection] Users', () => 
     }
 
     @Post('/logout')
-    @TokenRequired({ store: TypeORMStore, extendLifeTimeOrUpdate: false })
-    async logout(ctx: Context<any, Session>) {
-      await this.store.destroy(ctx.session.sessionID);
+    @TokenOptional({ store: TypeORMStore })
+    async logout(ctx: Context) {
+      if (ctx.session) {
+        await ctx.session.destroy();
+      }
+
       return new HttpResponseNoContent();
     }
   }

--- a/packages/acceptance-tests/src/mongoose-db.mongodb-store.spec.ts
+++ b/packages/acceptance-tests/src/mongoose-db.mongodb-store.spec.ts
@@ -15,7 +15,7 @@ import {
   HttpResponseOK,
   HttpResponseUnauthorized,
   Post,
-  Session,
+  TokenOptional,
   TokenRequired,
   ValidateBody,
   verifyPassword
@@ -87,9 +87,12 @@ describe('[Sample] Mongoose DB & MongoDB Store', async () => {
     store: MongoDBStore;
 
     @Post('/logout')
-    @TokenRequired({ store: MongoDBStore, extendLifeTimeOrUpdate: false })
-    async logout(ctx: Context<any, Session>) {
-      await this.store.destroy(ctx.session.sessionID);
+    @TokenOptional({ store: MongoDBStore })
+    async logout(ctx: Context) {
+      if (ctx.session) {
+        await ctx.session.destroy();
+      }
+
       return new HttpResponseNoContent();
     }
 

--- a/packages/acceptance-tests/src/mongoose-db.redis-store.spec.ts
+++ b/packages/acceptance-tests/src/mongoose-db.redis-store.spec.ts
@@ -15,7 +15,7 @@ import {
   HttpResponseOK,
   HttpResponseUnauthorized,
   Post,
-  Session,
+  TokenOptional,
   TokenRequired,
   ValidateBody,
   verifyPassword
@@ -86,9 +86,12 @@ describe('[Sample] Mongoose DB & Redis Store', async () => {
     store: RedisStore;
 
     @Post('/logout')
-    @TokenRequired({ store: RedisStore, extendLifeTimeOrUpdate: false })
-    async logout(ctx: Context<any, Session>) {
-      await this.store.destroy(ctx.session.sessionID);
+    @TokenOptional({ store: RedisStore })
+    async logout(ctx: Context) {
+      if (ctx.session) {
+        await ctx.session.destroy();
+      }
+
       return new HttpResponseNoContent();
     }
 

--- a/packages/core/src/sessions/session-store.spec.ts
+++ b/packages/core/src/sessions/session-store.spec.ts
@@ -191,7 +191,7 @@ describe('SessionStore', () => {
       class Store extends SessionStore {
         async createAndSaveSession(sessionContent: object, options: SessionOptions = {}): Promise<Session> {
           await this.applySessionOptions(sessionContent, options);
-          return new Session('xxx', sessionContent, 36);
+          return new Session(this, 'xxx', sessionContent, 36);
         }
         update(session: Session): Promise<void> {
           throw new Error('Method not implemented.');
@@ -216,8 +216,10 @@ describe('SessionStore', () => {
 
       const user = { id: 1 };
 
-      const session = await new Store().createAndSaveSessionFromUser(user, { csrfToken: true });
+      const store = new Store();
+      const session = await store.createAndSaveSessionFromUser(user, { csrfToken: true });
 
+      strictEqual(session.store, store);
       strictEqual(session.sessionID, 'xxx');
       const content: any = session.getContent();
       strictEqual(content.userId, 1);

--- a/packages/core/src/sessions/session.spec.ts
+++ b/packages/core/src/sessions/session.spec.ts
@@ -5,29 +5,56 @@ import { createHmac } from 'crypto';
 // FoalTS
 import { ConfigNotFoundError } from '../core';
 import { Session } from './session';
+import { SessionOptions, SessionStore } from './session-store';
 
 describe('Session', () => {
+
+  class ConcreteSessionStore extends SessionStore {
+    createAndSaveSession(sessionContent: object, options?: SessionOptions | undefined): Promise<Session> {
+      throw new Error('Method not implemented.');
+    }
+    update(session: Session): Promise<void> {
+      throw new Error('Method not implemented.');
+    }
+    destroy(sessionID: string): Promise<void> {
+      throw new Error('Method not implemented.');
+    }
+    read(sessionID: string): Promise<Session | undefined> {
+      throw new Error('Method not implemented.');
+    }
+    extendLifeTime(sessionID: string): Promise<void> {
+      throw new Error('Method not implemented.');
+    }
+    clear(): Promise<void> {
+      throw new Error('Method not implemented.');
+    }
+    cleanUpExpiredSessions(): Promise<void> {
+      throw new Error('Method not implemented.');
+    }
+  }
 
   describe('when it is instanciated', () => {
 
     it('should throw an error if the sessionID includes a dot.', () => {
       try {
         // tslint:disable-next-line:no-unused-expression
-        new Session('xxx.yyy', {}, 0);
+        new Session(new ConcreteSessionStore(), 'xxx.yyy', {}, 0);
         throw new Error('An error should have been thrown during instanciation.');
       } catch (error) {
         strictEqual(error.message, 'A session ID cannot include dots.');
       }
     });
 
-    it('should set two readonly properties "sessionID" and "createdAt" from the given arguments.', () => {
-      const session = new Session('xxx', {}, 3);
+    it('should set three readonly properties "store", "sessionID" and "createdAt" from the given arguments.', () => {
+      const store = new ConcreteSessionStore();
+      const session = new Session(store, 'xxx', {}, 3);
+      strictEqual((session as any).store, store);
       strictEqual(session.sessionID, 'xxx');
       strictEqual(session.createdAt, 3);
     });
 
     it('should not be "modified".', () => {
-      const session = new Session('xxx', {}, 0);
+      const session = new Session(new ConcreteSessionStore(), 'xxx', {}, 0);
       strictEqual(session.isModified, false);
     });
 
@@ -36,17 +63,17 @@ describe('Session', () => {
   describe('has a "get" method that', () => {
 
     it('should return the value of the key given in the param "sessionContent" during instantiation.', () => {
-      const session = new Session('', { foo: 'bar' }, 0);
+      const session = new Session(new ConcreteSessionStore(), '', { foo: 'bar' }, 0);
       strictEqual(session.get('foo'), 'bar');
     });
 
     it('should return the default value if the key does not exist.', () => {
-      const session = new Session('', { foo: 'bar' }, 0);
+      const session = new Session(new ConcreteSessionStore(), '', { foo: 'bar' }, 0);
       strictEqual(session.get<string>('foobar', 'barfoo'), 'barfoo');
     });
 
     it('should return undefined if there is no default value and if the key does not exist.', () => {
-      const session = new Session('', { foo: 'bar' }, 0);
+      const session = new Session(new ConcreteSessionStore(), '', { foo: 'bar' }, 0);
       strictEqual(session.get('foobar'), undefined);
     });
 
@@ -55,13 +82,13 @@ describe('Session', () => {
   describe('has a "set" method that', () => {
 
     it('should modify the session content...', () => {
-      const session = new Session('', {}, 0);
+      const session = new Session(new ConcreteSessionStore(), '', {}, 0);
       session.set('foo', 'bar');
       strictEqual(session.get('foo'), 'bar');
     });
 
     it('...and mark it as modified.', () => {
-      const session = new Session('', {}, 0);
+      const session = new Session(new ConcreteSessionStore(), '', {}, 0);
       strictEqual(session.isModified, false);
 
       session.set('foo', 'bar');
@@ -75,7 +102,7 @@ describe('Session', () => {
     afterEach(() => delete process.env.SETTINGS_SESSION_SECRET);
 
     it('should throw an Error is the configuration key `settings.session.secret` is not defined.', () => {
-      const session = new Session('aaa', {}, 0);
+      const session = new Session(new ConcreteSessionStore(), 'aaa', {}, 0);
       try {
         session.getToken();
         throw new Error('Session.getToken should have thrown an Error.');
@@ -118,7 +145,7 @@ describe('Session', () => {
 
       process.env.SETTINGS_SESSION_SECRET = secret;
 
-      const session = new Session(sessionID, {}, 0);
+      const session = new Session(new ConcreteSessionStore(), sessionID, {}, 0);
       const token = session.getToken();
 
       strictEqual(
@@ -179,7 +206,7 @@ describe('Session', () => {
 
     it('should return a copy of the session content', () => {
       const content = { foo: 'bar' };
-      const session = new Session('a', content, 0);
+      const session = new Session(new ConcreteSessionStore(), 'a', content, 0);
 
       deepStrictEqual(session.getContent(), content);
       notStrictEqual(session.getContent(), content);

--- a/packages/core/src/sessions/session.spec.ts
+++ b/packages/core/src/sessions/session.spec.ts
@@ -214,4 +214,32 @@ describe('Session', () => {
 
   });
 
+  describe('has a "destroy" method that', () => {
+
+    class ConcreteSessionStore2 extends ConcreteSessionStore {
+      calledWith: string|undefined;
+
+      async destroy(sessionID: string): Promise<void> {
+        this.calledWith = sessionID;
+      }
+    }
+
+    it('should call the "destroy" method of the store to destroy itself.', async () => {
+      const store = new ConcreteSessionStore2();
+      const session = new Session(store, 'a', {}, 0);
+
+      await session.destroy();
+      strictEqual(store.calledWith, 'a');
+    });
+
+    it('should make this.isDestroyed return "true".', async () => {
+      const store = new ConcreteSessionStore2();
+      const session = new Session(store, 'a', {}, 0);
+
+      strictEqual(session.isDestroyed, false);
+      await session.destroy();
+      strictEqual(session.isDestroyed, true);
+    });
+  });
+
 });

--- a/packages/core/src/sessions/session.ts
+++ b/packages/core/src/sessions/session.ts
@@ -1,6 +1,7 @@
 // FoalTS
 import { signToken, verifySignedToken } from '../common';
 import { Config } from '../core';
+import { SessionStore } from './session-store';
 
 /**
  * Representation of a server/database session.
@@ -30,7 +31,12 @@ export class Session {
 
   private modified = false;
 
-  constructor(readonly sessionID: string, private sessionContent: any, readonly createdAt: number) {
+  constructor(
+    readonly store: SessionStore,
+    readonly sessionID: string,
+    private sessionContent: any,
+    readonly createdAt: number
+  ) {
     if (sessionID.includes('.')) {
       throw new Error('A session ID cannot include dots.');
     }

--- a/packages/core/src/sessions/session.ts
+++ b/packages/core/src/sessions/session.ts
@@ -30,6 +30,7 @@ export class Session {
   }
 
   private modified = false;
+  private destroyed = false;
 
   constructor(
     readonly store: SessionStore,
@@ -51,6 +52,17 @@ export class Session {
    */
   get isModified(): boolean {
     return this.modified;
+  }
+
+  /**
+   * Return true if the session has been destroyed.
+   *
+   * @readonly
+   * @type {boolean}
+   * @memberof Session
+   */
+  get isDestroyed(): boolean {
+    return this.destroyed;
   }
 
   /**
@@ -107,6 +119,17 @@ export class Session {
    */
   getContent(): object {
     return { ...this.sessionContent };
+  }
+
+  /**
+   * Destroy the session in the session store.
+   *
+   * @returns {Promise<void>}
+   * @memberof Session
+   */
+  async destroy(): Promise<void> {
+    await this.store.destroy(this.sessionID);
+    this.destroyed = true;
   }
 
 }

--- a/packages/core/src/sessions/token.hook.spec.ts
+++ b/packages/core/src/sessions/token.hook.spec.ts
@@ -45,7 +45,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     }
     async createAndSaveSession(sessionContent: object): Promise<Session> {
       const sessionID = await this.generateSessionID();
-      const session = new Session(sessionID, sessionContent, Date.now());
+      const session = new Session({} as any, sessionID, sessionContent, Date.now());
       this.sessions.push(session);
       return session;
     }

--- a/packages/core/src/sessions/token.hook.spec.ts
+++ b/packages/core/src/sessions/token.hook.spec.ts
@@ -34,9 +34,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     async update(session: Session): Promise<void> {
       this.updateCalledWith = session;
     }
-    destroy(sessionID: string): Promise<void> {
-      throw new Error('Method not implemented.');
-    }
+    async destroy(sessionID: string): Promise<void> {}
     async extendLifeTime(sessionID: string): Promise<void> {
       this.extendLifeTimeCalledWith = sessionID;
     }
@@ -45,7 +43,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     }
     async createAndSaveSession(sessionContent: object): Promise<Session> {
       const sessionID = await this.generateSessionID();
-      const session = new Session({} as any, sessionID, sessionContent, Date.now());
+      const session = new Session(this, sessionID, sessionContent, Date.now());
       this.sessions.push(session);
       return session;
     }
@@ -562,20 +560,6 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
 
   });
 
-  it('should not return a post-hook function if options.extendLifeTimeOrUpdate is false.', async () => {
-    const hook = getHookFunction(Token({ store: Store, extendLifeTimeOrUpdate: false }));
-
-    const session = await services.get(Store).createAndSaveSession({ userId: 22 });
-    const token = session.getToken();
-
-    const ctx = new Context({
-      get(str: string) { return str === 'Authorization' ? `Bearer ${token}` : undefined; }
-    });
-
-    const postHookFunction = await hook(ctx, services);
-    strictEqual(postHookFunction, undefined);
-  });
-
   describe('should return a post-hook function that', () => {
 
     beforeEach(() => {
@@ -625,6 +609,54 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
 
       strictEqual(services.get(Store).updateCalledWith, undefined);
       strictEqual(services.get(Store).extendLifeTimeCalledWith, session.sessionID);
+    });
+
+    it('should not update the session or extend its lifetime if session.isDestroyed is true'
+      + ' (isModified === true).', async () => {
+        const session = await services.get(Store).createAndSaveSession({ userId: 47 });
+        const token = session.getToken();
+
+        const ctx = new Context({
+          get(str: string) { return str === 'Authorization' ? `Bearer ${token}` : undefined; }
+        });
+
+        const postHookFunction = await hook(ctx, services);
+        if (postHookFunction === undefined || isHttpResponse(postHookFunction)) {
+          throw new Error('The hook should return a post hook function');
+        }
+        if (!ctx.session) {
+          throw new Error('ctx.session should be defined');
+        }
+        ctx.session.set('something', 1); // set "isModified" to "true"
+        await ctx.session.destroy();
+        await postHookFunction(new HttpResponseOK());
+
+        strictEqual(services.get(Store).updateCalledWith, undefined);
+        strictEqual(services.get(Store).extendLifeTimeCalledWith, undefined);
+      }
+    );
+
+    it('should not extend the session lifetime if session.isDestroyed is true (isModified === false).', async () => {
+      const session = await services.get(Store).createAndSaveSession({ userId: 48 });
+      const token = session.getToken();
+
+      const ctx = new Context({
+        get(str: string) { return str === 'Authorization' ? `Bearer ${token}` : undefined; }
+      });
+
+      const postHookFunction = await hook(ctx, services);
+      if (postHookFunction === undefined || isHttpResponse(postHookFunction)) {
+        throw new Error('The hook should return a post hook function');
+      }
+      if (!ctx.session) {
+        throw new Error('ctx.session should be defined');
+      }
+      // Do not set "isModified" to "true"
+      await ctx.session.destroy();
+      await postHookFunction(new HttpResponseOK());
+
+      strictEqual(services.get(Store).updateCalledWith, undefined);
+      strictEqual(services.get(Store).extendLifeTimeCalledWith, undefined);
     });
 
     describe('given options.cookie is false or not defined', () => {
@@ -680,6 +712,35 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
         const { value, options } = response.getCookie(SESSION_DEFAULT_COOKIE_NAME);
         strictEqual(value, session.getToken());
         deepStrictEqual(options.maxAge, SessionStore.getExpirationTimeouts().inactivity);
+      });
+
+      it('should remove the session cookie if session.isDestroyed is true.', async () => {
+        const session = await services.get(Store).createAndSaveSession({ userId: 48 });
+        const token = session.getToken();
+
+        const hook = getHookFunction(Token({ store: Store, cookie: true }));
+
+        const ctx = new Context({
+          get(str: string) { return undefined; },
+          cookies: {
+            [SESSION_DEFAULT_COOKIE_NAME]: token
+          }
+        });
+
+        const postHookFunction = await hook(ctx, services);
+        if (postHookFunction === undefined || isHttpResponse(postHookFunction)) {
+          throw new Error('The hook should return a post hook function');
+        }
+        if (!ctx.session) {
+          throw new Error('ctx.session should be defined');
+        }
+        const response = new HttpResponseOK();
+        await ctx.session.destroy();
+        await postHookFunction(response);
+
+        const { value, options } = response.getCookie(SESSION_DEFAULT_COOKIE_NAME);
+        strictEqual(value, '');
+        deepStrictEqual(options.maxAge, 0);
       });
 
     });

--- a/packages/core/src/sessions/token.hook.ts
+++ b/packages/core/src/sessions/token.hook.ts
@@ -39,7 +39,6 @@ export interface TokenOptions {
   cookie?: boolean;
   redirectTo?: string;
   openapi?: boolean;
-  extendLifeTimeOrUpdate?: boolean;
 }
 
 export function Token(required: boolean, options: TokenOptions): HookDecorator {
@@ -144,11 +143,14 @@ export function Token(required: boolean, options: TokenOptions): HookDecorator {
       ctx.user = user;
     }
 
-    if (options.extendLifeTimeOrUpdate === false) {
-      return;
-    }
-
     return async (response: HttpResponse) => {
+      if (session.isDestroyed) {
+        if (options.cookie) {
+          removeSessionCookie(response);
+        }
+        return;
+      }
+
       if (session.isModified) {
         await store.update(session);
       } else {

--- a/packages/csrf/src/csrf-token-required.hook.spec.ts
+++ b/packages/csrf/src/csrf-token-required.hook.spec.ts
@@ -47,7 +47,7 @@ describe('CsrfTokenRequired', () => {
 
     it('should throw if the session content has no CSRF token.', async () => {
       const ctx = new Context({});
-      ctx.session = new Session('a', {}, 0);
+      ctx.session = new Session({} as any, 'a', {}, 0);
       try {
         await hook(ctx, services);
         throw new Error('An error should have been thrown.');
@@ -63,7 +63,7 @@ describe('CsrfTokenRequired', () => {
 
       it('should return an HttpResponseForbidden object if the token is incorrect.', async () => {
         const ctx = new Context<any, Session>({ body: { _csrf: 'xxx' }, headers: {} });
-        ctx.session = new Session('a', { csrfToken: 'bbb' }, 0);
+        ctx.session = new Session({} as any, 'a', { csrfToken: 'bbb' }, 0);
 
         const response = await hook(ctx, services);
         if (!isHttpResponseForbidden(response)) {
@@ -74,41 +74,41 @@ describe('CsrfTokenRequired', () => {
 
       it('should not return an HttpResponseForbidden object if the token is correct (body._csrf).', async () => {
         const ctx = new Context<any, Session>({ body: { _csrf: 'xxx' }, headers: {} });
-        ctx.session = new Session('a', { csrfToken: 'xxx' }, 0);
+        ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct (query._csrf).', async () => {
         const ctx = new Context<any, Session>({ query: { _csrf: 'xxx' }, headers: {} });
-        ctx.session = new Session('a', { csrfToken: 'xxx' }, 0);
+        ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["csrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'csrf-token': 'xxx' } });
-        ctx.session = new Session('a', { csrfToken: 'xxx' }, 0);
+        ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["xsrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'xsrf-token': 'xxx' } });
-        ctx.session = new Session('a', { csrfToken: 'xxx' }, 0);
+        ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["x-csrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'x-csrf-token': 'xxx' } });
-        ctx.session = new Session('a', { csrfToken: 'xxx' }, 0);
+        ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["x-xsrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'x-xsrf-token': 'xxx' } });
-        ctx.session = new Session('a', { csrfToken: 'xxx' }, 0);
+        ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
@@ -116,19 +116,19 @@ describe('CsrfTokenRequired', () => {
 
     it('should not return an HttpResponseForbidden object if the method is GET.', async () => {
       const ctx = new Context<any, Session>({ headers: {}, method: 'GET' });
-      ctx.session = new Session('a', { csrfToken: 'xxx' }, 0);
+      ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
       strictEqual(await hook(ctx, services), undefined);
     });
 
     it('should not return an HttpResponseForbidden object if the method is HEAD.', async () => {
       const ctx = new Context<any, Session>({ headers: {}, method: 'HEAD' });
-      ctx.session = new Session('a', { csrfToken: 'xxx' }, 0);
+      ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
       strictEqual(await hook(ctx, services), undefined);
     });
 
     it('should not return an HttpResponseForbidden object if the method is OPTIONS.', async () => {
       const ctx = new Context<any, Session>({ headers: {}, method: 'OPTIONS' });
-      ctx.session = new Session('a', { csrfToken: 'xxx' }, 0);
+      ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
       strictEqual(await hook(ctx, services), undefined);
     });
 
@@ -166,7 +166,7 @@ describe('CsrfTokenRequired', () => {
 
     it('should return an HttpResponseForbidden object if the "csrfToken" cookie is not found.', async () => {
       const ctx = new Context<any, Session>({ cookies: {} });
-      ctx.session = new Session('a', {}, 0);
+      ctx.session = new Session({} as any, 'a', {}, 0);
 
       const response = await hook(ctx, services);
       if (!isHttpResponseForbidden(response)) {
@@ -179,7 +179,7 @@ describe('CsrfTokenRequired', () => {
       process.env.SETTINGS_CSRF_COOKIE_NAME = 'csrf';
 
       const ctx = new Context<any, Session>({ cookies: { csrfToken: 'xxx' } });
-      ctx.session = new Session('a', {}, 0);
+      ctx.session = new Session({} as any, 'a', {}, 0);
 
       const response = await hook(ctx, services);
       if (!isHttpResponseForbidden(response)) {
@@ -194,7 +194,7 @@ describe('CsrfTokenRequired', () => {
           + ' is incorrect.', async () => {
         const token = 'xxx';
         const ctx = new Context<any, Session>({ body: { _csrf: 'xxx' }, cookies: { csrfToken: token } });
-        ctx.session = new Session('a', {}, 0);
+        ctx.session = new Session({} as any, 'a', {}, 0);
 
         const response = await hook(ctx, services);
         if (!isHttpResponseForbidden(response)) {
@@ -205,7 +205,7 @@ describe('CsrfTokenRequired', () => {
 
       it('should return an HttpResponseForbidden object if the token is incorrect.', async () => {
         const ctx = new Context<any, Session>({ body: { _csrf: 'xxx' }, cookies: { csrfToken: token } });
-        ctx.session = new Session('a', {}, 0);
+        ctx.session = new Session({} as any, 'a', {}, 0);
 
         const response = await hook(ctx, services);
         if (!isHttpResponseForbidden(response)) {
@@ -216,41 +216,41 @@ describe('CsrfTokenRequired', () => {
 
       it('should not return an HttpResponseForbidden object if the token is correct (body._csrf).', async () => {
         const ctx = new Context<any, Session>({ body: { _csrf: token }, cookies: { csrfToken: token } });
-        ctx.session = new Session('a', {}, 0);
+        ctx.session = new Session({} as any, 'a', {}, 0);
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct (query._csrf).', async () => {
         const ctx = new Context<any, Session>({ query: { _csrf: token }, cookies: { csrfToken: token } });
-        ctx.session = new Session('a', {}, 0);
+        ctx.session = new Session({} as any, 'a', {}, 0);
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["csrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'csrf-token': token }, cookies: { csrfToken: token } });
-        ctx.session = new Session('a', {}, 0);
+        ctx.session = new Session({} as any, 'a', {}, 0);
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["xsrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'xsrf-token': token }, cookies: { csrfToken: token } });
-        ctx.session = new Session('a', {}, 0);
+        ctx.session = new Session({} as any, 'a', {}, 0);
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["x-csrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'x-csrf-token': token }, cookies: { csrfToken: token } });
-        ctx.session = new Session('a', {}, 0);
+        ctx.session = new Session({} as any, 'a', {}, 0);
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["x-xsrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'x-xsrf-token': token }, cookies: { csrfToken: token } });
-        ctx.session = new Session('a', {}, 0);
+        ctx.session = new Session({} as any, 'a', {}, 0);
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
@@ -258,19 +258,19 @@ describe('CsrfTokenRequired', () => {
 
     it('should not return an HttpResponseForbidden object if the method is GET.', async () => {
       const ctx = new Context<any, Session>({ headers: {}, method: 'GET', cookies: { csrfToken: token } });
-      ctx.session = new Session('a', {}, 0);
+      ctx.session = new Session({} as any, 'a', {}, 0);
       strictEqual(await hook(ctx, services), undefined);
     });
 
     it('should not return an HttpResponseForbidden object if the method is HEAD.', async () => {
       const ctx = new Context<any, Session>({ headers: {}, method: 'HEAD', cookies: { csrfToken: token } });
-      ctx.session = new Session('a', {}, 0);
+      ctx.session = new Session({} as any, 'a', {}, 0);
       strictEqual(await hook(ctx, services), undefined);
     });
 
     it('should not return an HttpResponseForbidden object if the method is OPTIONS.', async () => {
       const ctx = new Context<any, Session>({ headers: {}, method: 'OPTIONS', cookies: { csrfToken: token } });
-      ctx.session = new Session('a', {}, 0);
+      ctx.session = new Session({} as any, 'a', {}, 0);
       strictEqual(await hook(ctx, services), undefined);
     });
 

--- a/packages/csrf/src/get-csrf-token.util.spec.ts
+++ b/packages/csrf/src/get-csrf-token.util.spec.ts
@@ -44,7 +44,7 @@ describe('getCsrfToken', () => {
   describe('given session is defined.', () => {
 
     it('should throw an error if the session key "csrfToken" is empty.', async () => {
-      const session = new Session('a', {}, 0);
+      const session = new Session({} as any, 'a', {}, 0);
       try {
         await getCsrfToken(session);
         throw new Error('An error should have been thrown.');
@@ -57,7 +57,7 @@ describe('getCsrfToken', () => {
     });
 
     it('should return the value of the session key "csrfToken".', async () => {
-      const session = new Session('a', { csrfToken: 'xxx' }, 0);
+      const session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
       const csrfToken = await getCsrfToken(session);
       strictEqual(csrfToken, 'xxx');
     });

--- a/packages/mongodb/src/mongodb-store.service.spec.ts
+++ b/packages/mongodb/src/mongodb-store.service.spec.ts
@@ -102,6 +102,7 @@ describe('MongoDBStore', () => {
       strictEqual(sessions.length, 1);
       const sessionA = sessions[0];
 
+      strictEqual(session.store, store);
       strictEqual(session.sessionID, sessionA._id);
       deepStrictEqual(session.getContent(), { foo: 'bar' });
       strictEqual(session.createdAt, sessionA.createdAt);
@@ -311,6 +312,7 @@ describe('MongoDBStore', () => {
       if (!session) {
         throw new Error('TypeORMStore.read should not return undefined.');
       }
+      strictEqual(session.store, store);
       strictEqual(session.sessionID, session2._id);
       strictEqual(session.get('foo'), 'bar');
       strictEqual(session.createdAt, session2.createdAt);

--- a/packages/mongodb/src/mongodb-store.service.spec.ts
+++ b/packages/mongodb/src/mongodb-store.service.spec.ts
@@ -130,7 +130,7 @@ describe('MongoDBStore', () => {
         updatedAt: Date.now(),
       });
 
-      await store.update(new Session(session1._id, { bar: 'foo' }, session1.createdAt));
+      await store.update(new Session({} as any, session1._id, { bar: 'foo' }, session1.createdAt));
 
       const sessionA = await findByID(session1._id);
       deepStrictEqual(sessionA.sessionContent, { bar: 'foo' });
@@ -156,7 +156,7 @@ describe('MongoDBStore', () => {
       });
 
       const dateBefore = Date.now();
-      await store.update(new Session(session1._id, session1.sessionContent, session1.createdAt));
+      await store.update(new Session({} as any, session1._id, session1.sessionContent, session1.createdAt));
       const dateAfter = Date.now();
 
       const sessionA = await findByID(session1._id);

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -31,7 +31,7 @@ export class MongoDBStore extends SessionStore {
       updatedAt: date,
     });
 
-    return new Session({} as any, sessionID, sessionContent, date);
+    return new Session(this, sessionID, sessionContent, date);
   }
 
   async update(session: Session): Promise<void> {
@@ -72,7 +72,7 @@ export class MongoDBStore extends SessionStore {
       return undefined;
     }
 
-    return new Session({} as any, session._id, session.sessionContent, session.createdAt);
+    return new Session(this, session._id, session.sessionContent, session.createdAt);
   }
 
   async extendLifeTime(sessionID: string): Promise<void> {

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -31,7 +31,7 @@ export class MongoDBStore extends SessionStore {
       updatedAt: date,
     });
 
-    return new Session(sessionID, sessionContent, date);
+    return new Session({} as any, sessionID, sessionContent, date);
   }
 
   async update(session: Session): Promise<void> {
@@ -72,7 +72,7 @@ export class MongoDBStore extends SessionStore {
       return undefined;
     }
 
-    return new Session(session._id, session.sessionContent, session.createdAt);
+    return new Session({} as any, session._id, session.sessionContent, session.createdAt);
   }
 
   async extendLifeTime(sessionID: string): Promise<void> {

--- a/packages/redis/src/redis-store.service.spec.ts
+++ b/packages/redis/src/redis-store.service.spec.ts
@@ -87,6 +87,7 @@ describe('RedisStore', () => {
       const session = await store.createAndSaveSession({ foo: 'bar' });
       const dateAfter = Date.now();
 
+      strictEqual(session.store, store);
       notStrictEqual(session.sessionID, undefined);
       deepStrictEqual(session.getContent(), { foo: 'bar' });
 
@@ -234,6 +235,7 @@ describe('RedisStore', () => {
       if (!session) {
         throw new Error('RedisStore.read should not return undefined.');
       }
+      strictEqual(session.store, store);
       strictEqual(session.sessionID, 'b');
       strictEqual(session.get('foo'), 'bar');
       strictEqual(session.createdAt, createdAt);

--- a/packages/redis/src/redis-store.service.spec.ts
+++ b/packages/redis/src/redis-store.service.spec.ts
@@ -123,7 +123,7 @@ describe('RedisStore', () => {
       await asyncSet('session:a', JSON.stringify(data));
       strictEqual(await asyncGet('session:a'), JSON.stringify(data));
 
-      const session = new Session('a', data.content, data.createdAt);
+      const session = new Session({} as any, 'a', data.content, data.createdAt);
       session.set('foo', 'foobar');
 
       await store.update(session);
@@ -143,7 +143,7 @@ describe('RedisStore', () => {
       await asyncSet('session:a', JSON.stringify(data));
       strictEqual(await asyncGet('session:a'), JSON.stringify(data));
 
-      const session = new Session('a', data.content, data.createdAt);
+      const session = new Session({} as any, 'a', data.content, data.createdAt);
       session.set('foo', 'foobar');
 
       await store.update(session);
@@ -154,7 +154,7 @@ describe('RedisStore', () => {
     it('should create the session if it does not exist (with the proper lifetime).', async () => {
       strictEqual(await asyncGet('session:a'), null);
 
-      const session = new Session('a', { foo: 'bar' }, Date.now());
+      const session = new Session({} as any, 'a', { foo: 'bar' }, Date.now());
 
       await store.update(session);
 

--- a/packages/redis/src/redis-store.service.ts
+++ b/packages/redis/src/redis-store.service.ts
@@ -25,7 +25,7 @@ export class RedisStore extends SessionStore {
         if (err) {
           return reject(err);
         }
-        const session = new Session({} as any, sessionID, sessionContent, createdAt);
+        const session = new Session(this, sessionID, sessionContent, createdAt);
         resolve(session);
       });
     });
@@ -68,7 +68,7 @@ export class RedisStore extends SessionStore {
           return resolve(undefined);
         }
         const data = JSON.parse(val);
-        const session = new Session({} as any, sessionID, data.content, data.createdAt);
+        const session = new Session(this, sessionID, data.content, data.createdAt);
 
         if (Date.now() - session.createdAt > absolute * 1000) {
           await this.destroy(sessionID);

--- a/packages/redis/src/redis-store.service.ts
+++ b/packages/redis/src/redis-store.service.ts
@@ -25,7 +25,7 @@ export class RedisStore extends SessionStore {
         if (err) {
           return reject(err);
         }
-        const session = new Session(sessionID, sessionContent, createdAt);
+        const session = new Session({} as any, sessionID, sessionContent, createdAt);
         resolve(session);
       });
     });
@@ -68,7 +68,7 @@ export class RedisStore extends SessionStore {
           return resolve(undefined);
         }
         const data = JSON.parse(val);
-        const session = new Session(sessionID, data.content, data.createdAt);
+        const session = new Session({} as any, sessionID, data.content, data.createdAt);
 
         if (Date.now() - session.createdAt > absolute * 1000) {
           await this.destroy(sessionID);
@@ -111,7 +111,7 @@ export class RedisStore extends SessionStore {
       const redisURI = Config.get2('redis.uri', 'string');
       this.redisClient = createClient(redisURI);
     }
-    return this.redisClient ;
+    return this.redisClient;
   }
 
 }

--- a/packages/typeorm/src/typeorm-store.service.spec.ts
+++ b/packages/typeorm/src/typeorm-store.service.spec.ts
@@ -155,7 +155,7 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
           updatedAt: Date.now(),
         });
 
-        await store.update(new Session(session1.sessionID, { bar: 'foo' }, session1.createdAt));
+        await store.update(new Session({} as any, session1.sessionID, { bar: 'foo' }, session1.createdAt));
 
         const sessionA = await findByID(session1.sessionID);
         deepStrictEqual(sessionA.sessionContent, { bar: 'foo' });
@@ -181,7 +181,7 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
         });
 
         const dateBefore = Date.now();
-        await store.update(new Session(session1.sessionID, session1.sessionContent, session1.createdAt));
+        await store.update(new Session({} as any, session1.sessionID, session1.sessionContent, session1.createdAt));
         const dateAfter = Date.now();
 
         const sessionA = await findByID(session1.sessionID);

--- a/packages/typeorm/src/typeorm-store.service.spec.ts
+++ b/packages/typeorm/src/typeorm-store.service.spec.ts
@@ -127,6 +127,7 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
         strictEqual(sessions.length, 1);
         const sessionA = sessions[0];
 
+        strictEqual(session.store, store);
         strictEqual(session.sessionID, sessionA.sessionID);
         deepStrictEqual(session.getContent(), { foo: 'bar' });
         strictEqual(session.createdAt, parseInt(sessionA.createdAt.toString(), 10));
@@ -336,6 +337,7 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
         if (!session) {
           throw new Error('TypeORMStore.read should not return undefined.');
         }
+        strictEqual(session.store, store);
         strictEqual(session.sessionID, session2.sessionID);
         strictEqual(session.get('foo'), 'bar');
         strictEqual(session.createdAt, session2.createdAt);

--- a/packages/typeorm/src/typeorm-store.service.ts
+++ b/packages/typeorm/src/typeorm-store.service.ts
@@ -34,7 +34,7 @@ export class TypeORMStore extends SessionStore {
       }
     );
 
-    return new Session(sessionID, sessionContent, date);
+    return new Session({} as any, sessionID, sessionContent, date);
   }
 
   async update(session: Session): Promise<void> {
@@ -84,7 +84,7 @@ export class TypeORMStore extends SessionStore {
       return undefined;
     }
 
-    return new Session(session.session_id, sessionContent, createdAt);
+    return new Session({} as any, session.session_id, sessionContent, createdAt);
   }
 
   async extendLifeTime(sessionID: string): Promise<void> {

--- a/packages/typeorm/src/typeorm-store.service.ts
+++ b/packages/typeorm/src/typeorm-store.service.ts
@@ -34,7 +34,7 @@ export class TypeORMStore extends SessionStore {
       }
     );
 
-    return new Session({} as any, sessionID, sessionContent, date);
+    return new Session(this, sessionID, sessionContent, date);
   }
 
   async update(session: Session): Promise<void> {
@@ -84,7 +84,7 @@ export class TypeORMStore extends SessionStore {
       return undefined;
     }
 
-    return new Session({} as any, session.session_id, sessionContent, createdAt);
+    return new Session(this, session.session_id, sessionContent, createdAt);
   }
 
   async extendLifeTime(sessionID: string): Promise<void> {


### PR DESCRIPTION
# Issue

**Version 2**

Logging users out in Foal is not simple and intuitive. This PR reduces the amount of code to be produced and makes it clearer.

# Specification

## Without cookies

**Before**
```typescript
import {
  dependency, Context, HttpResponseNoContent, Post,
  Session, TokenRequired
} from '@foal/core';
import { TypeORMStore } from '@foal/typeorm';

export class AuthController {

  @dependency
  store: TypeORMStore;

  @Post('/logout')
  @TokenRequired({
    extendLifeTimeOrUpdate: false,
    store: TypeORMStore,
  })
  async logout(ctx: Context<any, Session>) {
    await this.store.destroy(ctx.session.sessionID);

    return new HttpResponseNoContent();
  }

}
```

**After**
```typescript
import {
  Context, HttpResponseNoContent, Post, TokenOptional
} from '@foal/core';
import { TypeORMStore } from '@foal/typeorm';

export class AuthController {

  @Post('/logout')
  @TokenOptional({
    store: TypeORMStore,
  })
  async logout(ctx: Context) {
    if (ctx.session) {
      await ctx.session.destroy();
    }

    return new HttpResponseNoContent();
  }

}
```

## With cookies

**Before**
```typescript
import {
  dependency, Context, HttpResponseNoContent, Post,
  removeSessionCookie, Session, TokenRequired
} from '@foal/core';
import { TypeORMStore } from '@foal/typeorm';

export class AuthController {

  @dependency
  store: TypeORMStore;

  @Post('/logout')
  @TokenRequired({
    cookie: true,
    extendLifeTimeOrUpdate: false,
    store: TypeORMStore,
  })
  async logout(ctx: Context<any, Session>) {
    await this.store.destroy(ctx.session.sessionID);

    const response = new HttpResponseNoContent();
    removeSessionCookie(response);
    return response;
  }

}
```

**After**
```typescript
import {
  Context, HttpResponseNoContent, Post, TokenOptional
} from '@foal/core';
import { TypeORMStore } from '@foal/typeorm';

export class AuthController {

  @Post('/logout')
  @TokenOptional({
    cookie: true,
    store: TypeORMStore,
  })
  async logout(ctx: Context) {
    if (ctx.session) {
      await ctx.session.destroy();
    }

    return new HttpResponseNoContent();
  }

}
```

# Solution and steps

**Breaking change**: The `Session` know expects the store to be passed to the constructor upon instantiation.

- [x] Add `Session.store`.
- [x] Set `Session.store` with `this` in all the methods `read` and `createAndSaveSession` of all stores.
- [x] Add `Session.destroy` which calls `Store.destroy`.
- [x] Add the public property `Session.isDestroyed` and set it to `true` when `Session.destroy` is called.
- [x] In `@Token`, do not update the session or extend its lifetime if `session.isDestroyed` is `true`.
- [x] In `@Token`, remove the session cookie if `session.isDestroyed` is `true`.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
