### PR TITLE
Update services-and-dependency-injection.md

### DIFF
--- a/docs/architecture/services-and-dependency-injection.md
+++ b/docs/architecture/services-and-dependency-injection.md
@@ -285,7 +285,7 @@ export interface ILogger {
 ```typescript
 import { ILogger } from './logger.interface';
 
-export class Logger implements ILogger {
+export class ConsoleLogger implements ILogger {
   log(message: any): void {
     console.log(message);
   }
@@ -307,7 +307,7 @@ async function main() {
 
   const serviceManager = new ServiceManager()
     .set('product', productRepository)
-    .set('logger', new Logger());
+    .set('logger', new ConsoleLogger());
 
   const app = createApp(AppController, {
     serviceManager

--- a/packages/acceptance-tests/src/examples/architecture/services-and-dependency-injection.spec.ts
+++ b/packages/acceptance-tests/src/examples/architecture/services-and-dependency-injection.spec.ts
@@ -92,7 +92,7 @@ describe('[Docs] Architecture > Services', () => {
     }
 
     let msg: any = null;
-    class Logger implements ILogger {
+    class ConsoleLogger implements ILogger {
       log(message: any): void {
         msg = message;
       }
@@ -110,7 +110,7 @@ describe('[Docs] Architecture > Services', () => {
 
       const serviceManager = new ServiceManager()
         .set('product', productRepository)
-        .set('logger', new Logger());
+        .set('logger', new ConsoleLogger());
 
       const app = createApp(AppController, {
         serviceManager


### PR DESCRIPTION
The power of interfaces comes from having a generic interface and implementing it with concrete instances.

❌ Avoid generic implementations `LoggerImpl` and `Logger`.

✔️ Prefer concrete implementations `ConsoleLogger` , `LocalFileLogger`, etc.

Brilliant project by the way 👍