### PR TITLE
Pass request body and path parameters as third and second arguments to the controller methods

### DIFF
--- a/docs/architecture/controllers.md
+++ b/docs/architecture/controllers.md
@@ -120,7 +120,7 @@ import { Context, HttpResponseCreated, Post } from '@foal/core';
 class AppController {
   @Post('/products')
   createProduct(ctx: Context) {
-    const requestBody = ctx.request.body;
+    const body = ctx.request.body;
     // Do something.
     return new HttpResponseCreated();
   }
@@ -140,7 +140,7 @@ import { Context, HttpResponseOK, Post } from '@foal/core';
 
 class AppController {
   @Get('/products/:id')
-  createProduct(ctx: Context) {
+  readProduct(ctx: Context) {
     const productId = ctx.request.params.id;
     // Do something.
     return new HttpResponseOK(/* something */);
@@ -161,7 +161,7 @@ import { Context, HttpResponseOK, Post } from '@foal/core';
 
 class AppController {
   @Get('/products')
-  createProduct(ctx: Context) {
+  readProducts(ctx: Context) {
     const limit = ctx.request.query.limit;
     // Do something.
     return new HttpResponseOK(/* something */);
@@ -197,6 +197,25 @@ class AppController {
   index(ctx: Context) {
     const sessionID: string|undefined = ctx.request.cookies.sessionID;
     // ...
+  }
+}
+```
+
+
+#### The Controller Method Arguments
+
+> Available in Foal v1.9.0 onwards.
+
+The path paramaters and request body are also passed as second and third arguments to the controller method.
+
+```typescript
+import { Context, HttpResponseCreated, Put } from '@foal/core';
+
+class AppController {
+  @Put('/products/:id')
+  updateProduct(ctx: Context, { id }, body) {
+    // Do something.
+    return new HttpResponseCreated();
   }
 }
 ```

--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -46,8 +46,8 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "eslint": "^6.7.0",
-    "@typescript-eslint/eslint-plugin": "^2.7.0",
-    "@typescript-eslint/parser": "^2.7.0",
+    "@typescript-eslint/eslint-plugin": "~2.7.0",
+    "@typescript-eslint/parser": "~2.7.0",
     "typescript": "~3.5.3"
   }
 }

--- a/packages/cli/src/generate/specs/app/package.mongodb.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.json
@@ -41,8 +41,8 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "eslint": "^6.7.0",
-    "@typescript-eslint/eslint-plugin": "^2.7.0",
-    "@typescript-eslint/parser": "^2.7.0",
+    "@typescript-eslint/eslint-plugin": "~2.7.0",
+    "@typescript-eslint/parser": "~2.7.0",
     "typescript": "~3.5.3"
   }
 }

--- a/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
@@ -42,8 +42,8 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "eslint": "^6.7.0",
-    "@typescript-eslint/eslint-plugin": "^2.7.0",
-    "@typescript-eslint/parser": "^2.7.0",
+    "@typescript-eslint/eslint-plugin": "~2.7.0",
+    "@typescript-eslint/parser": "~2.7.0",
     "typescript": "~3.5.3"
   }
 }

--- a/packages/cli/src/generate/specs/app/package.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.yaml.json
@@ -47,8 +47,8 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "eslint": "^6.7.0",
-    "@typescript-eslint/eslint-plugin": "^2.7.0",
-    "@typescript-eslint/parser": "^2.7.0",
+    "@typescript-eslint/eslint-plugin": "~2.7.0",
+    "@typescript-eslint/parser": "~2.7.0",
     "typescript": "~3.5.3"
   }
 }

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -46,8 +46,8 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "eslint": "^6.7.0",
-    "@typescript-eslint/eslint-plugin": "^2.7.0",
-    "@typescript-eslint/parser": "^2.7.0",
+    "@typescript-eslint/eslint-plugin": "~2.7.0",
+    "@typescript-eslint/parser": "~2.7.0",
     "typescript": "~3.5.3"
   }
 }

--- a/packages/cli/src/generate/templates/app/package.mongodb.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.json
@@ -41,8 +41,8 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "eslint": "^6.7.0",
-    "@typescript-eslint/eslint-plugin": "^2.7.0",
-    "@typescript-eslint/parser": "^2.7.0",
+    "@typescript-eslint/eslint-plugin": "~2.7.0",
+    "@typescript-eslint/parser": "~2.7.0",
     "typescript": "~3.5.3"
   }
 }

--- a/packages/cli/src/generate/templates/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.yaml.json
@@ -42,8 +42,8 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "eslint": "^6.7.0",
-    "@typescript-eslint/eslint-plugin": "^2.7.0",
-    "@typescript-eslint/parser": "^2.7.0",
+    "@typescript-eslint/eslint-plugin": "~2.7.0",
+    "@typescript-eslint/parser": "~2.7.0",
     "typescript": "~3.5.3"
   }
 }

--- a/packages/cli/src/generate/templates/app/package.yaml.json
+++ b/packages/cli/src/generate/templates/app/package.yaml.json
@@ -47,8 +47,8 @@
     "supertest": "^3.3.0",
     "supervisor": "^0.12.0",
     "eslint": "^6.7.0",
-    "@typescript-eslint/eslint-plugin": "^2.7.0",
-    "@typescript-eslint/parser": "^2.7.0",
+    "@typescript-eslint/eslint-plugin": "~2.7.0",
+    "@typescript-eslint/parser": "~2.7.0",
     "typescript": "~3.5.3"
   }
 }

--- a/packages/core/src/express/create-middleware.spec.ts
+++ b/packages/core/src/express/create-middleware.spec.ts
@@ -53,10 +53,14 @@ describe('createMiddleware', () => {
     });
 
     it('should call the controller method with a context created from the request.', async () => {
-      let body = {};
+      let ctxBody = null;
+      let params = null;
+      let body = null;
       const route: Route = {
-        controller: { bar: (ctx: Context) => {
-          body = ctx.request.body;
+        controller: { bar: (ctx: Context, paramsBody: any, requestBody: any) => {
+          ctxBody = ctx.request.body;
+          params = paramsBody;
+          body = requestBody;
           return new HttpResponseOK();
         }},
         hooks: [],
@@ -64,14 +68,16 @@ describe('createMiddleware', () => {
         path: '',
         propertyKey: 'bar'
       };
-      const request = createRequest({ body: { foo: 'bar' } });
+      const request = createRequest({ body: { foo: 'bar' }, params: { id: '1' } });
       const response = createResponse();
 
       const middleware = createMiddleware(route, new ServiceManager());
 
       await middleware(request, response, () => {});
 
-      deepStrictEqual(body, request.body);
+      deepStrictEqual(ctxBody, request.body);
+      deepStrictEqual(params, request.params, 'The request params should be passed as the second argument.');
+      deepStrictEqual(body, request.body, 'The request body should be passed as the third argument.');
     });
 
     it('should call the sync and async hooks (with the ctx and the given ServiceManager)'

--- a/packages/core/src/express/create-middleware.ts
+++ b/packages/core/src/express/create-middleware.ts
@@ -38,7 +38,7 @@ export function createMiddleware(route: Route, services: ServiceManager) {
       }
 
       if (!isHttpResponse(response)) {
-        response = await route.controller[route.propertyKey](ctx);
+        response = await route.controller[route.propertyKey](ctx, ctx.request.params, ctx.request.body);
       }
 
       if (!isHttpResponse(response)) {

--- a/packages/core/src/sessions/session.ts
+++ b/packages/core/src/sessions/session.ts
@@ -37,7 +37,7 @@ export class Session {
   }
 
   /**
-   * Return true if an element was added/replaces in the session
+   * Return true if an element was added/replaced in the session
    *
    * @readonly
    * @type {boolean}


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Resolves #507 .

Also fixes bug #706.

# Solution and steps

The request body and path parameters are now also passed as third and second arguments to the controller methods.

```typescript
// Product is here a class validator in this example.

// before
class AppController {

  @Put('/products/:id')
  @ValidateBody(Product)
  updateProduct(ctx: Context) {
    const id = ctx.request.params.id;
    const body = ctx.request.body as Product;

    // Do something.
  }

}

// after
class AppController {

  @Put('/products/:id')
  @ValidateBody(Product)
  updateProduct(ctx: Context, { id }, body: Product) {
    // Do something.
  }

}
```

- [x] Add the feature.
- [x] Write doc.
- [x] Fix bug #706.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
