### PR TITLE
[V2] Drop NodeJS 8 support and test NodeJS 12.

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
     
     services:
       mongodb:

--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [10.x, 12.x]
+        node-version: [10, 12]
     
     services:
       mongodb:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10, 12]
 
     env:
       AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8, 10]
+        node-version: [10.x, 12.x]
 
     env:
       AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fcore">
     <img src="https://badge.fury.io/js/%40foal%2Fcore.svg" alt="npm version">
   </a>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)
-![node version](https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg)
+![node version](https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg)
 ![npm version](https://badge.fury.io/js/%40foal%2Fcore.svg)
 [![Actions Status](https://github.com/FoalTS/foal/workflows/Test/badge.svg)](https://github.com/FoalTS/foal/actions)
 ![Code coverage](https://codecov.io/gh/FoalTS/foal/branch/master/graphs/badge.svg)

--- a/docs/cloud/firebase.md
+++ b/docs/cloud/firebase.md
@@ -23,11 +23,12 @@ firebase init
 
 The CLI displays some prompts:
 
-- Select the `Hosting` option. You may select other options as well but do not select `Functions` (otherwise you will have to delete the `functions/` directory just after).
-
+- Select the `Hosting` option.
 - The default static path must be changed to `functions/public`.
 
 ## Create the Foal Application
+
+Remove the directory `functions`.
 
 Create the Foal application.
 
@@ -41,6 +42,8 @@ You can run locally your application using `npm run develop`.
 > Using `npm run develop` over `firebase serve` has the advantage to restart the development server when a file is changed.
 
 ## Configure the Project to Make it Work with Firebase
+
+> warning: version 2
 
 Install the dependencies.
 
@@ -77,22 +80,6 @@ export const app = functions.https.onRequest(createApp(AppController));
 
 ```
 
-Add the file to `tsconfig.app.json`.
-
-```json
-{
-  "extends": "./tsconfig.json",
-  "include": [
-    "src/app/**/*.ts",
-    "src/index.firebase.ts",
-    "src/index.ts"
-  ],
-  "exclude": [
-    "src/app/**/*.spec.ts"
-  ]
-}
-```
-
 Update the `firebase.json` file to specify that the server should use the previously exported application. 
 
 ```json
@@ -116,6 +103,20 @@ Update the `firebase.json` file to specify that the server should use the previo
 ## Deploy the Application
 
 > warning: version 2
+
+Add the compiler option `skipLibCheck` in your `tsconfig.json`.
+
+```json
+{
+  "compilerOptions": {
+    ...
+    "skipLibCheck": true
+  },
+  ...
+}
+```
+
+Then build and deploy the application.
 
 ```sh
 npm run build

--- a/docs/cloud/firebase.md
+++ b/docs/cloud/firebase.md
@@ -55,7 +55,7 @@ Update the file `package.json` in `functions/`.
   ...
   "main": "build/index.firebase.js",
   "engines": {
-    "node": "8"
+    "node": "10"
   }
   ...
 }

--- a/docs/tutorials/mongodb-todo-list/1-installation.md
+++ b/docs/tutorials/mongodb-todo-list/1-installation.md
@@ -4,7 +4,7 @@ In this tutorial you will learn how to create a basic web application with FoalT
 
 > **Requirements:**
 >
-> [Node.js](https://nodejs.org/en/) 8 or greater
+> [Node.js](https://nodejs.org/en/) 10 or greater
 >
 > [MongoDB](https://docs.mongodb.com/manual/administration/install-community/)
 

--- a/docs/tutorials/simple-todo-list/1-installation.md
+++ b/docs/tutorials/simple-todo-list/1-installation.md
@@ -4,7 +4,7 @@ In this tutorial you will learn how to create a basic web application with FoalT
 
 > **Requirements:**
 >
-> [Node.js](https://nodejs.org/en/) 8 or greater
+> [Node.js](https://nodejs.org/en/) 10 or greater
 
 # Create a New Project
 

--- a/packages/aws-s3/README.md
+++ b/packages/aws-s3/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Faws-s3">
     <img src="https://badge.fury.io/js/%40foal%2Faws-s3.svg" alt="npm version">
   </a>

--- a/packages/aws-s3/package.json
+++ b/packages/aws-s3/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/aws-s3/src/s3-disk.service.spec.ts
+++ b/packages/aws-s3/src/s3-disk.service.spec.ts
@@ -11,7 +11,7 @@ import * as S3 from 'aws-sdk/clients/s3';
 import { S3Disk } from './s3-disk.service';
 
 // Isolate each job with a different S3 bucket.
-const bucketName = `foal-test-${process.env.NODE_VERSION || 8}`;
+const bucketName = `foal-test-${process.env.NODE_VERSION || 10}`;
 
 function streamToBuffer(stream: Readable): Promise<Buffer> {
   const chunks: Buffer[] = [];

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fcli">
     <img src="https://badge.fury.io/js/%40foal%2Fcli.svg" alt="npm version">
   </a>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "bin": {
     "foal": "./lib/index.js"

--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -23,7 +23,7 @@
     "revertmigration": "npx typeorm migration:revert"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "dependencies": {
     "@foal/core": "^1.0.0",
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^5.2.1",
-    "@types/node": "^8.0.47",
+    "@types/node": "^10.5.6",
     "concurrently": "^3.5.1",
     "mocha": "^5.2.0",
     "supertest": "^3.3.0",

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -23,7 +23,7 @@
     "revertmigration": "npx typeorm migration:revert"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "dependencies": {
     "@foal/core": "^1.0.0",
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^5.2.1",
-    "@types/node": "^8.0.47",
+    "@types/node": "^10.5.6",
     "concurrently": "^3.5.1",
     "mocha": "^5.2.0",
     "supertest": "^3.3.0",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fcore">
     <img src="https://badge.fury.io/js/%40foal%2Fcore.svg" alt="npm version">
   </a>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/common/utils/render-error.util.spec.ts
+++ b/packages/core/src/common/utils/render-error.util.spec.ts
@@ -43,7 +43,7 @@ describe('renderError', () => {
 
     const text: string = response.body;
     strictEqual(text.includes('Error: This is an error'), true, '"Error: This is an error" not found');
-    strictEqual(text.includes('at Context.it'), true, '"at Context.it" not found');
+    strictEqual(text.includes('at Context.'), true, '"at Context." not found');
     strictEqual(
       text.includes(
         'You are seeing this error because you have settings.debug set to true in your configuration file.'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,14 @@
  * Released under the MIT License.
  */
 
+try {
+  const version = process.versions.node;
+  const NODE_MAJOR_VERSION = parseInt(version.split('.')[0], 10);
+  if (NODE_MAJOR_VERSION < 10) {
+    console.warn(`[Warning] You are using version ${version} of Node. FoalTS requires at least version 10.`);
+  }
+} finally {}
+
 export * from './common';
 export * from './core';
 export * from './express';

--- a/packages/csrf/README.md
+++ b/packages/csrf/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fcsrf">
     <img src="https://badge.fury.io/js/%40foal%2Fcsrf.svg" alt="npm version">
   </a>

--- a/packages/csrf/package.json
+++ b/packages/csrf/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ejs/README.md
+++ b/packages/ejs/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fejs">
     <img src="https://badge.fury.io/js/%40foal%2Fejs.svg" alt="npm version">
   </a>

--- a/packages/ejs/package.json
+++ b/packages/ejs/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/formidable/README.md
+++ b/packages/formidable/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fpassword">
     <img src="https://badge.fury.io/js/%40foal%2Fpassword.svg" alt="npm version">
   </a>

--- a/packages/formidable/package.json
+++ b/packages/formidable/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fgraphql">
     <img src="https://badge.fury.io/js/%40foal%2Fgraphql.svg" alt="npm version">
   </a>

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/internal-test/package.json
+++ b/packages/internal-test/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jwks-rsa/README.md
+++ b/packages/jwks-rsa/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fjwks-rsa">
     <img src="https://badge.fury.io/js/%40foal%2Fjwks-rsa.svg" alt="npm version">
   </a>

--- a/packages/jwks-rsa/package.json
+++ b/packages/jwks-rsa/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fjwt">
     <img src="https://badge.fury.io/js/%40foal%2Fjwt.svg" alt="npm version">
   </a>

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mongodb/README.md
+++ b/packages/mongodb/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fmongodb">
     <img src="https://badge.fury.io/js/%40foal%2Fmongodb.svg" alt="npm version">
   </a>

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mongoose/README.md
+++ b/packages/mongoose/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fmongoose">
     <img src="https://badge.fury.io/js/%40foal%2Fmongoose.svg" alt="npm version">
   </a>

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/password/README.md
+++ b/packages/password/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fpassword">
     <img src="https://badge.fury.io/js/%40foal%2Fpassword.svg" alt="npm version">
   </a>

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fredis">
     <img src="https://badge.fury.io/js/%40foal%2Fredis.svg" alt="npm version">
   </a>

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/social/README.md
+++ b/packages/social/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fsocial">
     <img src="https://badge.fury.io/js/%40foal%2Fsocial.svg" alt="npm version">
   </a>

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"
@@ -58,15 +58,15 @@
   },
   "devDependencies": {
     "@types/jsonwebtoken": "~8.3.5",
-    "@types/mocha": "^2.2.43",
-    "@types/node": "^10.5.6",
-    "copy": "^0.3.2",
+    "@types/mocha": "~2.2.43",
+    "@types/node": "~10.5.6",
+    "copy": "~0.3.2",
     "jsonwebtoken": "~8.5.1",
-    "mocha": "^5.2.0",
-    "rimraf": "^2.6.2",
-    "ts-node": "^3.3.0",
-    "typedoc": "^0.14.2",
-    "typedoc-plugin-markdown": "^1.2.0",
+    "mocha": "~5.2.0",
+    "rimraf": "~2.6.2",
+    "ts-node": "~3.3.0",
+    "typedoc": "~0.14.2",
+    "typedoc-plugin-markdown": "~1.2.0",
     "typescript": "~3.5.3"
   }
 }

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -58,15 +58,15 @@
   },
   "devDependencies": {
     "@types/jsonwebtoken": "~8.3.5",
-    "@types/mocha": "~2.2.43",
-    "@types/node": "~10.5.6",
-    "copy": "~0.3.2",
+    "@types/mocha": "^2.2.43",
+    "@types/node": "^10.5.6",
+    "copy": "^0.3.2",
     "jsonwebtoken": "~8.5.1",
-    "mocha": "~5.2.0",
-    "rimraf": "~2.6.2",
-    "ts-node": "~3.3.0",
-    "typedoc": "~0.14.2",
-    "typedoc-plugin-markdown": "~1.2.0",
+    "mocha": "^5.2.0",
+    "rimraf": "^2.6.2",
+    "ts-node": "^3.3.0",
+    "typedoc": "^0.14.2",
+    "typedoc-plugin-markdown": "^1.2.0",
     "typescript": "~3.5.3"
   }
 }

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fstorage">
     <img src="https://badge.fury.io/js/%40foal%2Fstorage.svg" alt="npm version">
   </a>

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/storage/src/disk.service.spec.ts
+++ b/packages/storage/src/disk.service.spec.ts
@@ -81,8 +81,8 @@ describe('Disk', () => {
         throw new Error('An error should have been thrown.');
       } catch (error) {
         strictEqual(
-          error.message,
-          'Cannot find module \'foo\''
+          error.message.startsWith('Cannot find module \'foo\''),
+          true
         );
       }
     });
@@ -151,8 +151,8 @@ describe('Disk', () => {
         throw new Error('An error should have been thrown.');
       } catch (error) {
         strictEqual(
-          error.message,
-          'Cannot find module \'foo\''
+          error.message.startsWith('Cannot find module \'foo\''),
+          true
         );
       }
     });
@@ -221,8 +221,8 @@ describe('Disk', () => {
         throw new Error('An error should have been thrown.');
       } catch (error) {
         strictEqual(
-          error.message,
-          'Cannot find module \'foo\''
+          error.message.startsWith('Cannot find module \'foo\''),
+          true
         );
       }
     });

--- a/packages/swagger/README.md
+++ b/packages/swagger/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fswagger">
     <img src="https://badge.fury.io/js/%40foal%2Fswagger.svg" alt="npm version">
   </a>

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/typeorm/README.md
+++ b/packages/typeorm/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Fjwt">
     <img src="https://badge.fury.io/js/%40foal%2Fjwt.svg" alt="npm version">
   </a>

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/typestack/README.md
+++ b/packages/typestack/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/FoalTS/foal/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   </a>
-  <img src="https://img.shields.io/badge/node-%3E%3D8-brightgreen.svg" alt="node version">
+  <img src="https://img.shields.io/badge/node-%3E%3D10-brightgreen.svg" alt="node version">
   <a href="https://badge.fury.io/js/%40foal%2Ftypestack">
     <img src="https://badge.fury.io/js/%40foal%2Ftypestack.svg" alt="npm version">
   </a>

--- a/packages/typestack/package.json
+++ b/packages/typestack/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
# Issue

Since the end of 2019, version 8 of Node is [no longer maintained](https://github.com/nodejs/Release#end-of-life-releases). There is no reason to keep maintaining its support in FoalTS version 2. We will able to use all features of Node 10, especially those on promises in the `assert` module (for unit testing).

# Solution and steps

- [x] Remove Node 8 from CI and test Node 12.
- [x] Test Node 12 and make changes if necessary.
- [x] Remove Node 8 from documentation.
- [x] Add version warning in `@foal/core`.
- [x] Update CLI to generate new project with Node 10 types.
- [x] Test manually the deployment with version 10 on firebase (to check if the doc is correct).

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
