### PR TITLE
[Sessions] Allow to specify the store name in a configuration file

### DIFF
--- a/docs/authentication-and-access-control/session-tokens.md
+++ b/docs/authentication-and-access-control/session-tokens.md
@@ -371,6 +371,33 @@ Run the script.
 foal run revoke-all-sessions
 ```
 
+## Specifying Globally the Session Store
+
+> Available in Foal v1.10.0 onwards.
+
+In order to avoid passing the session store to the hooks each time, you can provide it via the configuration.
+
+*default.yml*
+```yaml
+settings:
+  session:
+    store: '@foal/typeorm' # or '@foal/mongodb' or '@foal/redis'
+```
+
+```typescript
+// Before
+@TokenRequired({ store: TypeORMStore })
+export class ApiController {
+  // ...
+}
+
+// After
+@TokenRequired()
+export class ApiController {
+  // ...
+}
+```
+
 ## Session Stores
 
 FoalTS currently offers three built-in session stores: `TypeORMStore`, `MongoDBStore` `RedisStore`. Others will come in the future. If you need a specific one, you can submit a Github issue or even create your own store (see section below).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -89,6 +89,7 @@
   },
   "devDependencies": {
     "@foal/ejs": "^1.9.0",
+    "@foal/internal-test": "^1.9.0",
     "@types/mocha": "~2.2.43",
     "@types/node": "~10.1.2",
     "@types/supertest": "~2.0.5",

--- a/packages/core/src/sessions/token-optional.hook.ts
+++ b/packages/core/src/sessions/token-optional.hook.ts
@@ -6,7 +6,7 @@ import { Token, TokenOptions } from './token.hook';
 
 // TODO: Add missing documentation.
 
-export function TokenOptional(options: TokenOptions): HookDecorator {
+export function TokenOptional(options: TokenOptions = {}): HookDecorator {
   return (target: any, propertyKey?: string) =>  {
     Token(false, options)(target, propertyKey);
 

--- a/packages/core/src/sessions/token-required.hook.ts
+++ b/packages/core/src/sessions/token-required.hook.ts
@@ -6,7 +6,7 @@ import { Token, TokenOptions } from './token.hook';
 
 // TODO: Add missing documentation.
 
-export function TokenRequired(options: TokenOptions): HookDecorator {
+export function TokenRequired(options: TokenOptions = {}): HookDecorator {
   return (target: any, propertyKey?: string) =>  {
     Token(true, options)(target, propertyKey);
 

--- a/packages/core/src/sessions/token.hook.spec.ts
+++ b/packages/core/src/sessions/token.hook.spec.ts
@@ -67,6 +67,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
   afterEach(() => {
     delete process.env.SETTINGS_SESSION_SECRET;
     delete process.env.SETTINGS_SESSION_COOKIE_NAME;
+    delete process.env.SETTINGS_SESSION_STORE;
   });
 
   beforeEach(() => {
@@ -92,6 +93,25 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
         strictEqual(
           error.msg,
           'You must provide the package name of your session store when using @TokenRequired or @TokenOptional.'
+        );
+      }
+    });
+
+    it('should throw an error if the package name provided in settings.session.store is not installed.', async () => {
+      process.env.SETTINGS_SESSION_STORE = 'foobarxxx';
+
+      const hook = getHookFunction(Token({}));
+
+      const ctx = new Context({});
+
+      try {
+        await hook(ctx, services);
+        throw new Error('The hook should have thrown an error.')
+      } catch (error) {
+        strictEqual(
+          error.message,
+          'The package "foobarxxx" provided with the configuration key settings.session.store was not found.'
+          + ' Did you install it?'
         );
       }
     });

--- a/packages/core/src/sessions/token.hook.spec.ts
+++ b/packages/core/src/sessions/token.hook.spec.ts
@@ -71,6 +71,19 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     services.get(Store).clear();
   });
 
+  it('should throw an error if no store is provided as option.', async () => {
+    const hook = getHookFunction(Token({}));
+
+    const ctx = new Context({});
+
+    try {
+      await hook(ctx, services);
+      throw new Error('The hook should have thrown an error.')
+    } catch (error) {
+      strictEqual(error.message, 'You must provide a SessionStore class to the hook.')
+    }
+  })
+
   describe('should validate the request and', () => {
 
     describe('given options.cookie is false or not defined', () => {

--- a/packages/core/src/sessions/token.hook.spec.ts
+++ b/packages/core/src/sessions/token.hook.spec.ts
@@ -1,6 +1,9 @@
 import { deepStrictEqual, strictEqual } from 'assert';
 import {
-  Class, Context, getHookFunction,
+  Class,
+  ConfigNotFoundError,
+  Context,
+  getHookFunction,
   HttpResponseOK,
   isHttpResponse,
   isHttpResponseBadRequest,
@@ -71,18 +74,29 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     services.get(Store).clear();
   });
 
-  it('should throw an error if no store is provided as option.', async () => {
-    const hook = getHookFunction(Token({}));
+  describe('when no session store class is provided as option', () => {
 
-    const ctx = new Context({});
+    it('should throw an error if the configuration value settings.session.store is empty.', async () => {
+      const hook = getHookFunction(Token({}));
 
-    try {
-      await hook(ctx, services);
-      throw new Error('The hook should have thrown an error.')
-    } catch (error) {
-      strictEqual(error.message, 'You must provide a SessionStore class to the hook.')
-    }
-  })
+      const ctx = new Context({});
+  
+      try {
+        await hook(ctx, services);
+        throw new Error('The hook should have thrown an error.')
+      } catch (error) {
+        if (!(error instanceof ConfigNotFoundError)) {
+          throw new Error('A ConfigNotFoundError should have been thrown');
+        }
+        strictEqual(error.key, 'settings.session.store');
+        strictEqual(
+          error.msg,
+          'You must provide the package name of your session store when using @TokenRequired or @TokenOptional.'
+        );
+      }
+    });
+
+  });
 
   describe('should validate the request and', () => {
 

--- a/packages/core/src/sessions/token.hook.spec.ts
+++ b/packages/core/src/sessions/token.hook.spec.ts
@@ -97,7 +97,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
       }
     });
 
-    it('should throw an error if the package name provided in settings.session.store is not installed.', async () => {
+    it('should throw an error if the store package provided in settings.session.store is not installed.', async () => {
       process.env.SETTINGS_SESSION_STORE = 'foobarxxx';
 
       const hook = getHookFunction(Token({}));
@@ -115,6 +115,29 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
         );
       }
     });
+
+    it(
+      'should throw an error if the store package provided in settings.session.store'
+      + ' does not export a ConcreteSessionStore.',
+      async () => {
+        process.env.SETTINGS_SESSION_STORE = 'supertest';
+
+        const hook = getHookFunction(Token({}));
+
+        const ctx = new Context({});
+
+        try {
+          await hook(ctx, services);
+          throw new Error('The hook should have thrown an error.');
+        } catch (error) {
+          strictEqual(
+            error.message,
+            'The package "supertest" does not export a ConcreteSessionStore class.'
+            + ' Are you sure it is a session store package?'
+          );
+        }
+      }
+    );
 
   });
 

--- a/packages/core/src/sessions/token.hook.spec.ts
+++ b/packages/core/src/sessions/token.hook.spec.ts
@@ -78,13 +78,9 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
   describe('when no session store class is provided as option', () => {
 
     it('should throw an error if the configuration value settings.session.store is empty.', async () => {
-      const hook = getHookFunction(Token({}));
-
-      const ctx = new Context({});
-  
       try {
-        await hook(ctx, services);
-        throw new Error('The hook should have thrown an error.')
+        getHookFunction(Token({}));
+        throw new Error('The hook should have thrown an error.');
       } catch (error) {
         if (!(error instanceof ConfigNotFoundError)) {
           throw new Error('A ConfigNotFoundError should have been thrown');
@@ -100,13 +96,8 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     it('should throw an error if the store package provided in settings.session.store is not installed.', async () => {
       process.env.SETTINGS_SESSION_STORE = 'foobarxxx';
 
-      const hook = getHookFunction(Token({}));
-
-      const ctx = new Context({});
-
       try {
-        await hook(ctx, services);
-        throw new Error('The hook should have thrown an error.')
+        getHookFunction(Token({}));
       } catch (error) {
         strictEqual(
           error.message,
@@ -119,15 +110,11 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     it(
       'should throw an error if the store package provided in settings.session.store'
       + ' does not export a ConcreteSessionStore.',
-      async () => {
+      () => {
         process.env.SETTINGS_SESSION_STORE = 'supertest';
 
-        const hook = getHookFunction(Token({}));
-
-        const ctx = new Context({});
-
         try {
-          await hook(ctx, services);
+          getHookFunction(Token({}));
           throw new Error('The hook should have thrown an error.');
         } catch (error) {
           strictEqual(
@@ -138,6 +125,26 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
         }
       }
     );
+
+    // TODO: improve this test. This code actually tests that no error is thrown but not that
+    // the ConcreteSessionStore is assigned to options.store.
+    it('should use the session store package provided in settings.session.store.', async () => {
+      process.env.SETTINGS_SESSION_STORE = '@foal/internal-test';
+
+      const hook = getHookFunction(Token({}));
+
+      const ctx = new Context({});
+
+      try {
+        await hook(ctx, services);
+        throw new Error('The hook should have thrown an error.');
+      } catch (error) {
+        strictEqual(
+          error.message,
+          'ctx.request.get is not a function'
+        );
+      }
+    });
 
   });
 

--- a/packages/core/src/sessions/token.hook.ts
+++ b/packages/core/src/sessions/token.hook.ts
@@ -45,6 +45,11 @@ export interface TokenOptions {
 export function Token(required: boolean, options: TokenOptions): HookDecorator {
   return Hook(async (ctx: Context, services: ServiceManager) => {
     if (!options.store) {
+      Config.getOrThrow(
+        'settings.session.store',
+        'string',
+        'You must provide the package name of your session store when using @TokenRequired or @TokenOptional.'
+      );
       throw new Error('You must provide a SessionStore class to the hook.');
     }
 

--- a/packages/core/src/sessions/token.hook.ts
+++ b/packages/core/src/sessions/token.hook.ts
@@ -35,7 +35,7 @@ class InvalidTokenResponse extends HttpResponseUnauthorized {
 
 export interface TokenOptions {
   user?: (id: string|number) => Promise<any|undefined>;
-  store: Class<SessionStore>;
+  store?: Class<SessionStore>;
   cookie?: boolean;
   redirectTo?: string;
   openapi?: boolean;
@@ -44,6 +44,10 @@ export interface TokenOptions {
 
 export function Token(required: boolean, options: TokenOptions): HookDecorator {
   return Hook(async (ctx: Context, services: ServiceManager) => {
+    if (!options.store) {
+      throw new Error('You must provide a SessionStore class to the hook.');
+    }
+
     const cookieName = Config.get2('settings.session.cookie.name', 'string', SESSION_DEFAULT_COOKIE_NAME);
 
     /* Validate the request */

--- a/packages/core/src/sessions/token.hook.ts
+++ b/packages/core/src/sessions/token.hook.ts
@@ -42,28 +42,40 @@ export interface TokenOptions {
   extendLifeTimeOrUpdate?: boolean;
 }
 
+function getSessionStoreClass() {
+  const pkgName = Config.getOrThrow(
+    'settings.session.store',
+    'string',
+    'You must provide the package name of your session store when using @TokenRequired or @TokenOptional.'
+  );
+
+  let pkg: { ConcreteSessionStore?: Class<SessionStore> };
+  try {
+    pkg = require(pkgName);
+  } catch (err) {
+    // TODO: test this line
+    if (err.code !== 'MODULE_NOT_FOUND') {
+      throw err;
+    }
+    throw new Error(
+      `The package "${pkgName}" provided with the configuration key settings.session.store was not found.`
+      + ' Did you install it?'
+    );
+  }
+
+  if (!pkg.ConcreteSessionStore) {
+    throw new Error(
+      `The package "${pkgName}" does not export a ConcreteSessionStore class.`
+      + ' Are you sure it is a session store package?'
+    );
+  }
+}
+
 export function Token(required: boolean, options: TokenOptions): HookDecorator {
   return Hook(async (ctx: Context, services: ServiceManager) => {
     if (!options.store) {
-      const pkgName = Config.getOrThrow(
-        'settings.session.store',
-        'string',
-        'You must provide the package name of your session store when using @TokenRequired or @TokenOptional.'
-      );
-
-      try {
-        require(pkgName);
-      } catch (err) {
-        // TODO: test this line
-        if (err.code !== 'MODULE_NOT_FOUND') {
-          throw err;
-        }
-        throw new Error(
-          `The package "${pkgName}" provided with the configuration key settings.session.store was not found.`
-          + ' Did you install it?'
-        );
-      }
-      throw new Error('You must provide a SessionStore class to the hook.');
+      getSessionStoreClass();
+      throw new Error('You musdssss to the hook.');
     }
 
     const cookieName = Config.get2('settings.session.cookie.name', 'string', SESSION_DEFAULT_COOKIE_NAME);

--- a/packages/core/src/sessions/token.hook.ts
+++ b/packages/core/src/sessions/token.hook.ts
@@ -45,11 +45,24 @@ export interface TokenOptions {
 export function Token(required: boolean, options: TokenOptions): HookDecorator {
   return Hook(async (ctx: Context, services: ServiceManager) => {
     if (!options.store) {
-      Config.getOrThrow(
+      const pkgName = Config.getOrThrow(
         'settings.session.store',
         'string',
         'You must provide the package name of your session store when using @TokenRequired or @TokenOptional.'
       );
+
+      try {
+        require(pkgName);
+      } catch (err) {
+        // TODO: test this line
+        if (err.code !== 'MODULE_NOT_FOUND') {
+          throw err;
+        }
+        throw new Error(
+          `The package "${pkgName}" provided with the configuration key settings.session.store was not found.`
+          + ' Did you install it?'
+        );
+      }
       throw new Error('You must provide a SessionStore class to the hook.');
     }
 

--- a/packages/core/src/sessions/token.hook.ts
+++ b/packages/core/src/sessions/token.hook.ts
@@ -42,7 +42,7 @@ export interface TokenOptions {
   extendLifeTimeOrUpdate?: boolean;
 }
 
-function getSessionStoreClass() {
+function getSessionStoreClass(): Class<SessionStore> {
   const pkgName = Config.getOrThrow(
     'settings.session.store',
     'string',
@@ -69,14 +69,14 @@ function getSessionStoreClass() {
       + ' Are you sure it is a session store package?'
     );
   }
+
+  return pkg.ConcreteSessionStore;
 }
 
 export function Token(required: boolean, options: TokenOptions): HookDecorator {
+  const ConcreteSessionStore = options.store || getSessionStoreClass();
+
   return Hook(async (ctx: Context, services: ServiceManager) => {
-    if (!options.store) {
-      getSessionStoreClass();
-      throw new Error('You musdssss to the hook.');
-    }
 
     const cookieName = Config.get2('settings.session.cookie.name', 'string', SESSION_DEFAULT_COOKIE_NAME);
 
@@ -137,7 +137,7 @@ export function Token(required: boolean, options: TokenOptions): HookDecorator {
 
     /* Verify the session ID */
 
-    const store = services.get(options.store);
+    const store = services.get(ConcreteSessionStore);
     const session = await store.read(sessionID);
 
     if (!session) {

--- a/packages/internal-test/src/index.ts
+++ b/packages/internal-test/src/index.ts
@@ -18,3 +18,8 @@ export class ConcreteDisk {
     throw new Error('internal-test package: delete called');
   }
 }
+
+// Used in @foal/core:
+export class ConcreteSessionStore {
+
+}

--- a/packages/mongodb/src/index.ts
+++ b/packages/mongodb/src/index.ts
@@ -4,4 +4,4 @@
  * Released under the MIT License.
  */
 
-export { MongoDBStore } from './mongodb-store.service';
+export { MongoDBStore, MongoDBStore as ConcreteSessionStore } from './mongodb-store.service';

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -4,4 +4,4 @@
  * Released under the MIT License.
  */
 
-export { RedisStore } from './redis-store.service';
+export { RedisStore, RedisStore as ConcreteSessionStore } from './redis-store.service';

--- a/packages/storage/src/disk.service.spec.ts
+++ b/packages/storage/src/disk.service.spec.ts
@@ -69,7 +69,7 @@ describe('Disk', () => {
       } catch (error) {
         strictEqual(
           error.message,
-          '"@foal/core" is not a valid driver. Cannot find the "ConcreteClass" export.'
+          '"@foal/core" is not a valid driver. Cannot find the "ConcreteDisk" export.'
         );
       }
     });

--- a/packages/storage/src/disk.service.spec.ts
+++ b/packages/storage/src/disk.service.spec.ts
@@ -139,7 +139,7 @@ describe('Disk', () => {
       } catch (error) {
         strictEqual(
           error.message,
-          '"@foal/core" is not a valid driver. Cannot find the "ConcreteClass" export.'
+          '"@foal/core" is not a valid driver. Cannot find the "ConcreteDisk" export.'
         );
       }
     });
@@ -209,7 +209,7 @@ describe('Disk', () => {
       } catch (error) {
         strictEqual(
           error.message,
-          '"@foal/core" is not a valid driver. Cannot find the "ConcreteClass" export.'
+          '"@foal/core" is not a valid driver. Cannot find the "ConcreteDisk" export.'
         );
       }
     });

--- a/packages/storage/src/disk.service.ts
+++ b/packages/storage/src/disk.service.ts
@@ -60,7 +60,7 @@ export class Disk extends AbstractDisk {
 
     const { ConcreteDisk } = require(driver) as { ConcreteDisk: Class<AbstractDisk>|undefined };
     if (!ConcreteDisk) {
-      throw new Error(`"${driver}" is not a valid driver. Cannot find the "ConcreteClass" export.`);
+      throw new Error(`"${driver}" is not a valid driver. Cannot find the "ConcreteDisk" export.`);
     }
     return this.services.get(ConcreteDisk);
   }

--- a/packages/typeorm/src/index.ts
+++ b/packages/typeorm/src/index.ts
@@ -7,4 +7,4 @@
 export * from './entities';
 export * from './hooks';
 export * from './utils';
-export { TypeORMStore } from './typeorm-store.service';
+export { TypeORMStore, TypeORMStore as ConcreteSessionStore } from './typeorm-store.service';


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Resolves #725

# Solution and steps

- [x] Export the store as `SessionStore` in the three packages `@foal/mongodb`, `@foal/typeorm` and `@foal/redis`.
- [x] Make store property optional and throw error if not given.
- [x] Support settings.session.store and throw error if property and settings are not provided.
- [x] Throw an error if module not found
- [x] Throw an error if no SessionStore
- [x] Export a SessionStore in internal test
- [x] Test with this store

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
