### PR TITLE
Fix Express types

### DIFF
--- a/docs/tutorials/mongodb-todo-list/3-the-todo-model.md
+++ b/docs/tutorials/mongodb-todo-list/3-the-todo-model.md
@@ -11,19 +11,15 @@ foal generate model todo
 Open the file `todo.model.ts` in the `src/app/models` directory and add a `text` field.
 
 ```typescript
-import { Document, model, Model, models, Schema } from 'mongoose';
+import { model, models, Schema } from 'mongoose';
 
-const todoSchema: Schema = new Schema({
+const todoSchema = new Schema({
   text: {
     required: true,
     type: String // String with a capital letter
   }
 });
 
-export interface ITodo extends Document {
-  text: string; // string a lowercase letter
-}
-
-export const Todo: Model<ITodo> = models.Todo || model<ITodo>('Todo', todoSchema);
+export const Todo = models.Todo || model('Todo', todoSchema);
 
 ```

--- a/packages/acceptance-tests/src/error-handling.spec.ts
+++ b/packages/acceptance-tests/src/error-handling.spec.ts
@@ -58,7 +58,7 @@ describe('FoalTS should support custom error-handling', () => {
         handleError: true
       },
       postMiddlewares: [
-        (err, req, res, next) => {
+        (err: any, req: any, res: any, next: (err?: any) => any) => {
           next(new Error('Hi!'));
         }
       ]

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -142,15 +142,6 @@
 			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
 			"dev": true
 		},
-		"@types/express-serve-static-core": {
-			"version": "4.17.0",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.0.tgz",
-			"integrity": "sha512-Xnub7w57uvcBqFdIGoRg1KhNOeEj0vB6ykUM7uFWyxvbdE89GFyqgmUcanAriMr4YOxNFZBAWkfcWIb4WBPt3g==",
-			"requires": {
-				"@types/node": "*",
-				"@types/range-parser": "*"
-			}
-		},
 		"@types/fs-extra": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
@@ -213,12 +204,8 @@
 		"@types/node": {
 			"version": "10.1.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.4.tgz",
-			"integrity": "sha512-GpQxofkdlHYxjHad98UUdNoMO7JrmzQZoAaghtNg14Gwg7YkohcrCoJEcEMSgllx4VIZ+mYw7ZHjfaeIagP/rg=="
-		},
-		"@types/range-parser": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-			"integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+			"integrity": "sha512-GpQxofkdlHYxjHad98UUdNoMO7JrmzQZoAaghtNg14Gwg7YkohcrCoJEcEMSgllx4VIZ+mYw7ZHjfaeIagP/rg==",
+			"dev": true
 		},
 		"@types/shelljs": {
 			"version": "0.8.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,6 @@
     "all": true
   },
   "dependencies": {
-    "@types/express-serve-static-core": "4.17.0",
     "ajv": "~6.12.0",
     "cookie-parser": "~1.4.4",
     "express": "~4.17.1",

--- a/packages/core/src/core/http/contexts.ts
+++ b/packages/core/src/core/http/contexts.ts
@@ -1,5 +1,101 @@
-import { Request } from 'express-serve-static-core';
 import { Session } from '../../sessions';
+
+interface Readable {
+  [name: string]: any;
+}
+
+interface IncomingMessage extends Readable {
+  aborted: boolean;
+  complete: boolean;
+  headers: any;
+  // These two lines are present in @types/node but not in Node.js official documentation.
+  // Missing: httpVersionMajor: number;
+  // Missing: httpVersionMinor: string;
+  httpVersion: string;
+  method?: string;
+  rawHeaders: string[];
+  rawTrailers: string[];
+  socket: any;
+  statusCode?: number;
+  statusMessage?: number;
+  trailers: any;
+  url?: string;
+  destroy(err?: any): void;
+  // tslint:disable-next-line:ban-types
+  setTimeout(msecs: number, callback: Function): this;
+}
+
+/**
+ * Express Request interface.
+ *
+ * @interface Request
+ */
+interface Request extends IncomingMessage {
+  app: any;
+  baseUrl: string;
+  body: any;
+  cookies: any;
+  fresh: boolean;
+  // This line is present in @types/express but not in Express official documentation.
+  // host: string; // @deprecated
+  hostname: string;
+  ip: string;
+  ips: string[];
+  method: string;
+  originalUrl: string;
+  params: any;
+  path: string;
+  // The type is a string in @types/express.
+  procotol: 'http'|'https';
+  query: any;
+  route: any;
+  secure: boolean;
+  signedCookies: any;
+  stale: boolean;
+  subdomains: string[];
+  xhr: boolean;
+  // This line has been added based on @types/express in order not to make the url possibly undefined.
+  url: string;
+
+  // This line has been added based on @types/express but it is not present in Express official documentation.
+  accepts(): string[];
+  accepts(types: string|string[]): string|false;
+  accepts(...types: string[]): string|false;
+
+  // This line has been added based on @types/express but it is not present in Express official documentation.
+  acceptsCharsets(): string[];
+  acceptsCharsets(charset: string|string[]): string|false;
+  acceptsCharsets(...charset: string[]): string|false;
+
+  // This line has been added based on @types/express but it is not present in Express official documentation.
+  acceptsEncodings(): string[];
+  acceptsEncodings(encoding: string|string[]): string|false;
+  acceptsEncodings(...encoding: string[]): string|false;
+
+  // This line has been added based on @types/express but it is not present in Express official documentation.
+  acceptsLanguages(): string[];
+  acceptsLanguages(lang: string|string[]): string|false;
+  acceptsLanguages(...lang: string[]): string|false;
+
+  // This line has been added based on @types/express but it is not present in Express official documentation.
+  get(field: 'set-cookie'): string[] | undefined;
+  get(field: string): string|undefined;
+
+  // This line has been added based on @types/express but it is not present in Express official documentation.
+  header(field: 'set-cookie'): string[] | undefined;
+  header(field: string): string|undefined;
+
+  // The string[] type has been added based on @types/express but it is not present in Express official documentation.
+  is(type: string|string[]): string | false | null;
+
+  /**
+   * @deprecated
+   */
+  param(name: string, defaultValue?: any): any;
+
+  // The undefined type has been added based on @types/express but it is not present in Express official documentation.
+  range(size: number, options?: { combine?: boolean }): -1|-2|any[]|undefined;
+}
 
 /**
  * Class instantiated on each request. It includes:

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -4,11 +4,6 @@ import { Buffer } from 'buffer';
 
 // 3p
 import * as express from 'express';
-import {
-  NextFunction,
-  Request,
-  Response
-} from 'express-serve-static-core';
 import * as request from 'supertest';
 
 // FoalTS
@@ -309,8 +304,8 @@ describe('createApp', () => {
 
     const app = createApp(AppController, {
       preMiddlewares: [
-        (req: Request, res: Response, next: NextFunction) => {
-          (req as any).foalMessage = 'Hello world!'; next();
+        (req: any, res: any, next: (err?: any) => any) => {
+          req.foalMessage = 'Hello world!'; next();
         }
       ]
     });
@@ -337,9 +332,9 @@ describe('createApp', () => {
 
     const app = createApp(AppController, {
       postMiddlewares: [
-        express.Router().get('/a', (req, res) => res.send('a2')),
-        express.Router().get('/b', (req, res) => res.send('b2')),
-        (err, req, res, next) => {
+        express.Router().get('/a', (req: any, res: any) => res.send('a2')),
+        express.Router().get('/b', (req: any, res: any) => res.send('b2')),
+        (err: any, req: any, res: any, next: any) => {
           err.message += '!!!';
           next(err);
         }
@@ -436,7 +431,7 @@ describe('createAndInitApp', () => {
 
     const app = await createAndInitApp(AppController, {
       postMiddlewares: [
-        express.Router().get('/ping2', (req, res) => res.send('pong'))
+        express.Router().get('/ping2', (req: any, res: any) => res.send('pong'))
       ]
     });
 

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -1,14 +1,6 @@
 // 3p
 import * as cookieParser from 'cookie-parser';
 import * as express from 'express';
-import {
-  ErrorRequestHandler,
-  Express,
-  NextFunction,
-  Request,
-  RequestHandler,
-  Response
-} from 'express-serve-static-core';
 import * as logger from 'morgan';
 
 // FoalTS
@@ -22,21 +14,22 @@ import { createMiddleware } from './create-middleware';
 import { handleErrors } from './handle-errors';
 import { notFound } from './not-found';
 
-export interface ExpressApplication extends Express {
-  [name: string]: any;
-}
+export type ExpressApplication = any;
+
+type Middleware = (req: any, res: any, next: (err?: any) => any) => any;
+type ErrorMiddleware = (err: any, req: any, res: any, next: (err?: any) => any) => any;
 
 export interface CreateAppOptions {
-  expressInstance?: ExpressApplication;
+  expressInstance?: any;
   methods?: {
     handleError?: boolean;
   };
   serviceManager?: ServiceManager;
-  preMiddlewares?: (RequestHandler | ErrorRequestHandler)[];
-  postMiddlewares?: (RequestHandler | ErrorRequestHandler)[];
+  preMiddlewares?: (Middleware|ErrorMiddleware)[];
+  postMiddlewares?: (Middleware|ErrorMiddleware)[];
 }
 
-function handleJsonErrors(err: any, req: Request, res: Response, next: NextFunction) {
+function handleJsonErrors(err: any, req: any, res: any, next: (err?: any) => any) {
   if (err.type !== 'entity.parse.failed') {
     next(err);
     return;
@@ -47,7 +40,7 @@ function handleJsonErrors(err: any, req: Request, res: Response, next: NextFunct
   });
 }
 
-function protectionHeaders(req: Request, res: Response, next: NextFunction) {
+function protectionHeaders(req: any, res: any, next: (err?: any) => any) {
   res.removeHeader('X-Powered-By');
   res.setHeader('X-Content-Type-Options', 'nosniff');
   res.setHeader('X-DNS-Prefetch-Control', 'off');
@@ -58,7 +51,7 @@ function protectionHeaders(req: Request, res: Response, next: NextFunction) {
   next();
 }
 
-function getOptions(expressInstanceOrOptions?: ExpressApplication|CreateAppOptions): CreateAppOptions {
+function getOptions(expressInstanceOrOptions?: any|CreateAppOptions): CreateAppOptions {
   if (!expressInstanceOrOptions) {
     return {};
   }
@@ -75,9 +68,9 @@ function getOptions(expressInstanceOrOptions?: ExpressApplication|CreateAppOptio
  *
  * @export
  * @param {Class} AppController - The root controller, usually called `AppController` and located in `src/app`.
- * @param {(ExpressApplication|CreateAppOptions)} [expressInstanceOrOptions] - Express instance or options containaining
+ * @param {(any|CreateAppOptions)} [expressInstanceOrOptions] - Express instance or options containaining
  * Express middlewares or other settings.
- * @param {ExpressApplication} [expressInstanceOrOptions.expressInstance] - Express instance to be used as base for the
+ * @param {any} [expressInstanceOrOptions.expressInstance] - Express instance to be used as base for the
  * returned application.
  * @param {boolean} [expressInstanceOrOptions.methods.handleError] - Specifies if AppController.handleError should be
  * used to handle errors.
@@ -87,14 +80,14 @@ function getOptions(expressInstanceOrOptions?: ExpressApplication|CreateAppOptio
  * middlewares to be executed before the controllers and hooks.
  * @param {(RequestHandler | ErrorRequestHandler)[]} [expressInstanceOrOptions.postMiddlewares] Express
  * middlewares to be executed after the controllers and hooks, but before the 500 or 404 handler get called.
- * @returns {ExpressApplication} The express application.
+ * @returns {any} The express application.
  */
 export function createApp(
   AppController: Class,
-  expressInstanceOrOptions?: ExpressApplication | CreateAppOptions,
-): ExpressApplication {
+  expressInstanceOrOptions?: any | CreateAppOptions,
+): any {
   const options = getOptions(expressInstanceOrOptions);
-  const app: ExpressApplication = options.expressInstance || express();
+  const app = options.expressInstance || express();
 
   // Add optional pre-middlewares.
   for (const middleware of options.preMiddlewares || []) {
@@ -157,9 +150,9 @@ export function createApp(
  *
  * @export
  * @param {Class} AppController - The root controller, usually called `AppController` and located in `src/app`.
- * @param {(ExpressApplication|CreateAppOptions)} [expressInstanceOrOptions] - Express instance or options containaining
+ * @param {(any|CreateAppOptions)} [expressInstanceOrOptions] - Express instance or options containaining
  * Express middlewares or other settings.
- * @param {ExpressApplication} [expressInstanceOrOptions.expressInstance] - Express instance to be used as base for the
+ * @param {any} [expressInstanceOrOptions.expressInstance] - Express instance to be used as base for the
  * returned application.
  * @param {boolean} [expressInstanceOrOptions.methods.handleError] - Specifies if AppController.handleError should be
  * used to handle errors.
@@ -169,11 +162,11 @@ export function createApp(
  * middlewares to be executed before the controllers and hooks.
  * @param {(RequestHandler | ErrorRequestHandler)[]} [expressInstanceOrOptions.postMiddlewares] Express
  * middlewares to be executed after the controllers and hooks, but before the 500 or 404 handler get called.
- * @returns {Promise<ExpressApplication>} The express application.
+ * @returns {Promise<any>} The express application.
  */
 export async function createAndInitApp(
-  AppController: Class, expressInstanceOrOptions?: ExpressApplication | CreateAppOptions
-): Promise<ExpressApplication> {
+  AppController: Class, expressInstanceOrOptions?: any | CreateAppOptions
+): Promise<any> {
   const app = createApp(AppController, expressInstanceOrOptions);
 
   const controller = app.foal.services.get(AppController);

--- a/packages/core/src/express/create-middleware.spec.ts
+++ b/packages/core/src/express/create-middleware.spec.ts
@@ -3,11 +3,6 @@ import { deepStrictEqual, ok, strictEqual } from 'assert';
 
 // 3p
 import * as express from 'express';
-import {
-  NextFunction,
-  Request,
-  Response
-} from 'express-serve-static-core';
 import { createRequest, createResponse } from 'node-mocks-http';
 import * as request from 'supertest';
 
@@ -169,7 +164,7 @@ describe('createMiddleware', () => {
       it('should forward an Error to the next error-handling middleware.', done => {
         const app = express();
         app.get('/a', createMiddleware(route(() => ({})), new ServiceManager()));
-        app.use((err: any, req: Request, res: Response, next: NextFunction) => {
+        app.use((err: any, req: any, res: any, next: (err?: any) => any) => {
           try {
             ok(err instanceof Error);
             strictEqual(err.message, 'The controller method "fn" should return an HttpResponse.');
@@ -195,7 +190,7 @@ describe('createMiddleware', () => {
         path: '',
         propertyKey: 'bar'
       }, new ServiceManager()));
-      app.use((err: any, req: Request, res: Response, next: NextFunction) => {
+      app.use((err: any, req: any, res: any, next: (err?: any) => any) => {
         try {
           ok(err instanceof Error);
           strictEqual(err.message, 'Error thrown in a hook.');
@@ -215,7 +210,7 @@ describe('createMiddleware', () => {
           route(() => { throw new Error('Error thrown in a controller method.'); }),
           new ServiceManager())
         );
-        app.use((err: any, req: Request, res: Response, next: NextFunction) => {
+        app.use((err: any, req: any, res: any, next: (err?: any) => any) => {
           try {
             ok(err instanceof Error);
             strictEqual(err.message, 'Error thrown in a controller method.');
@@ -239,7 +234,7 @@ describe('createMiddleware', () => {
         path: '',
         propertyKey: 'bar'
       }, new ServiceManager()));
-      app.use((err: any, req: Request, res: Response, next: NextFunction) => {
+      app.use((err: any, req: any, res: any, next: (err?: any) => any) => {
         try {
           ok(err instanceof Error);
           strictEqual(err.message, 'Error rejected in a hook.');
@@ -259,7 +254,7 @@ describe('createMiddleware', () => {
           route(async () => { throw new Error('Error rejected in a controller method.'); }),
           new ServiceManager())
         );
-        app.use((err: any, req: Request, res: Response, next: NextFunction) => {
+        app.use((err: any, req: any, res: any, next: (err?: any) => any) => {
           try {
             ok(err instanceof Error);
             strictEqual(err.message, 'Error rejected in a controller method.');

--- a/packages/core/src/express/create-middleware.ts
+++ b/packages/core/src/express/create-middleware.ts
@@ -1,6 +1,3 @@
-// 3p
-import { RequestHandler } from 'express-serve-static-core';
-
 // FoalTS
 import {
   Context,
@@ -20,11 +17,11 @@ import { sendResponse } from './send-response';
  * @param {ServiceManager} services - The application services.
  * @returns {(...args) => any} The express middleware.
  */
-export function createMiddleware(route: Route, services: ServiceManager): RequestHandler {
-  return async (req, res, next) => {
+export function createMiddleware(route: Route, services: ServiceManager) {
+  return async (req: any, res: any, next: (err?: any) => any) => {
     try {
       const ctx = new Context(req);
-      (req as any).foal = { ctx };
+      req.foal = { ctx };
 
       let response: undefined | HttpResponse;
 

--- a/packages/core/src/express/express.d.ts
+++ b/packages/core/src/express/express.d.ts
@@ -1,54 +1,12 @@
 declare module 'express' {
-  import { Express, RequestHandler, Response, Router as IRouter } from 'express-serve-static-core';
-
-  function express(): Express;
+  function express(): any;
 
   namespace express {
-    function Router(options?: {
-      caseSensitive?: boolean;
-      mergeParams?: boolean;
-      strict?: boolean;
-    }): IRouter;
-
-    function json(options?: {
-      strict?: boolean;
-      inflate?: boolean;
-      limit?: number | string;
-      type?: string | string[] | ((req: any) => any);
-      reviver?(key: string, value: any): any;
-      verify?(req: any, res: any, buf: Buffer, encoding: string): void;
-    }): RequestHandler;
-
-    function text(options?: {
-      defaultCharset?: string;
-      inflate?: boolean;
-      limit?: number | string;
-      type?: string | string[] | ((req: any) => any);
-      verify?(req: any, res: any, buf: Buffer, encoding: string): void;
-    }): RequestHandler;
-
-    function urlencoded(options?: {
-      extended?: boolean;
-      parameterLimit?: number;
-      inflate?: boolean;
-      limit?: number | string;
-      type?: string | string[] | ((req: any) => any);
-      verify?(req: any, res: any, buf: Buffer, encoding: string): void;
-    }): RequestHandler;
-
-    function static(root: string, options?: {
-      cacheControl?: boolean;
-      dotfiles?: string;
-      etag?: boolean;
-      extensions?: string[];
-      fallthrough?: boolean;
-      immutable?: boolean;
-      index?: boolean | string | string[];
-      lastModified?: boolean;
-      maxAge?: number | string;
-      redirect?: boolean;
-      setHeaders?: (res: Response, path: string, stat: any) => any;
-    }): RequestHandler;
+    function Router(options?: any): any;
+    function json(options?: any): any;
+    function text(options?: any): any;
+    function urlencoded(options?: any): any;
+    function static(root: string, options?: any): any;
   }
   export = express;
 }

--- a/packages/core/src/express/handle-errors.spec.ts
+++ b/packages/core/src/express/handle-errors.spec.ts
@@ -39,7 +39,7 @@ describe('handleErrors', () => {
       const middleware = handleErrors({}, {}, logFn);
 
       const app = express()
-        .use((req, res, next) => { throw err; })
+        .use((req: any, res: any, next: any) => { throw err; })
         .use(middleware);
       return request(app)
         .get('/')
@@ -57,7 +57,7 @@ describe('handleErrors', () => {
       const middleware = handleErrors({}, {}, logFn);
 
       const app = express()
-        .use((req, res, next) => { throw err; })
+        .use((req: any, res: any, next: any) => { throw err; })
         .use(middleware);
       await request(app)
         .get('/')
@@ -73,7 +73,7 @@ describe('handleErrors', () => {
         + '<h1>500 - INTERNAL SERVER ERROR</h1></body></html>';
 
         const app = express()
-          .use((req, res, next) => { throw new Error(); })
+          .use((req: any, res: any, next: any) => { throw new Error(); })
           .use(handleErrors(options, appController, () => {}));
         return request(app)
           .get('/')
@@ -116,7 +116,7 @@ describe('handleErrors', () => {
         };
 
         const app = express()
-          .use((req, res, next) => { throw new Error(); })
+          .use((req: any, res: any, next: any) => { throw new Error(); })
           .use(handleErrors(options, appController, () => {}));
         return request(app)
           .get('/')
@@ -134,7 +134,7 @@ describe('handleErrors', () => {
         };
 
         const app = express()
-          .use((req, res, next) => { throw new Error(); })
+          .use((req: any, res: any, next: any) => { throw new Error(); })
           .use(handleErrors(options, appController, () => {}));
         return request(app)
           .get('/')
@@ -160,9 +160,9 @@ describe('handleErrors', () => {
         };
 
         const app = express()
-          .use((req, res, next) => {
+          .use((req: any, res: any, next: any) => {
             expectedContext = new Context(req);
-            (req as any).foal = { ctx: expectedContext };
+            req.foal = { ctx: expectedContext };
             throw expectedError;
           })
           .use(handleErrors(options, appController, () => {}));
@@ -191,7 +191,7 @@ describe('handleErrors', () => {
         };
 
         const app = express()
-          .use((req, res, next) => {
+          .use((req: any, res: any, next: any) => {
             expectedRequest = req;
             throw expectedError;
           })
@@ -220,7 +220,7 @@ describe('handleErrors', () => {
         };
 
         const app = express()
-          .use((req, res, next) => { throw new Error('error 1'); })
+          .use((req: any, res: any, next: any) => { throw new Error('error 1'); })
           .use(handleErrors(options, appController, () => {}));
         return request(app)
           .get('/')

--- a/packages/core/src/express/handle-errors.ts
+++ b/packages/core/src/express/handle-errors.ts
@@ -1,6 +1,3 @@
-// 3p
-import { ErrorRequestHandler } from 'express-serve-static-core';
-
 // FoalTS
 import { renderError } from '../common';
 import { Config, Context, HttpResponse } from '../core';
@@ -16,10 +13,8 @@ import { sendResponse } from './send-response';
  * @param {*} [logFn=console.error]
  * @returns {ErrorRequestHandler}
  */
-export function handleErrors(
-  options: CreateAppOptions, appController: any, logFn = console.error
-): ErrorRequestHandler {
-  return async (err, req, res, next) => {
+export function handleErrors(options: CreateAppOptions, appController: any, logFn = console.error) {
+  return async (err: any, req: any, res: any, next: (err?: any) => any) => {
     if (err.expose && err.status) {
       next(err);
       return;
@@ -29,7 +24,7 @@ export function handleErrors(
       logFn(err.stack);
     }
 
-    const ctx = (req as any).foal ? (req as any).foal.ctx : new Context(req);
+    const ctx = req.foal ? req.foal.ctx : new Context(req);
 
     let response: HttpResponse;
     if (options.methods && options.methods.handleError && appController.handleError) {

--- a/packages/core/src/express/not-found.ts
+++ b/packages/core/src/express/not-found.ts
@@ -1,5 +1,3 @@
-import { RequestHandler } from 'express-serve-static-core';
-
 const page404 = '<html><head><title>PAGE NOT FOUND</title></head><body><h1>404 - PAGE NOT FOUND</h1></body></html>';
 
 /**
@@ -8,8 +6,8 @@ const page404 = '<html><head><title>PAGE NOT FOUND</title></head><body><h1>404 -
  * @export
  * @returns The express middleware.
  */
-export function notFound(): RequestHandler {
-  return (req, res) => {
+export function notFound() {
+  return (req: any, res: any) => {
     res.status(404)
        .send(page404);
   };

--- a/packages/core/src/express/send-response.spec.ts
+++ b/packages/core/src/express/send-response.spec.ts
@@ -16,7 +16,7 @@ import { sendResponse } from './send-response';
 
 function execSendResponse(response: HttpResponse): request.Test {
   const app = express()
-    .use((req, res) => sendResponse(response, res));
+    .use((req: any, res: any) => sendResponse(response, res));
   return request(app).get('/');
 }
 

--- a/packages/core/src/express/send-response.ts
+++ b/packages/core/src/express/send-response.ts
@@ -1,5 +1,4 @@
 // 3p
-import { Response } from 'express-serve-static-core';
 import * as pump from 'pump';
 
 // FoalTS
@@ -10,10 +9,10 @@ import { HttpResponse, isHttpResponseMovedPermanently, isHttpResponseRedirect } 
  *
  * @export
  * @param {HttpResponse} response - FoalTS response.
- * @param {Response} res - Express response used in middlewares.
+ * @param {any} res - Express response used in middlewares.
  * @returns {void}
  */
-export function sendResponse(response: HttpResponse, res: Response): void {
+export function sendResponse(response: HttpResponse, res: any): void {
   res.status(response.statusCode);
   res.set(response.getHeaders());
   const cookies = response.getCookies();

--- a/packages/core/src/sessions/token.hook.ts
+++ b/packages/core/src/sessions/token.hook.ts
@@ -64,7 +64,7 @@ export function Token(required: boolean, options: TokenOptions): HookDecorator {
 
       token = content;
     } else {
-      const authorizationHeader = ctx.request.get('Authorization') as string|undefined || '';
+      const authorizationHeader = ctx.request.get('Authorization') || '';
 
       if (!authorizationHeader) {
         if (!required) {

--- a/packages/formidable/package-lock.json
+++ b/packages/formidable/package-lock.json
@@ -7,23 +7,8 @@
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
-		},
-		"@types/formidable": {
-			"version": "1.0.31",
-			"resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-1.0.31.tgz",
-			"integrity": "sha512-dIhM5t8lRP0oWe2HF8MuPvdd1TpPTjhDMAqemcq6oIZQCBQTovhBAdTQ5L5veJB4pdQChadmHuxtB0YzqvfU3Q==",
-			"requires": {
-				"@types/events": "*",
-				"@types/node": "*"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "12.12.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-					"integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA=="
-				}
-			}
+			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+			"dev": true
 		},
 		"@types/fs-extra": {
 			"version": "5.1.0",
@@ -490,12 +475,6 @@
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
-		},
-		"formidable": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-			"integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
-			"dev": true
 		},
 		"fs-extra": {
 			"version": "7.0.1",

--- a/packages/formidable/package.json
+++ b/packages/formidable/package.json
@@ -42,19 +42,17 @@
   "files": [
     "lib/"
   ],
+  "dependencies": {
+    "@foal/core": "^1.8.0"
+  },
   "devDependencies": {
     "@types/mocha": "~2.2.43",
     "@types/node": "~10.5.6",
-    "formidable": "~1.2.1",
     "mocha": "~5.2.0",
     "rimraf": "~2.6.2",
     "ts-node": "~3.3.0",
     "typedoc": "~0.14.2",
     "typedoc-plugin-markdown": "~1.2.0",
     "typescript": "~3.5.3"
-  },
-  "dependencies": {
-    "@foal/core": "^1.8.0",
-    "@types/formidable": "~1.0.31"
   }
 }

--- a/packages/formidable/src/parse-form.spec.ts
+++ b/packages/formidable/src/parse-form.spec.ts
@@ -12,6 +12,17 @@ interface Fields {
   [key: string]: string|string[];
 }
 
+interface File {
+  size: number;
+  path: string;
+  name: string;
+  type: string;
+  lastModifiedDate?: Date;
+  hash?: string;
+
+  toJSON(): any;
+}
+
 interface Files {
   [key: string]: File; // | File[];
 }

--- a/packages/formidable/src/parse-form.spec.ts
+++ b/packages/formidable/src/parse-form.spec.ts
@@ -4,10 +4,17 @@ import { IncomingMessage } from 'http';
 
 // "3p"
 import { Context } from '@foal/core';
-import { Fields, Files, IncomingForm } from 'formidable';
 
 // FoalTS
 import { parseForm } from './parse-form';
+
+interface Fields {
+  [key: string]: string|string[];
+}
+
+interface Files {
+  [key: string]: File; // | File[];
+}
 
 interface FakeIncomingForm {
   parse(req: IncomingMessage, callback?: (err: any, fields: Fields, files: Files) => any): void;
@@ -20,7 +27,7 @@ describe('parseForm', () => {
     const fakeIncomingForm: FakeIncomingForm = {
       parse(req, callback) {}
     };
-    const actual = parseForm(fakeIncomingForm as IncomingForm, ctx);
+    const actual = parseForm(fakeIncomingForm, ctx);
 
     ok(actual instanceof Promise, `${actual} is not a promise`);
   });
@@ -34,7 +41,7 @@ describe('parseForm', () => {
       }
     };
 
-    parseForm(fakeIncomingForm as IncomingForm, ctx);
+    parseForm(fakeIncomingForm, ctx);
 
     strictEqual(request, ctx.request);
   });
@@ -50,7 +57,7 @@ describe('parseForm', () => {
       }
     };
 
-    parseForm(fakeIncomingForm as IncomingForm, ctx)
+    parseForm(fakeIncomingForm, ctx)
       .then(() => done('The promise was resolved.'))
       .catch(error => {
         if (error !== err) {
@@ -73,7 +80,7 @@ describe('parseForm', () => {
       }
     };
 
-    parseForm(fakeIncomingForm as IncomingForm, ctx)
+    parseForm(fakeIncomingForm, ctx)
       .then(data => {
         if (data.fields !== fields || data.files !== files) {
           done(`The promise was resolved but with incorrect fields (${data.fields}) or files (${data.files}).`);

--- a/packages/formidable/src/parse-form.ts
+++ b/packages/formidable/src/parse-form.ts
@@ -1,6 +1,17 @@
 // 3p
 import { Context } from '@foal/core';
 
+interface File {
+  size: number;
+  path: string;
+  name: string;
+  type: string;
+  lastModifiedDate?: Date;
+  hash?: string;
+
+  toJSON(): any;
+}
+
 interface Fields {
   [key: string]: string|string[];
 }

--- a/packages/formidable/src/parse-form.ts
+++ b/packages/formidable/src/parse-form.ts
@@ -1,6 +1,13 @@
 // 3p
 import { Context } from '@foal/core';
-import { Fields, Files, IncomingForm } from 'formidable';
+
+interface Fields {
+  [key: string]: string|string[];
+}
+
+interface Files {
+  [key: string]: File; // | File[];
+}
 
 /**
  * Promisify IncomingForm.parse.
@@ -10,9 +17,9 @@ import { Fields, Files, IncomingForm } from 'formidable';
  * @param {Context} ctx - The Context instance.
  * @returns {Promise<{ fields: Fields, files: Files }>} The fields and files inside an object.
  */
-export function parseForm(form: IncomingForm, ctx: Context): Promise<{ fields: Fields, files: Files }> {
+export function parseForm(form: any, ctx: Context): Promise<{ fields: Fields, files: Files }> {
   return new Promise<{ fields: Fields, files: Files }>((resolve, reject) => {
-    form.parse(ctx.request, (err, fields, files) => {
+    form.parse(ctx.request, (err: any, fields: Fields, files: Files) => {
       if (err) {
         return reject(err);
       }

--- a/packages/jwt/src/jwt.hook.ts
+++ b/packages/jwt/src/jwt.hook.ts
@@ -74,7 +74,7 @@ export function JWT(required: boolean, options: JWTOptions, verifyOptions: Verif
 
       token = content;
     } else {
-      const authorizationHeader = ctx.request.get('Authorization') as string|undefined || '';
+      const authorizationHeader = ctx.request.get('Authorization') || '';
 
       if (!authorizationHeader) {
         if (!required) {


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Fixes #686 

As `@types/express` requires any `*` version of `@types/express-serve-static-core` we are stuck. We cannot go back to `@types/express@4.17.2` because it will requires the latest version of `@types/express-serve-static-core` which is incompatible with v4.17.2.

# Solution and steps

Remove `@types/express-serve-static-core` from `@foal/core` and define manually the interface of `Context.request` (based on Node.js and Express documentation, `@types/node` and the old `@types/express-serve-static-core`). This will unfortunately turn some types into `any` but it should not add any breaking changes.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
