### PR TITLE
Support other character encodings for JWT secrets

### DIFF
--- a/docs/authentication-and-access-control/jwt.md
+++ b/docs/authentication-and-access-control/jwt.md
@@ -350,7 +350,7 @@ In these cases, the two hooks `JWTRequired` and `JWTOptional` offer a `user` opt
 
 By default, UTF-8 is used to encode the secret string into bytes when verifying the token. However, you can use another character encoding with the `settings.jwt.secretEncoding` configuration key.
 
-Available encoding are listed [here](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings).
+Available encodings are listed [here](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings).
 
 {% code-tabs %}
 {% code-tabs-item title="YAML" %}

--- a/docs/authentication-and-access-control/jwt.md
+++ b/docs/authentication-and-access-control/jwt.md
@@ -346,6 +346,41 @@ In these cases, the two hooks `JWTRequired` and `JWTOptional` offer a `user` opt
   }
   ```
 
+## Specifying a Different Encoding for Secrets
+
+By default, UTF-8 is used to encode the secret string into bytes when verifying the token. However, you can use another character encoding with the `settings.jwt.secretEncoding` configuration key.
+
+Available encoding are listed [here](https://nodejs.org/api/buffer.html#buffer_buffers_and_character_encodings).
+
+{% code-tabs %}
+{% code-tabs-item title="YAML" %}
+```yaml
+settings:
+  jwt:
+    secretOrPublicKey: HEwh0TW7w6a5yUwIrpHilUqetAqTFAVSHx2rg6DWNtg=
+    secretEncoding: base64
+```
+{% endcode-tabs-item %}
+{% code-tabs-item title="JSON" %}
+```json
+{
+  "settings": {
+    "jwt": {
+      "secretOrPublicKey": "HEwh0TW7w6a5yUwIrpHilUqetAqTFAVSHx2rg6DWNtg=",
+      "secretEncoding": "base64",
+    }
+  }
+}
+```
+{% endcode-tabs-item %}
+{% code-tabs-item title=".env or environment variables" %}
+```
+SETTINGS_JWT_SECRET_OR_PUBLIC_KEY=HEwh0TW7w6a5yUwIrpHilUqetAqTFAVSHx2rg6DWNtg=
+SETTINGS_JWT_SECRET_ENCODING=base64
+```
+{% endcode-tabs-item %}
+{% endcode-tabs %}
+
 ## Store JWTs in a cookie
 
 > Be aware that if you use cookies, your application must provide a [CSRF defense](../security/csrf-protection.md).

--- a/packages/jwt/src/jwt.hook.ts
+++ b/packages/jwt/src/jwt.hook.ts
@@ -111,7 +111,7 @@ export function JWT(required: boolean, options: JWTOptions, verifyOptions: Verif
       return new InvalidTokenResponse('invalid token');
     }
 
-    let secretOrPublicKey: string;
+    let secretOrPublicKey: string|Buffer;
     if (options.secretOrPublicKey) {
       try {
         secretOrPublicKey = await options.secretOrPublicKey(decoded.header, decoded.payload);
@@ -127,6 +127,10 @@ export function JWT(required: boolean, options: JWTOptions, verifyOptions: Verif
         'string',
         'You must provide a secret or a RSA public key when using @JWTRequired or @JWTOptional.'
       );
+      const encoding = Config.get2('settings.jwt.secretEncoding', 'string');
+      if (encoding) {
+        secretOrPublicKey = Buffer.from(secretOrPublicKey, 'base64');
+      }
     }
 
     let payload: any;

--- a/packages/jwt/src/jwt.hook.ts
+++ b/packages/jwt/src/jwt.hook.ts
@@ -129,7 +129,7 @@ export function JWT(required: boolean, options: JWTOptions, verifyOptions: Verif
       );
       const encoding = Config.get2('settings.jwt.secretEncoding', 'string');
       if (encoding) {
-        secretOrPublicKey = Buffer.from(secretOrPublicKey, 'base64');
+        secretOrPublicKey = Buffer.from(secretOrPublicKey, encoding);
       }
     }
 


### PR DESCRIPTION
# Issue

Fixes #523 

# Solution and steps

- [x] Add the option `secretEncoding`.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
