### PR TITLE
Remove mongoose types

### DIFF
--- a/packages/cli/src/generate/generators/model/create-model.spec.ts
+++ b/packages/cli/src/generate/generators/model/create-model.spec.ts
@@ -42,13 +42,6 @@ describe('createModel', () => {
         createModel({ name: 'test-fooBar' });
       });
 
-      it('should should order the export in index.ts.', () => {
-        createModel({ name: 'a-test-fooBar' });
-
-        testEnv
-          .validateSpec('index.sorted.ts', 'index.ts');
-      });
-
     });
 
   }

--- a/packages/cli/src/generate/generators/model/create-model.ts
+++ b/packages/cli/src/generate/generators/model/create-model.ts
@@ -35,8 +35,7 @@ export function createModel({ name, checkMongoose }: { name: string, checkMongoo
   new Generator('model', root)
     .renderTemplate('model.ts', names, `${names.kebabName}.model.ts`)
     .updateFile('index.ts', content => {
-      const exportNames = [ `I${names.upperFirstCamelName}`, names.upperFirstCamelName ].sort();
-      content += `export { ${exportNames.join(', ')} } from './${names.kebabName}.model';\n`;
+      content += `export { ${names.upperFirstCamelName} } from './${names.kebabName}.model';\n`;
       return content;
     }, { allowFailure: true });
 }

--- a/packages/cli/src/generate/specs/app/package.mongodb.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@types/mocha": "^5.2.1",
-    "@types/mongoose": "^5.3.12",
     "@types/node": "^8.0.47",
     "concurrently": "^3.5.1",
     "copy": "^0.3.2",

--- a/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@types/mocha": "^5.2.1",
-    "@types/mongoose": "^5.3.12",
     "@types/node": "^8.0.47",
     "concurrently": "^3.5.1",
     "copy": "^0.3.2",

--- a/packages/cli/src/generate/specs/app/src/app/models/index.ts
+++ b/packages/cli/src/generate/specs/app/src/app/models/index.ts
@@ -1,1 +1,1 @@
-export { IUser, User } from './user.model';
+export { User } from './user.model';

--- a/packages/cli/src/generate/specs/app/src/app/models/user.model.ts
+++ b/packages/cli/src/generate/specs/app/src/app/models/user.model.ts
@@ -1,5 +1,5 @@
 // import { hashPassword } from '@foal/core';
-import { Document, model, Model, models, Schema } from 'mongoose';
+import { model, models, Schema } from 'mongoose';
 
 const userSchema: Schema = new Schema({
   // email: {
@@ -17,10 +17,4 @@ const userSchema: Schema = new Schema({
 //   this.password = await hashPassword(password);
 // };
 
-export interface IUser extends Document {
-  email: string;
-  password: string;
-  // setPassword: (password: string) => Promise<void>;
-}
-
-export const User: Model<IUser> = models.User || model<IUser>('User', userSchema);
+export const User = models.User || model('User', userSchema);

--- a/packages/cli/src/generate/specs/model/index.sorted.ts
+++ b/packages/cli/src/generate/specs/model/index.sorted.ts
@@ -1,2 +1,0 @@
-export { BarFoo } from './bar-foo.model';
-export { ATestFooBar, IATestFooBar } from './a-test-foo-bar.model';

--- a/packages/cli/src/generate/specs/model/index.ts
+++ b/packages/cli/src/generate/specs/model/index.ts
@@ -1,2 +1,2 @@
 export { BarFoo } from './bar-foo.model';
-export { ITestFooBar, TestFooBar } from './test-foo-bar.model';
+export { TestFooBar } from './test-foo-bar.model';

--- a/packages/cli/src/generate/specs/model/test-foo-bar.model.ts
+++ b/packages/cli/src/generate/specs/model/test-foo-bar.model.ts
@@ -1,11 +1,7 @@
-import { Document, model, Model, models, Schema } from 'mongoose';
+import { model, models, Schema } from 'mongoose';
 
 const testFooBarSchema: Schema = new Schema({
 
 });
 
-export interface ITestFooBar extends Document {
-
-}
-
-export const TestFooBar: Model<ITestFooBar> = models.TestFooBar || model<ITestFooBar>('TestFooBar', testFooBarSchema);
+export const TestFooBar = models.TestFooBar || model('TestFooBar', testFooBarSchema);

--- a/packages/cli/src/generate/templates/app/package.mongodb.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.json
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@types/mocha": "^5.2.1",
-    "@types/mongoose": "^5.3.12",
     "@types/node": "^8.0.47",
     "concurrently": "^3.5.1",
     "copy": "^0.3.2",

--- a/packages/cli/src/generate/templates/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.yaml.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@types/mocha": "^5.2.1",
-    "@types/mongoose": "^5.3.12",
     "@types/node": "^8.0.47",
     "concurrently": "^3.5.1",
     "copy": "^0.3.2",

--- a/packages/cli/src/generate/templates/app/src/app/models/index.ts
+++ b/packages/cli/src/generate/templates/app/src/app/models/index.ts
@@ -1,1 +1,1 @@
-export { IUser, User } from './user.model';
+export { User } from './user.model';

--- a/packages/cli/src/generate/templates/app/src/app/models/user.model.ts
+++ b/packages/cli/src/generate/templates/app/src/app/models/user.model.ts
@@ -1,5 +1,5 @@
 // import { hashPassword } from '@foal/core';
-import { Document, model, Model, models, Schema } from 'mongoose';
+import { model, models, Schema } from 'mongoose';
 
 const userSchema: Schema = new Schema({
   // email: {
@@ -17,10 +17,4 @@ const userSchema: Schema = new Schema({
 //   this.password = await hashPassword(password);
 // };
 
-export interface IUser extends Document {
-  email: string;
-  password: string;
-  // setPassword: (password: string) => Promise<void>;
-}
-
-export const User: Model<IUser> = models.User || model<IUser>('User', userSchema);
+export const User = models.User || model('User', userSchema);

--- a/packages/cli/src/generate/templates/model/model.ts
+++ b/packages/cli/src/generate/templates/model/model.ts
@@ -1,11 +1,7 @@
-import { Document, model, Model, models, Schema } from 'mongoose';
+import { model, models, Schema } from 'mongoose';
 
 const /* camelName */Schema: Schema = new Schema({
 
 });
 
-export interface I/* upperFirstCamelName */ extends Document {
-
-}
-
-export const /* upperFirstCamelName */: Model<I/* upperFirstCamelName */> = models./* upperFirstCamelName */ || model<I/* upperFirstCamelName */>('/* upperFirstCamelName */', /* camelName */Schema);
+export const /* upperFirstCamelName */ = models./* upperFirstCamelName */ || model('/* upperFirstCamelName */', /* camelName */Schema);

--- a/packages/mongodb/package-lock.json
+++ b/packages/mongodb/package-lock.json
@@ -4,15 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@types/bson": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.1.tgz",
-			"integrity": "sha512-K6VAEdLVJFBxKp8m5cRTbUfeZpuSvOuLKJLrgw9ANIXo00RiyGzgH4BKWWR4F520gV4tWmxG7q9sKQRVDuzrBw==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -77,16 +68,6 @@
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
 			"integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
 			"dev": true
-		},
-		"@types/mongodb": {
-			"version": "3.1.31",
-			"resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.1.31.tgz",
-			"integrity": "sha512-0l6z2ARkyAkgdtzF/Hqx3cRoADDQK/7VHvESikhLXjanSpIo1EJt2JL4NpM+jIqLWzn5P1IxRBSIIOqs5ZKBOQ==",
-			"dev": true,
-			"requires": {
-				"@types/bson": "*",
-				"@types/node": "*"
-			}
 		},
 		"@types/node": {
 			"version": "10.5.8",

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -51,7 +51,6 @@
   },
   "devDependencies": {
     "@types/mocha": "~2.2.43",
-    "@types/mongodb": "3.1.31",
     "@types/node": "~10.5.6",
     "copy": "~0.3.2",
     "mocha": "~5.2.0",

--- a/packages/mongodb/src/mongodb-store.service.spec.ts
+++ b/packages/mongodb/src/mongodb-store.service.spec.ts
@@ -19,7 +19,7 @@ describe('MongoDBStore', () => {
   const MONGODB_URI = 'mongodb://localhost:27017/db';
 
   let store: MongoDBStore;
-  let mongoDBClient: MongoClient;
+  let mongoDBClient: any;
 
   async function insertSessionIntoDB(session: PlainSession): Promise<PlainSession> {
     await mongoDBClient.db().collection('foalSessions').insertOne(session);

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -1,5 +1,5 @@
 import { Config, Session, SessionOptions, SessionStore } from '@foal/core';
-import { Collection, MongoClient } from 'mongodb';
+import { MongoClient } from 'mongodb';
 
 export interface DatabaseSession {
   _id: string;
@@ -17,7 +17,7 @@ export interface DatabaseSession {
  */
 export class MongoDBStore extends SessionStore {
 
-  private mongoDBClient: MongoClient;
+  private mongoDBClient: any;
 
   async createAndSaveSession(sessionContent: object, options: SessionOptions = {}): Promise<Session> {
     const sessionID = await this.generateSessionID();
@@ -100,7 +100,7 @@ export class MongoDBStore extends SessionStore {
     });
   }
 
-  async getMongoDBInstance(): Promise<MongoClient> {
+  async getMongoDBInstance(): Promise<any> {
     if (!this.mongoDBClient) {
       const mongoDBURI = Config.getOrThrow(
         'mongodb.uri',
@@ -112,7 +112,7 @@ export class MongoDBStore extends SessionStore {
     return this.mongoDBClient;
   }
 
-  private async getSessionCollection(): Promise<Collection> {
+  private async getSessionCollection(): Promise<any> {
     const mongoClient = await this.getMongoDBInstance();
     return mongoClient.db().collection('foalSessions');
   }

--- a/packages/mongodb/src/mongodb.d.ts
+++ b/packages/mongodb/src/mongodb.d.ts
@@ -1,0 +1,1 @@
+declare module 'mongodb';

--- a/packages/mongoose/package-lock.json
+++ b/packages/mongoose/package-lock.json
@@ -4,21 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@types/bson": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.1.tgz",
-			"integrity": "sha512-K6VAEdLVJFBxKp8m5cRTbUfeZpuSvOuLKJLrgw9ANIXo00RiyGzgH4BKWWR4F520gV4tWmxG7q9sKQRVDuzrBw==",
-			"requires": {
-				"@types/node": "*"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "12.12.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-					"integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA=="
-				}
-			}
-		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -83,38 +68,6 @@
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
 			"integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
 			"dev": true
-		},
-		"@types/mongodb": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.3.11.tgz",
-			"integrity": "sha512-i8mUMYzFYzUpH4a7IBbdOD/87/kyQHvOVAL8J8hvX+E6SQbPd83d+xkpPtRZlRELtjZFqyQMlEcxW+zfMw32vQ==",
-			"requires": {
-				"@types/bson": "*",
-				"@types/node": "*"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "12.12.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-					"integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA=="
-				}
-			}
-		},
-		"@types/mongoose": {
-			"version": "5.5.32",
-			"resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.5.32.tgz",
-			"integrity": "sha512-2BemWy7SynT87deweqc2eCzg6pRyTVlnnMat2JxsTNoyeSFKC27b19qBTeKRfBVt+SjtaWd/ud4faUaObONwBA==",
-			"requires": {
-				"@types/mongodb": "*",
-				"@types/node": "*"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "12.12.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-					"integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA=="
-				}
-			}
 		},
 		"@types/node": {
 			"version": "10.5.8",

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -44,9 +44,6 @@
   "files": [
     "lib/"
   ],
-  "dependencies": {
-    "@types/mongoose": "~5.5.32"
-  },
   "peerDependencies": {
     "mongoose": "^5.4.9"
   },

--- a/packages/mongoose/src/utils/fetch-user.util.spec.ts
+++ b/packages/mongoose/src/utils/fetch-user.util.spec.ts
@@ -2,32 +2,28 @@
 import { notStrictEqual, strictEqual } from 'assert';
 
 // 3p
-import { connect, disconnect, Document, Model, model, Schema } from 'mongoose';
+
+import { connect, disconnect, model, Schema } from 'mongoose';
 
 // FoalTS
 import { fetchUser } from './fetch-user.util';
 
 describe('fetchUser', () => {
 
-  const UserSchema: Schema = new Schema({
+  const UserSchema = new Schema({
     name: {
       type: String
     }
   });
 
-  interface IUser extends Document {
-    name: string;
-  }
-
-  const User: Model<IUser> = model<IUser>('User', UserSchema);
-
-  let user: IUser;
+  let user: any;
+  const User = model('User', UserSchema);
 
   before(async () => {
     await connect('mongodb://localhost:27017/test_db', { useNewUrlParser: true });
 
     await new Promise((resolve, reject) => {
-      User.deleteMany({}, err => err ? reject(err) : resolve());
+      User.deleteMany({}, (err: any) => err ? reject(err) : resolve());
     });
 
     user = new User({ name: 'Alex' });
@@ -39,7 +35,7 @@ describe('fetchUser', () => {
   it('should return the user fetched from the database.', async () => {
     const actual = await fetchUser(User)(user._id.toString());
     notStrictEqual(actual, undefined);
-    strictEqual(user._id.equals((actual as IUser)._id), true);
+    strictEqual(user._id.equals(actual._id), true);
   });
 
   it('should return undefined if no user is found in the database.', async () => {

--- a/packages/mongoose/src/utils/fetch-user.util.ts
+++ b/packages/mongoose/src/utils/fetch-user.util.ts
@@ -1,6 +1,3 @@
-// 3p
-import { Model } from 'mongoose';
-
 /**
  * Create a function that finds the first document that matches some id.
  *
@@ -13,13 +10,13 @@ import { Model } from 'mongoose';
  * - JWTOptional (@foal/jwt)
  *
  * @export
- * @param {Model<any>} userModel - The Mongoose Model
+ * @param {any} userModel - The Mongoose Model
  * @returns {((id: number|string) => Promise<any>)} The returned function expecting an id.
  */
-export function fetchUser(userModel: Model<any>): (id: number|string) => Promise<any> {
+export function fetchUser(userModel: any): (id: number|string) => Promise<any> {
   return (id: number|string) => {
     return new Promise((resolve, reject) => {
-      userModel.findOne({ _id: id }, (err: any, res: Model<any>|null) => {
+      userModel.findOne({ _id: id }, (err: any, res: any) => {
         if (err) {
           reject(err);
           return;

--- a/packages/mongoose/src/utils/mongoose.d.ts
+++ b/packages/mongoose/src/utils/mongoose.d.ts
@@ -1,0 +1,1 @@
+declare module 'mongoose';


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Fixes #687.

A recent change on the `@types/mongodb` package made the build to fail. We had a lot of these issues in the past with different `@types` packages.

To fix this, `@types/mongodb` and `@types/mongoose` are removed from `@foal` packages. This introduces some `any` in function parameters or return values but does not add breaking changes (`any` can be assigned to anything and anything can be assign to `any`).

People using Foal still have the possibility to install `@types/mongodb` and `@types/mongoose` if they want to use them.

# Solution and steps

- [x] Uninstall `@types/mongodb`
- [x] Uninstall `@types/mongoose`
- [x] Do not install and use by default `@types/mongoose` in the generators

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
