### PR TITLE
Support service initialization (boot method) 

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -36,6 +36,7 @@
   * [Controllers](./architecture/controllers.md)
   * [Services & Dependency Injection](./architecture/services-and-dependency-injection.md)
   * [Hooks](./architecture/hooks.md)
+  * [Initialization](./architecture/initialization.md)
 * Databases
   * [TypeORM (SQL & noSQL)](./databases/typeorm.md)
   * [Create Models & Queries](./databases/create-models-and-queries.md)
@@ -87,7 +88,6 @@
   * [Templates (SSR)](./utilities/templating.md)
   * [Logging & Debugging](./utilities/logging-and-debugging.md)
 * Cookbook
-  * [Initialization](./cookbook/initialization.md)
   * [Error Handling](./cookbook/error-handling.md)
   * [Generate Tokens](./cookbook/generate-tokens.md)
   * [Scheduling Jobs](./cookbook/scheduling-jobs.md)

--- a/docs/architecture/initialization.md
+++ b/docs/architecture/initialization.md
@@ -2,7 +2,7 @@
 
 In many situations, we need to initialize the application (i.e perform certain actions) before listening to incoming HTTP requests. This is the case, for example, if you need to establish a connection to the database.
 
-There are two ways to achieve this in FoalTS.
+There are three ways to achieve this in FoalTS.
 
 ## The `main` function
 
@@ -72,6 +72,49 @@ async function main() {
 }
 
 main();
+```
+
+## The services `boot` method
+
+> `boot` methods are available in v1.8.0 onwards.
+
+Alternatively you can add a `boot` method in your services. This method can be synchronous or asynchronous.
+
+*Example*
+```typescript
+export class ServiceA {
+
+  async boot() {
+    await doSomething();
+  }
+
+}
+```
+
+Then, you have to call the `boot` method of your service manager (it will be automatically called starting from version 2).
+
+```typescript
+import { createAndInitApp } from '@foal/core';
+
+async function main() {
+  const serviceManager = new ServiceManager();
+  const app = createApp(AppController, {
+    serviceManager
+  });
+  // This line calls the `boot` method of all your services that have one.
+  await serviceManager.boot();
+
+  // ...
+}
+
+main();
+```
+
+If you manually inject services to your service manager and you want their `boot` methods to be called, you must specify this in the `set` method options.
+
+```typescript
+const serviceManager = new ServiceManager();
+serviceManager.set(ServiceA, myServiceInstance, { boot: true })
 ```
 
 ## Best Practices

--- a/packages/core/src/core/service-manager.spec.ts
+++ b/packages/core/src/core/service-manager.spec.ts
@@ -263,7 +263,7 @@ describe('ServiceManager', () => {
       }
     });
 
-    it('should not call the "boot" method of instances which are not FoalTS services.', async () => {
+    it('should not call by default the "boot" method of instances injected manually.', async () => {
       let called = false;
       class Service {
         boot() {
@@ -279,7 +279,7 @@ describe('ServiceManager', () => {
       const serviceManager = new ServiceManager();
       serviceManager.set(Connection, new Connection());
       // This line tests the options in the "set" method.
-      serviceManager.set(Service, new Service(), { service: true });
+      serviceManager.set(Service, new Service(), { boot: true });
 
       await serviceManager.boot();
       strictEqual(called, true);

--- a/packages/core/src/core/service-manager.spec.ts
+++ b/packages/core/src/core/service-manager.spec.ts
@@ -2,7 +2,7 @@
 import { deepStrictEqual, notStrictEqual, ok, strictEqual } from 'assert';
 
 // FoalTS
-import { createService, dependency, Dependency, ServiceManager } from './service-manager';
+import { createService, dependency, Dependency, IDependency, ServiceManager } from './service-manager';
 
 describe('dependency', () => {
 
@@ -26,7 +26,7 @@ describe('dependency', () => {
       myService3: MyService3;
     }
 
-    const expectedDependenciesA: Dependency[] = [
+    const expectedDependenciesA: IDependency[] = [
       { propertyKey: 'myService1', serviceClass: MyService1 },
       { propertyKey: 'myService2', serviceClass: MyService2 },
     ];
@@ -34,7 +34,7 @@ describe('dependency', () => {
 
     deepStrictEqual(actualDependenciesA, expectedDependenciesA);
 
-    const expectedDependenciesB: Dependency[] = [
+    const expectedDependenciesB: IDependency[] = [
       { propertyKey: 'myService1', serviceClass: MyService1 },
       { propertyKey: 'myService3', serviceClass: MyService3 },
     ];
@@ -67,7 +67,7 @@ describe('Dependency', () => {
       myService3: MyService3;
     }
 
-    const expectedDependenciesA: Dependency[] = [
+    const expectedDependenciesA: IDependency[] = [
       { propertyKey: 'myService1', serviceClass: 'service 1' },
       { propertyKey: 'myService2', serviceClass: 'service 2' },
     ];
@@ -75,7 +75,7 @@ describe('Dependency', () => {
 
     deepStrictEqual(actualDependenciesA, expectedDependenciesA);
 
-    const expectedDependenciesB: Dependency[] = [
+    const expectedDependenciesB: IDependency[] = [
       { propertyKey: 'myService1', serviceClass: 'service 1' },
       { propertyKey: 'myService3', serviceClass: 'service 3' },
     ];

--- a/packages/core/src/core/service-manager.ts
+++ b/packages/core/src/core/service-manager.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 
 import { Class } from './class.interface';
 
-export interface Dependency {
+export interface IDependency {
   propertyKey: string;
   // Service class or service ID.
   serviceClass: string|Class;
@@ -15,7 +15,7 @@ export interface Dependency {
  */
 export function Dependency(id: string) {
   return (target: any, propertyKey: string) => {
-    const dependencies: Dependency[] = [ ...(Reflect.getMetadata('dependencies', target) || []) ];
+    const dependencies: IDependency[] = [ ...(Reflect.getMetadata('dependencies', target) || []) ];
     dependencies.push({ propertyKey, serviceClass: id });
     Reflect.defineMetadata('dependencies', dependencies, target);
   };
@@ -28,7 +28,7 @@ export function Dependency(id: string) {
  */
 export function dependency(target: any, propertyKey: string) {
   const serviceClass = Reflect.getMetadata('design:type', target, propertyKey);
-  const dependencies: Dependency[] = [ ...(Reflect.getMetadata('dependencies', target) || []) ];
+  const dependencies: IDependency[] = [ ...(Reflect.getMetadata('dependencies', target) || []) ];
   dependencies.push({ propertyKey, serviceClass });
   Reflect.defineMetadata('dependencies', dependencies, target);
 }
@@ -48,7 +48,7 @@ export function createService<Service>(serviceClass: Class<Service>, dependencie
 }
 
 export function createControllerOrService<T>(serviceClass: Class<T>, dependencies?: object|ServiceManager): T {
-  const metadata: Dependency[] = Reflect.getMetadata('dependencies', serviceClass.prototype) || [];
+  const metadata: IDependency[] = Reflect.getMetadata('dependencies', serviceClass.prototype) || [];
 
   let serviceManager = new ServiceManager();
 
@@ -108,6 +108,8 @@ export class ServiceManager {
    *
    * @param {string|Class} identifier - The service ID or the service class.
    * @param {*} service - The service object (or mock).
+   * @param {{ boot: boolean }} [options={ boot: false }] If `boot` is true, the service method "boot"
+   * will be executed when calling `ServiceManager.boot` is called.
    * @returns {this} The service manager.
    * @memberof ServiceManager
    */
@@ -147,7 +149,7 @@ export class ServiceManager {
     }
 
     // If the service has not been instantiated yet then do it.
-    const dependencies: Dependency[] = Reflect.getMetadata('dependencies', identifier.prototype) || [];
+    const dependencies: IDependency[] = Reflect.getMetadata('dependencies', identifier.prototype) || [];
 
     // identifier is a class here.
     const service = new identifier();


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Resolves #628 

# Solution and steps

- [x] Add `ServiceManager.boot` (no parameters) to init all services with a `boot` method.
- [x] Allow to optionally boot services injected manually.
- [x] Add an optional parameter to `ServiceManager.boot` to init only one specific service.


# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
