### PR TITLE
Fix @types/express types problems

### DIFF
--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -2,7 +2,7 @@ mkdir e2e-test-temp
 cd e2e-test-temp
 
 # Test app creation
-foal createapp my-app
+foal createapp my-app || exit 1
 cd my-app
 
 # Check some compilation errors
@@ -12,35 +12,35 @@ if grep -Ril "../../Users/loicp" .; then
 fi
 
 # Test the generators
-foal g entity flight
-foal g hook foo-bar
-foal g service foo
-foal g controller bar --register
-foal g rest-api product --register
-foal g sub-app bar-foo
-foal g script bar-script
+foal g entity flight || exit 1
+foal g hook foo-bar || exit 1
+foal g service foo || exit 1
+foal g controller bar --register || exit 1
+foal g rest-api product --register || exit 1
+foal g sub-app bar-foo || exit 1
+foal g script bar-script || exit 1
 
 # Test linting
-npm run lint
+npm run lint || exit 1
 
 # Build and run the unit tests
-npm run build:test
-npm run start:test
+npm run build:test || exit 1
+npm run start:test || exit 1
 
 # Build the app
-npm run build:app
+npm run build:app || exit 1
 
 # Build and run the migrations
-npm run migration:generate -- -n my-migration
-npm run build:migrations
-npm run migration:run
+npm run migration:generate -- -n my-migration || exit 1
+npm run build:migrations || exit 1
+npm run migration:run || exit 1
 
 # Build and run the e2e tests
-npm run build:e2e
-npm run start:e2e
+npm run build:e2e || exit 1
+npm run start:e2e || exit 1
 
 # Test the application when it is started
-pm2 start build/index.js
+pm2 start build/index.js || exit 1
 sleep 1
 response=$(
     curl http://localhost:3001 \
@@ -114,12 +114,12 @@ test_rest_api DELETE "http://localhost:3001/products/1" 204
 test_rest_api DELETE "http://localhost:3001/products/1" 404
 test_rest_api DELETE "http://localhost:3001/products/ab" 400
 
-pm2 delete index
+pm2 delete index || exit 1
 
 # Test the default shell scripts to create permissions, groups and users.
-npm run build:scripts
+npm run build:scripts || exit 1
 
-foal run create-user
+foal run create-user || exit 1
 
 #################################################################
 # Repeat (almost) the same tests with a Mongoose and YAML project
@@ -128,7 +128,7 @@ foal run create-user
 cd ..
 
 # Test app creation
-foal createapp my-mongodb-app --mongodb --yaml
+foal createapp my-mongodb-app --mongodb --yaml || exit 1
 cd my-mongodb-app
 
 # Check some compilation errors
@@ -138,24 +138,24 @@ if grep -Ril "../../Users/loicp" .; then
 fi
 
 # Test the generators
-foal g model flight
+foal g model flight || exit 1
 
 # Test linting
-npm run lint
+npm run lint || exit 1
 
 # Build and run the unit tests
-npm run build:test
-npm run start:test
+npm run build:test || exit 1
+npm run start:test || exit 1
 
 # Build the app
-npm run build:app
+npm run build:app || exit 1
 
 # Build and run the e2e tests
-npm run build:e2e
-npm run start:e2e
+npm run build:e2e || exit 1
+npm run start:e2e || exit 1
 
 # Test the application when it is started
-PORT=3001 pm2 start build/index.js
+PORT=3001 pm2 start build/index.js || exit 1
 sleep 1
 response=$(
     curl http://localhost:3001 \
@@ -165,8 +165,8 @@ response=$(
 )
 test "$response" -ge 200 && test "$response" -le 299
 
-pm2 delete index
+pm2 delete index || exit 1
 
 # Test the default shell scripts to create users.
-npm run build:scripts
-foal run create-user
+npm run build:scripts || exit 1
+foal run create-user || exit 1

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -130,37 +130,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@types/body-parser": {
-			"version": "1.17.1",
-			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
-			"integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
-			"requires": {
-				"@types/connect": "*",
-				"@types/node": "*"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "12.12.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-					"integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA=="
-				}
-			}
-		},
-		"@types/connect": {
-			"version": "3.4.32",
-			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
-			"integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
-			"requires": {
-				"@types/node": "*"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "12.12.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-					"integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA=="
-				}
-			}
-		},
 		"@types/cookiejar": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.1.tgz",
@@ -173,16 +142,6 @@
 			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
 			"dev": true
 		},
-		"@types/express": {
-			"version": "4.17.2",
-			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.2.tgz",
-			"integrity": "sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==",
-			"requires": {
-				"@types/body-parser": "*",
-				"@types/express-serve-static-core": "*",
-				"@types/serve-static": "*"
-			}
-		},
 		"@types/express-serve-static-core": {
 			"version": "4.17.0",
 			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.0.tgz",
@@ -190,13 +149,6 @@
 			"requires": {
 				"@types/node": "*",
 				"@types/range-parser": "*"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "12.12.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-					"integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA=="
-				}
 			}
 		},
 		"@types/fs-extra": {
@@ -246,11 +198,6 @@
 			"integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
 			"dev": true
 		},
-		"@types/mime": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-			"integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
-		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -266,22 +213,12 @@
 		"@types/node": {
 			"version": "10.1.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.4.tgz",
-			"integrity": "sha512-GpQxofkdlHYxjHad98UUdNoMO7JrmzQZoAaghtNg14Gwg7YkohcrCoJEcEMSgllx4VIZ+mYw7ZHjfaeIagP/rg==",
-			"dev": true
+			"integrity": "sha512-GpQxofkdlHYxjHad98UUdNoMO7JrmzQZoAaghtNg14Gwg7YkohcrCoJEcEMSgllx4VIZ+mYw7ZHjfaeIagP/rg=="
 		},
 		"@types/range-parser": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
 			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
-		},
-		"@types/serve-static": {
-			"version": "1.13.3",
-			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
-			"integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
-			"requires": {
-				"@types/express-serve-static-core": "*",
-				"@types/mime": "*"
-			}
 		},
 		"@types/shelljs": {
 			"version": "0.8.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,7 @@
     "all": true
   },
   "dependencies": {
-    "@types/express": "~4.17.2",
+    "@types/express-serve-static-core": "4.17.0",
     "ajv": "~6.12.0",
     "cookie-parser": "~1.4.4",
     "express": "~4.17.1",

--- a/packages/core/src/core/http/contexts.ts
+++ b/packages/core/src/core/http/contexts.ts
@@ -1,4 +1,4 @@
-import { Request } from 'express';
+import { Request } from 'express-serve-static-core';
 import { Session } from '../../sessions';
 
 /**

--- a/packages/core/src/core/http/mime.d.ts
+++ b/packages/core/src/core/http/mime.d.ts
@@ -1,0 +1,3 @@
+declare module 'mime' {
+  export function getType(path: string): string | null;
+}

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -4,6 +4,11 @@ import { Buffer } from 'buffer';
 
 // 3p
 import * as express from 'express';
+import {
+  NextFunction,
+  Request,
+  Response
+} from 'express-serve-static-core';
 import * as request from 'supertest';
 
 // FoalTS
@@ -304,7 +309,7 @@ describe('createApp', () => {
 
     const app = createApp(AppController, {
       preMiddlewares: [
-        (req: express.Request, res: express.Response, next: express.NextFunction) => {
+        (req: Request, res: Response, next: NextFunction) => {
           (req as any).foalMessage = 'Hello world!'; next();
         }
       ]

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -1,6 +1,14 @@
 // 3p
 import * as cookieParser from 'cookie-parser';
 import * as express from 'express';
+import {
+  ErrorRequestHandler,
+  Express,
+  NextFunction,
+  Request,
+  RequestHandler,
+  Response
+} from 'express-serve-static-core';
 import * as logger from 'morgan';
 
 // FoalTS
@@ -14,7 +22,7 @@ import { createMiddleware } from './create-middleware';
 import { handleErrors } from './handle-errors';
 import { notFound } from './not-found';
 
-export interface ExpressApplication extends express.Express {
+export interface ExpressApplication extends Express {
   [name: string]: any;
 }
 
@@ -24,11 +32,11 @@ export interface CreateAppOptions {
     handleError?: boolean;
   };
   serviceManager?: ServiceManager;
-  preMiddlewares?: (express.RequestHandler | express.ErrorRequestHandler)[];
-  postMiddlewares?: (express.RequestHandler | express.ErrorRequestHandler)[];
+  preMiddlewares?: (RequestHandler | ErrorRequestHandler)[];
+  postMiddlewares?: (RequestHandler | ErrorRequestHandler)[];
 }
 
-function handleJsonErrors(err: any, req: express.Request, res: express.Response, next: express.NextFunction) {
+function handleJsonErrors(err: any, req: Request, res: Response, next: NextFunction) {
   if (err.type !== 'entity.parse.failed') {
     next(err);
     return;
@@ -39,7 +47,7 @@ function handleJsonErrors(err: any, req: express.Request, res: express.Response,
   });
 }
 
-function protectionHeaders(req: express.Request, res: express.Response, next: express.NextFunction) {
+function protectionHeaders(req: Request, res: Response, next: NextFunction) {
   res.removeHeader('X-Powered-By');
   res.setHeader('X-Content-Type-Options', 'nosniff');
   res.setHeader('X-DNS-Prefetch-Control', 'off');
@@ -75,9 +83,9 @@ function getOptions(expressInstanceOrOptions?: ExpressApplication|CreateAppOptio
  * used to handle errors.
  * @param {ServiceManager} [expressInstanceOrOptions.serviceManager] - Prebuilt and configured Service Manager for
  * optionally overriding the mapped identities.
- * @param {(express.RequestHandler | express.ErrorRequestHandler)[]} [expressInstanceOrOptions.preMiddlewares] Express
+ * @param {(RequestHandler | ErrorRequestHandler)[]} [expressInstanceOrOptions.preMiddlewares] Express
  * middlewares to be executed before the controllers and hooks.
- * @param {(express.RequestHandler | express.ErrorRequestHandler)[]} [expressInstanceOrOptions.postMiddlewares] Express
+ * @param {(RequestHandler | ErrorRequestHandler)[]} [expressInstanceOrOptions.postMiddlewares] Express
  * middlewares to be executed after the controllers and hooks, but before the 500 or 404 handler get called.
  * @returns {ExpressApplication} The express application.
  */
@@ -157,9 +165,9 @@ export function createApp(
  * used to handle errors.
  * @param {ServiceManager} [expressInstanceOrOptions.serviceManager] - Prebuilt and configured Service Manager for
  * optionally overriding the mapped identities.
- * @param {(express.RequestHandler | express.ErrorRequestHandler)[]} [expressInstanceOrOptions.preMiddlewares] Express
+ * @param {(RequestHandler | ErrorRequestHandler)[]} [expressInstanceOrOptions.preMiddlewares] Express
  * middlewares to be executed before the controllers and hooks.
- * @param {(express.RequestHandler | express.ErrorRequestHandler)[]} [expressInstanceOrOptions.postMiddlewares] Express
+ * @param {(RequestHandler | ErrorRequestHandler)[]} [expressInstanceOrOptions.postMiddlewares] Express
  * middlewares to be executed after the controllers and hooks, but before the 500 or 404 handler get called.
  * @returns {Promise<ExpressApplication>} The express application.
  */

--- a/packages/core/src/express/create-middleware.spec.ts
+++ b/packages/core/src/express/create-middleware.spec.ts
@@ -3,6 +3,11 @@ import { deepStrictEqual, ok, strictEqual } from 'assert';
 
 // 3p
 import * as express from 'express';
+import {
+  NextFunction,
+  Request,
+  Response
+} from 'express-serve-static-core';
 import { createRequest, createResponse } from 'node-mocks-http';
 import * as request from 'supertest';
 
@@ -164,7 +169,7 @@ describe('createMiddleware', () => {
       it('should forward an Error to the next error-handling middleware.', done => {
         const app = express();
         app.get('/a', createMiddleware(route(() => ({})), new ServiceManager()));
-        app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+        app.use((err: any, req: Request, res: Response, next: NextFunction) => {
           try {
             ok(err instanceof Error);
             strictEqual(err.message, 'The controller method "fn" should return an HttpResponse.');
@@ -190,7 +195,7 @@ describe('createMiddleware', () => {
         path: '',
         propertyKey: 'bar'
       }, new ServiceManager()));
-      app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+      app.use((err: any, req: Request, res: Response, next: NextFunction) => {
         try {
           ok(err instanceof Error);
           strictEqual(err.message, 'Error thrown in a hook.');
@@ -210,7 +215,7 @@ describe('createMiddleware', () => {
           route(() => { throw new Error('Error thrown in a controller method.'); }),
           new ServiceManager())
         );
-        app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+        app.use((err: any, req: Request, res: Response, next: NextFunction) => {
           try {
             ok(err instanceof Error);
             strictEqual(err.message, 'Error thrown in a controller method.');
@@ -234,7 +239,7 @@ describe('createMiddleware', () => {
         path: '',
         propertyKey: 'bar'
       }, new ServiceManager()));
-      app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+      app.use((err: any, req: Request, res: Response, next: NextFunction) => {
         try {
           ok(err instanceof Error);
           strictEqual(err.message, 'Error rejected in a hook.');
@@ -254,7 +259,7 @@ describe('createMiddleware', () => {
           route(async () => { throw new Error('Error rejected in a controller method.'); }),
           new ServiceManager())
         );
-        app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+        app.use((err: any, req: Request, res: Response, next: NextFunction) => {
           try {
             ok(err instanceof Error);
             strictEqual(err.message, 'Error rejected in a controller method.');

--- a/packages/core/src/express/create-middleware.ts
+++ b/packages/core/src/express/create-middleware.ts
@@ -1,5 +1,5 @@
 // 3p
-import { RequestHandler } from 'express';
+import { RequestHandler } from 'express-serve-static-core';
 
 // FoalTS
 import {

--- a/packages/core/src/express/express.d.ts
+++ b/packages/core/src/express/express.d.ts
@@ -1,0 +1,49 @@
+declare module 'express' {
+  import { Express, RequestHandler, Response } from 'express-serve-static-core';
+
+  function express(): Express;
+
+  namespace express {
+
+    function json(options?: {
+      strict?: boolean;
+      inflate?: boolean;
+      limit?: number | string;
+      type?: string | string[] | ((req: any) => any);
+      reviver?(key: string, value: any): any;
+      verify?(req: any, res: any, buf: Buffer, encoding: string): void;
+    }): RequestHandler;
+
+    function text(options?: {
+      defaultCharset?: string;
+      inflate?: boolean;
+      limit?: number | string;
+      type?: string | string[] | ((req: any) => any);
+      verify?(req: any, res: any, buf: Buffer, encoding: string): void;
+    }): RequestHandler;
+
+    function urlencoded(options?: {
+      extended?: boolean;
+      parameterLimit?: number;
+      inflate?: boolean;
+      limit?: number | string;
+      type?: string | string[] | ((req: any) => any);
+      verify?(req: any, res: any, buf: Buffer, encoding: string): void;
+    }): RequestHandler;
+
+    function static(root: string, options?: {
+      cacheControl?: boolean;
+      dotfiles?: string;
+      etag?: boolean;
+      extensions?: string[];
+      fallthrough?: boolean;
+      immutable?: boolean;
+      index?: boolean | string | string[];
+      lastModified?: boolean;
+      maxAge?: number | string;
+      redirect?: boolean;
+      setHeaders?: (res: Response, path: string, stat: any) => any;
+    }): RequestHandler;
+  }
+  export = express;
+}

--- a/packages/core/src/express/express.d.ts
+++ b/packages/core/src/express/express.d.ts
@@ -1,9 +1,14 @@
 declare module 'express' {
-  import { Express, RequestHandler, Response } from 'express-serve-static-core';
+  import { Express, RequestHandler, Response, Router as IRouter } from 'express-serve-static-core';
 
   function express(): Express;
 
   namespace express {
+    function Router(options?: {
+      caseSensitive?: boolean;
+      mergeParams?: boolean;
+      strict?: boolean;
+    }): IRouter;
 
     function json(options?: {
       strict?: boolean;

--- a/packages/core/src/express/handle-errors.ts
+++ b/packages/core/src/express/handle-errors.ts
@@ -1,5 +1,5 @@
 // 3p
-import { ErrorRequestHandler } from 'express';
+import { ErrorRequestHandler } from 'express-serve-static-core';
 
 // FoalTS
 import { renderError } from '../common';

--- a/packages/core/src/express/not-found.ts
+++ b/packages/core/src/express/not-found.ts
@@ -1,4 +1,4 @@
-import { RequestHandler } from 'express';
+import { RequestHandler } from 'express-serve-static-core';
 
 const page404 = '<html><head><title>PAGE NOT FOUND</title></head><body><h1>404 - PAGE NOT FOUND</h1></body></html>';
 

--- a/packages/core/src/express/send-response.ts
+++ b/packages/core/src/express/send-response.ts
@@ -1,5 +1,5 @@
 // 3p
-import { Response } from 'express';
+import { Response } from 'express-serve-static-core';
 import * as pump from 'pump';
 
 // FoalTS


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Fixes #683 

Some changes have been brought in a *patch* version to `@types/express` causing some parts of the framework to break (i.e. `foal g rest-api`).

This is not the first time it happens, so the idea is to fix `@types/express` to a specific version.

Unfortunately, this cannot be done because `@types/express` requires version `*` of `@types/express-serve-static-core`. So going back to an old version of `@types/express` cannot work.

So we have to use `@types/express-serve-static-core` directly.

# Solution and steps

- [x] Make the bash test fail if a line fails.
- [x] Use `@types/express-serve-static-core` instead of `@types/express`.
- [x] Fix `@types/express-serve-static-core` to `v4.17.0`

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
