### PR TITLE
Extend ValidateBody from typestack

### DIFF
--- a/docs/validation-and-sanitization.md
+++ b/docs/validation-and-sanitization.md
@@ -572,7 +572,7 @@ export class SocialPost {
 
 ```
 
-*social-post.controller.ts*
+*social-post.controller.ts (first example)*
 ```typescript
 import { Context, HttpResponseCreated, Post } from '@foal/core';
 import { ValidateBody } from '@foal/typestack';
@@ -582,6 +582,26 @@ export class SocialPostController {
 
   @Post()
   @ValidateBody(SocialPost, { /* options if relevant */ })
+  createSocialPost(ctx: Context) {
+    // ctx.request.body is an instance of SocialPost.
+    // ...
+    return new HttpResponseCreated();
+  }
+
+}
+```
+
+*social-post.controller.ts (second example)*
+```typescript
+import { Context, HttpResponseCreated, Post } from '@foal/core';
+import { ValidateBody } from '@foal/typestack';
+import { SocialPost } from './social-post.validator';
+
+export class SocialPostController {
+  entityClass = SocialPost;
+
+  @Post()
+  @ValidateBody(controller => controller.entityClass, { /* options if relevant */ })
   createSocialPost(ctx: Context) {
     // ctx.request.body is an instance of SocialPost.
     // ...

--- a/packages/typestack/src/validate-body.hook.spec.ts
+++ b/packages/typestack/src/validate-body.hook.spec.ts
@@ -2,172 +2,186 @@
 import { deepStrictEqual, strictEqual } from 'assert';
 
 // 3p
-import { Context, getHookFunction, isHttpResponseBadRequest, ServiceManager } from '@foal/core';
+import { Class, Context, getHookFunction, HookFunction, isHttpResponseBadRequest, ServiceManager } from '@foal/core';
 import { Expose } from 'class-transformer';
 import { IsNumber, Min } from 'class-validator';
 
 // FoalTS
-import { ValidateBody } from './validate-body.hook';
+import { ValidateBody, ValidateBodyOptions } from './validate-body.hook';
 
 describe('ValidateBody', () => {
 
   class Product {}
+  context('given class as argument', () => {
+    testSuite((cls, options) => getHookFunction(ValidateBody(cls, options)));
+  });
 
-  it('should return an HttpResponseBadRequest instance if ctx.request.body is not an object.', async () => {
-    const hook = getHookFunction(ValidateBody(Product));
-    const ctx = new Context({});
-    ctx.request.body = 3;
+  context('given arrow function as argument', () => {
+    testSuite(
+        (cls, options) =>
+        getHookFunction(ValidateBody((controller: any) => controller.entityClass, options))
+            .bind({ entityClass: cls })
+    );
+  });
 
-    const actual = await hook(ctx, new ServiceManager());
-    if (!isHttpResponseBadRequest(actual)) {
-      throw new Error('The hook should have returned an HttpResponseBadRequest instance.');
-    }
-    deepStrictEqual(actual.body, {
-      message: 'The request body should be a valid JSON object or array.'
+  function testSuite(getHook: (cls: Class, options?: ValidateBodyOptions) => HookFunction) {
+    it('should return an HttpResponseBadRequest instance if ctx.request.body is not an object.', async () => {
+      const hook = getHook(Product);
+      const ctx = new Context({});
+      ctx.request.body = 3;
+
+      const actual = await hook(ctx, new ServiceManager());
+      if (!isHttpResponseBadRequest(actual)) {
+        throw new Error('The hook should have returned an HttpResponseBadRequest instance.');
+      }
+      deepStrictEqual(actual.body, {
+        message: 'The request body should be a valid JSON object or array.'
+      });
+
+      const ctx2 = new Context({});
+      ctx2.request.body = null;
+
+      const actual2 = await hook(ctx2, new ServiceManager());
+      if (!isHttpResponseBadRequest(actual2)) {
+        throw new Error('The hook should have returned an HttpResponseBadRequest instance.');
+      }
+      deepStrictEqual(actual2.body, {
+        message: 'The request body should be a valid JSON object or array.'
+      });
     });
 
-    const ctx2 = new Context({});
-    ctx2.request.body = null;
-
-    const actual2 = await hook(ctx2, new ServiceManager());
-    if (!isHttpResponseBadRequest(actual2)) {
-      throw new Error('The hook should have returned an HttpResponseBadRequest instance.');
-    }
-    deepStrictEqual(actual2.body, {
-      message: 'The request body should be a valid JSON object or array.'
-    });
-  });
-
-  it('should unserialize the request body (plain object).', async () => {
-    const hook = getHookFunction(ValidateBody(Product));
-    const ctx = new Context({});
-    ctx.request.body = {
-      foo: 3
-    };
-
-    await hook(ctx, new ServiceManager());
-
-    strictEqual(ctx.request.body instanceof Product, true);
-    deepStrictEqual(ctx.request.body, Object.assign(new Product(), {
-      foo: 3
-    }));
-  });
-
-  it('should unserialize the request body (plain object & options).', async () => {
-    class Product {
-      @Expose() id: number;
-      @Expose() firstName: string;
-      @Expose() lastName: string;
-    }
-
-    const hook = getHookFunction(ValidateBody(Product, {
-      transformer: {  excludeExtraneousValues: true  }
-    }));
-    const ctx = new Context({});
-    ctx.request.body = {
-      firstName: 'Kelly',
-      lastName: 'Smith',
-      unkownProp: 'hello there',
-    };
-
-    await hook(ctx, new ServiceManager());
-
-    strictEqual(ctx.request.body instanceof Product, true);
-    deepStrictEqual(ctx.request.body, Object.assign(new Product(), {
-      firstName: 'Kelly',
-      id: undefined,
-      lastName: 'Smith',
-    }));
-  });
-
-  it('should unserialize the request body (array of plain objects).', async () => {
-    const hook = getHookFunction(ValidateBody(Product));
-    const ctx = new Context({});
-    ctx.request.body = [
-      {
-        foo: 4
-      },
-      {
+    it('should unserialize the request body (plain object).', async () => {
+      const hook = getHook(Product);
+      const ctx = new Context({});
+      ctx.request.body = {
         foo: 3
-      }
-    ];
-
-    await hook(ctx, new ServiceManager());
-
-    strictEqual(ctx.request.body[0] instanceof Product, true);
-    deepStrictEqual(ctx.request.body[0], Object.assign(new Product(), {
-      foo: 4
-    }));
-    strictEqual(ctx.request.body[1] instanceof Product, true);
-    deepStrictEqual(ctx.request.body[1], Object.assign(new Product(), {
-      foo: 3
-    }));
-  });
-
-  describe('should validate the request body and', () => {
-
-    class Product {
-      @IsNumber()
-      foo: number;
-    }
-
-    it('return an HttpResponseBadRequest instance if the validation fails (plain object).', async () => {
-      const hook = getHookFunction(ValidateBody(Product));
-      const ctx = new Context({});
-      ctx.request.body = {
-        foo: 'hello'
       };
 
-      const actual = await hook(ctx, new ServiceManager());
-      if (!isHttpResponseBadRequest(actual)) {
-        throw new Error('The hook should have returned an HttpResponseBadRequest instance.');
-      }
-      if (!Array.isArray(actual.body)) {
-        throw new Error('The hook should have returned the errors');
-      }
-      strictEqual(actual.body.length, 1);
-    });
+      await hook(ctx, new ServiceManager());
 
-    it('return an HttpResponseBadRequest instance if the validation fails (plain object & options).', async () => {
-      class Product {
-        @Min(10, {
-          groups: [ 'a' ]
-        })
-        foo: number;
-
-        @Min(10)
-        bar: number;
-      }
-      const hook = getHookFunction(ValidateBody(Product, {
-        validator: { groups: [ 'a' ] }
+      strictEqual(ctx.request.body instanceof Product, true);
+      deepStrictEqual(ctx.request.body, Object.assign(new Product(), {
+        foo: 3
       }));
-      const ctx = new Context({});
-      ctx.request.body = {
-        bar: 3,
-        foo: 3,
-      };
-
-      const actual = await hook(ctx, new ServiceManager());
-      if (!isHttpResponseBadRequest(actual)) {
-        throw new Error('The hook should have returned an HttpResponseBadRequest instance.');
-      }
-      if (!Array.isArray(actual.body)) {
-        throw new Error('The hook should have returned the errors');
-      }
-      strictEqual(actual.body.length, 1);
     });
 
-    it('return nothing if the validation succeeds.', async () => {
-      const hook = getHookFunction(ValidateBody(Product));
+    it('should unserialize the request body (plain object & options).', async () => {
+      class Product {
+        @Expose() id: number;
+        @Expose() firstName: string;
+        @Expose() lastName: string;
+      }
+
+      const hook = getHook(Product, {
+        transformer: {  excludeExtraneousValues: true  }
+      });
       const ctx = new Context({});
       ctx.request.body = {
-        foo: 13
+        firstName: 'Kelly',
+        lastName: 'Smith',
+        unknownProp: 'hello there',
       };
 
-      const actual = await hook(ctx, new ServiceManager());
-      strictEqual(actual, undefined);
+      await hook(ctx, new ServiceManager());
+
+      strictEqual(ctx.request.body instanceof Product, true);
+      deepStrictEqual(ctx.request.body, Object.assign(new Product(), {
+        firstName: 'Kelly',
+        id: undefined,
+        lastName: 'Smith',
+      }));
     });
 
-  });
+    it('should unserialize the request body (array of plain objects).', async () => {
+      const hook = getHook(Product);
+      const ctx = new Context({});
+      ctx.request.body = [
+        {
+          foo: 4
+        },
+        {
+          foo: 3
+        }
+      ];
+
+      await hook(ctx, new ServiceManager());
+
+      strictEqual(ctx.request.body[0] instanceof Product, true);
+      deepStrictEqual(ctx.request.body[0], Object.assign(new Product(), {
+        foo: 4
+      }));
+      strictEqual(ctx.request.body[1] instanceof Product, true);
+      deepStrictEqual(ctx.request.body[1], Object.assign(new Product(), {
+        foo: 3
+      }));
+    });
+
+    describe('should validate the request body and', () => {
+
+      class Product {
+        @IsNumber()
+        foo: number;
+      }
+
+      it('return an HttpResponseBadRequest instance if the validation fails (plain object).', async () => {
+        const hook = getHook(Product);
+        const ctx = new Context({});
+        ctx.request.body = {
+          foo: 'hello'
+        };
+
+        const actual = await hook(ctx, new ServiceManager());
+        if (!isHttpResponseBadRequest(actual)) {
+          throw new Error('The hook should have returned an HttpResponseBadRequest instance.');
+        }
+        if (!Array.isArray(actual.body)) {
+          throw new Error('The hook should have returned the errors');
+        }
+        strictEqual(actual.body.length, 1);
+      });
+
+      it('return an HttpResponseBadRequest instance if the validation fails (plain object & options).', async () => {
+        class Product {
+          @Min(10, {
+            groups: [ 'a' ]
+          })
+          foo: number;
+
+          @Min(10)
+          bar: number;
+        }
+        const hook = getHook(Product, {
+          validator: { groups: [ 'a' ] }
+        });
+        const ctx = new Context({});
+        ctx.request.body = {
+          bar: 3,
+          foo: 3,
+        };
+
+        const actual = await hook(ctx, new ServiceManager());
+        if (!isHttpResponseBadRequest(actual)) {
+          throw new Error('The hook should have returned an HttpResponseBadRequest instance.');
+        }
+        if (!Array.isArray(actual.body)) {
+          throw new Error('The hook should have returned the errors');
+        }
+        strictEqual(actual.body.length, 1);
+      });
+
+      it('return nothing if the validation succeeds.', async () => {
+        const hook = getHook(Product);
+        const ctx = new Context({});
+        ctx.request.body = {
+          foo: 13
+        };
+
+        const actual = await hook(ctx, new ServiceManager());
+        strictEqual(actual, undefined);
+      });
+
+    });
+
+  }
 
 });


### PR DESCRIPTION
Add ability to provide "factory function" for clas against which body will be validated.

# Issue
#752 

# Solution and steps
It turned out to be a little bit harder and flaky than ValidateBody from core. There is no robust difference between function and class (it's just a constructor function). The only way I found, use only arrow functions in this decorator if you want it to be generic, cause they cannot be used as constructors and don't have `prototype`. (https://stackoverflow.com/a/45759444/6540091).
Maybe it's worth adding separate decorator for this case, though I didn't came up with meaningfull name for it.

P.S. I didn't update the docs, cause I'm not sure of the solution.
# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [ ] Update/check the cli generators.

