### PR TITLE
[V2][Sessions] Do not let TypeORMStore auto-update the database schema.

### DIFF
--- a/docs/authentication-and-access-control/quick-start.md
+++ b/docs/authentication-and-access-control/quick-start.md
@@ -54,6 +54,8 @@ You will find more information in the documentation pages dedicated to them.
 
 ## Code Examples
 
+> warning: version 2 -> add the migrations
+
 The four examples below can be used directly in your application to configure login, logout and signup routes. You can use them as they are or customize them to meet your specific needs.
 
 For these examples, we will use TypeORM as default ORM and emails and passwords as credentials. An API will allow authenticated users to list *products* with the request `GET /api/products`.

--- a/docs/authentication-and-access-control/session-tokens.md
+++ b/docs/authentication-and-access-control/session-tokens.md
@@ -10,6 +10,8 @@ A session usually begins when the user logs in and ends after a period of inacti
 
 ## Get Started
 
+> warning: version 2 -> add the migrations
+
 ### Choose a Session Store
 
 Then you have to choose where the temporary session state will be stored. FoalTS provides several *session stores* for this. For example, you can use the `TypeORMStore` to save the sessions in your SQL database or the `RedisStore` to save them in a redis cache.

--- a/packages/acceptance-tests/src/authentication/session-token.cookie.redirection.spec.ts
+++ b/packages/acceptance-tests/src/authentication/session-token.cookie.redirection.spec.ts
@@ -14,7 +14,7 @@ import {
   HttpResponseOK, HttpResponseRedirect, Post,
   setSessionCookie, TokenOptional, TokenRequired, ValidateBody, verifyPassword
 } from '@foal/core';
-import { TypeORMStore } from '@foal/typeorm';
+import { DatabaseSession, TypeORMStore } from '@foal/typeorm';
 
 describe('[Authentication|session token|cookie|redirection] Users', () => {
 
@@ -122,7 +122,7 @@ describe('[Authentication|session token|cookie|redirection] Users', () => {
     await createConnection({
       database: 'e2e_db.sqlite',
       dropSchema: true,
-      entities: [ User ],
+      entities: [ User, DatabaseSession ],
       synchronize: true,
       type: 'sqlite',
     });

--- a/packages/acceptance-tests/src/authentication/session-token.cookie.spec.ts
+++ b/packages/acceptance-tests/src/authentication/session-token.cookie.spec.ts
@@ -15,7 +15,7 @@ import {
   HttpResponseUnauthorized, Post,
   setSessionCookie, TokenOptional, TokenRequired, ValidateBody, verifyPassword
 } from '@foal/core';
-import { TypeORMStore } from '@foal/typeorm';
+import { DatabaseSession, TypeORMStore } from '@foal/typeorm';
 
 describe('[Authentication|session token|cookie|no redirection] Users', () => {
 
@@ -116,7 +116,7 @@ describe('[Authentication|session token|cookie|no redirection] Users', () => {
     await createConnection({
       database: 'e2e_db.sqlite',
       dropSchema: true,
-      entities: [ User ],
+      entities: [ User, DatabaseSession ],
       synchronize: true,
       type: 'sqlite',
     });

--- a/packages/acceptance-tests/src/authentication/session-token.token.spec.ts
+++ b/packages/acceptance-tests/src/authentication/session-token.token.spec.ts
@@ -14,7 +14,7 @@ import {
   hashPassword, HttpResponseNoContent, HttpResponseOK,
   HttpResponseUnauthorized, Post, TokenOptional, TokenRequired, ValidateBody, verifyPassword
 } from '@foal/core';
-import { TypeORMStore } from '@foal/typeorm';
+import { DatabaseSession, TypeORMStore } from '@foal/typeorm';
 
 describe('[Authentication|session token|no cookie|no redirection] Users', () => {
 
@@ -110,7 +110,7 @@ describe('[Authentication|session token|no cookie|no redirection] Users', () => 
     await createConnection({
       database: 'e2e_db.sqlite',
       dropSchema: true,
-      entities: [ User ],
+      entities: [ User, DatabaseSession ],
       synchronize: true,
       type: 'sqlite',
     });

--- a/packages/acceptance-tests/src/authorization/groups-and-permissions.spec.ts
+++ b/packages/acceptance-tests/src/authorization/groups-and-permissions.spec.ts
@@ -11,6 +11,7 @@ import {
   TokenRequired,
 } from '@foal/core';
 import {
+  DatabaseSession,
   fetchUserWithPermissions,
   Group,
   Permission,
@@ -47,7 +48,7 @@ describe('[Authorization|permissions] Users', () => {
     await createConnection({
       database: 'e2e_db.sqlite',
       dropSchema: true,
-      entities: [ User, Permission, Group ],
+      entities: [ User, Permission, Group, DatabaseSession ],
       synchronize: true,
       type: 'sqlite',
     });

--- a/packages/acceptance-tests/src/csrf/regular-web-app.stateful.spec.ts
+++ b/packages/acceptance-tests/src/csrf/regular-web-app.stateful.spec.ts
@@ -16,7 +16,7 @@ import {
   TokenRequired
 } from '@foal/core';
 import { CsrfTokenRequired, getCsrfToken } from '@foal/csrf';
-import { TypeORMStore } from '@foal/typeorm';
+import { TypeORMStore, DatabaseSession } from '@foal/typeorm';
 
 describe('[CSRF|regular web app|stateful] Users', () => {
 
@@ -75,6 +75,7 @@ describe('[CSRF|regular web app|stateful] Users', () => {
     await createConnection({
       database: 'e2e_db.sqlite',
       dropSchema: true,
+      entities: [ DatabaseSession ],
       synchronize: true,
       type: 'sqlite',
     });

--- a/packages/acceptance-tests/src/csrf/regular-web-app.stateful.spec.ts
+++ b/packages/acceptance-tests/src/csrf/regular-web-app.stateful.spec.ts
@@ -16,7 +16,7 @@ import {
   TokenRequired
 } from '@foal/core';
 import { CsrfTokenRequired, getCsrfToken } from '@foal/csrf';
-import { TypeORMStore, DatabaseSession } from '@foal/typeorm';
+import { DatabaseSession, TypeORMStore } from '@foal/typeorm';
 
 describe('[CSRF|regular web app|stateful] Users', () => {
 

--- a/packages/acceptance-tests/src/csrf/spa-and-api.stateful.spec.ts
+++ b/packages/acceptance-tests/src/csrf/spa-and-api.stateful.spec.ts
@@ -14,7 +14,7 @@ import {
   TokenRequired
 } from '@foal/core';
 import { CsrfTokenRequired, getCsrfToken, setCsrfCookie } from '@foal/csrf';
-import { TypeORMStore, DatabaseSession } from '@foal/typeorm';
+import { DatabaseSession, TypeORMStore } from '@foal/typeorm';
 
 describe('[CSRF|spa and api|stateful] Users', () => {
 

--- a/packages/acceptance-tests/src/csrf/spa-and-api.stateful.spec.ts
+++ b/packages/acceptance-tests/src/csrf/spa-and-api.stateful.spec.ts
@@ -14,7 +14,7 @@ import {
   TokenRequired
 } from '@foal/core';
 import { CsrfTokenRequired, getCsrfToken, setCsrfCookie } from '@foal/csrf';
-import { TypeORMStore } from '@foal/typeorm';
+import { TypeORMStore, DatabaseSession } from '@foal/typeorm';
 
 describe('[CSRF|spa and api|stateful] Users', () => {
 
@@ -60,6 +60,7 @@ describe('[CSRF|spa and api|stateful] Users', () => {
     await createConnection({
       database: 'e2e_db.sqlite',
       dropSchema: true,
+      entities: [ DatabaseSession ],
       synchronize: true,
       type: 'sqlite',
     });

--- a/packages/typeorm/src/index.ts
+++ b/packages/typeorm/src/index.ts
@@ -7,4 +7,4 @@
 export * from './entities';
 export * from './hooks';
 export * from './utils';
-export { TypeORMStore, TypeORMStore as ConcreteSessionStore } from './typeorm-store.service';
+export { DatabaseSession, TypeORMStore, TypeORMStore as ConcreteSessionStore } from './typeorm-store.service';

--- a/packages/typeorm/src/typeorm-store.service.spec.ts
+++ b/packages/typeorm/src/typeorm-store.service.spec.ts
@@ -2,11 +2,18 @@
 import { deepStrictEqual, notStrictEqual, strictEqual } from 'assert';
 
 // 3p
-import { createConnection, getConnection } from 'typeorm';
+import { createConnection, getConnection, getRepository } from 'typeorm';
 
 // FoalTS
 import { createService, Session, SessionStore } from '@foal/core';
-import { DatabaseSession, TypeORMStore } from './typeorm-store.service';
+import { TypeORMStore, FoalSession } from './typeorm-store.service';
+
+interface DatabaseSession {
+  session_id: string;
+  session_content: string;
+  created_at: string;
+  updated_at: string;
+}
 
 interface PlainSession {
   sessionID: string;
@@ -59,8 +66,10 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
           await createConnection({
             database: 'test',
             dropSchema: true,
+            entities: [ FoalSession ],
             password: 'test',
             port: type === 'mysql' ? 3308 : 3307,
+            synchronize: true,
             type,
             username: 'test',
           });
@@ -69,7 +78,9 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
           await createConnection({
             database: 'test',
             dropSchema: true,
+            entities: [ FoalSession ],
             password: 'test',
+            synchronize: true,
             type,
             username: 'test',
           });
@@ -78,6 +89,8 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
           await createConnection({
             database: 'test_db.sqlite',
             dropSchema: true,
+            entities: [ FoalSession ],
+            synchronize: true,
             type,
           });
           break;
@@ -88,11 +101,7 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
 
     beforeEach(async () => {
       store = createService(TypeORMStore);
-      const queryRunner = getConnection().createQueryRunner();
-      if (await queryRunner.hasTable('foal_session')) {
-        await queryRunner.clearTable('foal_session');
-      }
-      await queryRunner.release();
+      await getRepository(FoalSession).clear();
     });
 
     after(() => getConnection().close());

--- a/packages/typeorm/src/typeorm-store.service.spec.ts
+++ b/packages/typeorm/src/typeorm-store.service.spec.ts
@@ -107,14 +107,14 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
 
       it('should update the content of the session if the session exists.', async () => {
         const session1 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'a',
           updatedAt: Date.now(),
         });
         const session2 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'b',
           updatedAt: Date.now(),
         });
@@ -134,14 +134,14 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
 
       it('should update the lifetime (inactiviy) if the session exists.', async () => {
         const session1 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'a',
           updatedAt: Date.now(),
         });
         const session2 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'b',
           updatedAt: Date.now(),
         });
@@ -167,14 +167,14 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
 
       it('should delete the session from its ID.', async () => {
         const session1 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'a',
           updatedAt: Date.now(),
         });
         const session2 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'b',
           updatedAt: Date.now(),
         });
@@ -207,8 +207,8 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
         const inactivity = SessionStore.getExpirationTimeouts().inactivity;
 
         const session1 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'a',
           updatedAt: Date.now() - inactivity * 1000,
         });
@@ -222,14 +222,14 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
       it('should delete the session if it has expired (inactivity).', async () => {
         const inactivity = SessionStore.getExpirationTimeouts().inactivity;
         const session1 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'a',
           updatedAt: Date.now(),
         });
         const session2 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'b',
           updatedAt: Date.now() - inactivity * 1000,
         });
@@ -253,8 +253,8 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
         const absolute = SessionStore.getExpirationTimeouts().absolute;
 
         const session1 = getRepository(DatabaseSession).create({
-          createdAt: Date.now() - absolute * 1000,
           content: JSON.stringify({}),
+          createdAt: Date.now() - absolute * 1000,
           id: 'a',
           updatedAt: Date.now(),
         });
@@ -269,14 +269,14 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
         const absolute = SessionStore.getExpirationTimeouts().absolute;
 
         const session1 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'a',
           updatedAt: Date.now(),
         });
         const session2 = getRepository(DatabaseSession).create({
-          createdAt: Date.now() - absolute * 1000,
           content: JSON.stringify({}),
+          createdAt: Date.now() - absolute * 1000,
           id: 'b',
           updatedAt: Date.now(),
         });
@@ -298,14 +298,14 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
 
       it('should return the session.', async () => {
         const session1 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'a',
           updatedAt: Date.now(),
         });
         const session2 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({ foo: 'bar' }),
+          createdAt: Date.now(),
           id: 'b',
           updatedAt: Date.now(),
         });
@@ -330,14 +330,14 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
         const inactivity = SessionStore.getExpirationTimeouts().inactivity;
 
         const session1 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'a',
           updatedAt: Date.now() - Math.round(inactivity * 1000 / 2),
         });
         const session2 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'b',
           updatedAt: Date.now() - Math.round(inactivity * 1000 / 2),
         });
@@ -367,14 +367,14 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
 
       it('should remove all sessions.', async () => {
         const session1 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'a',
           updatedAt: Date.now(),
         });
         const session2 = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({ foo: 'bar' }),
+          createdAt: Date.now(),
           id: 'b',
           updatedAt: Date.now(),
         });
@@ -395,15 +395,15 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
       it('should remove expired sessions due to inactivity.', async () => {
         const inactivityTimeout = SessionStore.getExpirationTimeouts().inactivity;
 
-        const currentSession =getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
+        const currentSession = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'a',
           updatedAt: Date.now() - inactivityTimeout * 1000 + 5000,
         });
         const expiredSession = getRepository(DatabaseSession).create({
-          createdAt: Date.now(),
           content: JSON.stringify({}),
+          createdAt: Date.now(),
           id: 'b',
           updatedAt: Date.now() - inactivityTimeout * 1000,
         });
@@ -427,14 +427,14 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite') {
         const absoluteTimeout = SessionStore.getExpirationTimeouts().absolute;
 
         const currentSession = getRepository(DatabaseSession).create({
-          createdAt: Date.now() - absoluteTimeout * 1000 + 5000,
           content: JSON.stringify({}),
+          createdAt: Date.now() - absoluteTimeout * 1000 + 5000,
           id: 'a',
           updatedAt: Date.now(),
         });
         const expiredSession = getRepository(DatabaseSession).create({
-          createdAt: Date.now() - absoluteTimeout * 1000,
           content: JSON.stringify({}),
+          createdAt: Date.now() - absoluteTimeout * 1000,
           id: 'b',
           updatedAt: Date.now(),
         });

--- a/packages/typeorm/src/typeorm-store.service.ts
+++ b/packages/typeorm/src/typeorm-store.service.ts
@@ -1,11 +1,19 @@
 import { Session, SessionOptions, SessionStore } from '@foal/core';
-import { Connection, getConnection, ObjectLiteral, Table } from 'typeorm';
+import {  Column, Entity, getRepository,  LessThan, PrimaryColumn} from 'typeorm';
 
-export interface DatabaseSession {
+@Entity()
+export class FoalSession {
+  @PrimaryColumn()
   session_id: string;
+
+  @Column({ type: 'text' })
   session_content: string;
-  created_at: string;
-  updated_at: string;
+
+  @Column({ type: 'bigint' })
+  updated_at: number;
+
+  @Column({ type: 'bigint' })
+  created_at: number;
 }
 
 /**
@@ -16,59 +24,49 @@ export interface DatabaseSession {
  * @extends {SessionStore}
  */
 export class TypeORMStore extends SessionStore {
-  private tableCreated = false;
-
   async createAndSaveSession(sessionContent: object, options: SessionOptions = {}): Promise<Session> {
     const sessionID = await this.generateSessionID();
     await this.applySessionOptions(sessionContent, options);
 
     const date = Date.now();
 
-    await this.execQuery(
-      `INSERT INTO foal_session (session_id, session_content, updated_at, created_at)
-      VALUES (:sessionID, :sessionContent, :date, :date)`,
-      {
-        date,
-        sessionContent: JSON.stringify(sessionContent),
-        sessionID,
-      }
-    );
+    const databaseSession = new FoalSession();
+    databaseSession.session_id = sessionID;
+    databaseSession.session_content = JSON.stringify(sessionContent),
+    databaseSession.updated_at = date;
+    databaseSession.created_at = date;
+
+    await getRepository(FoalSession)
+      .save(databaseSession);
 
     return new Session(this, sessionID, sessionContent, date);
   }
 
   async update(session: Session): Promise<void> {
-    await this.execQuery(
-      `UPDATE foal_session
-      SET updated_at=:updatedAt, created_at=:createdAt, session_content=:sessionContent
-      WHERE session_id=:sessionID`,
-      {
-        createdAt: session.createdAt,
-        sessionContent: JSON.stringify(session.getContent()),
-        sessionID: session.sessionID,
-        updatedAt: Date.now()
-      }
-    );
+    await getRepository(FoalSession)
+      .createQueryBuilder()
+      .update()
+      .set({
+        created_at: session.createdAt,
+        session_content: JSON.stringify(session.getContent()),
+        updated_at: Date.now()
+      })
+      .where({ session_id: session.sessionID })
+      .execute();
   }
 
   async destroy(sessionID: string): Promise<void> {
-    await this.execQuery(
-      `DELETE FROM foal_session WHERE session_id=:sessionID`,
-      { sessionID }
-    );
+    await getRepository(FoalSession)
+      .delete({ session_id: sessionID });
   }
 
   async read(sessionID: string): Promise<Session | undefined> {
     const timeouts = SessionStore.getExpirationTimeouts();
 
-    const sessions = await this.execQuery(
-      `SELECT * FROM foal_session WHERE session_id=:sessionID`,
-      { sessionID }
-    );
-    if (sessions.length === 0) {
+    const session = await getRepository(FoalSession).findOne({ session_id: sessionID });
+    if (!session) {
       return undefined;
     }
-    const session: DatabaseSession = sessions[0];
 
     const createdAt = parseInt(session.created_at.toString(), 10);
     const updatedAt = parseInt(session.updated_at.toString(), 10);
@@ -88,75 +86,29 @@ export class TypeORMStore extends SessionStore {
   }
 
   async extendLifeTime(sessionID: string): Promise<void> {
-    await this.execQuery(
-      'UPDATE foal_session SET updated_at=:updatedAt WHERE session_id=:sessionID',
-      { sessionID, updatedAt: Date.now() }
-    );
+    await getRepository(FoalSession)
+      .createQueryBuilder()
+      .update()
+      .set({ updated_at: Date.now() })
+      .where({ session_id: sessionID })
+      .execute();
   }
 
   async clear(): Promise<void> {
-    await this.execQuery(`DELETE FROM foal_session`, {});
+    await getRepository(FoalSession)
+      .clear();
   }
 
   async cleanUpExpiredSessions(): Promise<void> {
     const expiredTimeouts = SessionStore.getExpirationTimeouts();
-    await this.execQuery(
-      `DELETE FROM foal_session
-      WHERE updated_at < :updatedAtMax OR created_at < :createdAtMax`,
-      {
-        createdAtMax: Date.now() - expiredTimeouts.absolute * 1000,
-        updatedAtMax: Date.now() - expiredTimeouts.inactivity * 1000,
-      }
-    );
-  }
-
-  private async execQuery(query: string, parameters: ObjectLiteral): Promise<any> {
-    const connection = await this.getConnection();
-    const [ escapedQuery, escapedParams ] = connection.driver.escapeQueryWithParameters(
-      query, parameters, {}
-    );
-    return connection.query(escapedQuery, escapedParams);
-  }
-
-  private async getConnection(): Promise<Connection> {
-    const connection = getConnection();
-    if (!this.tableCreated) {
-      const table = new Table({
-        columns: [
-          {
-            isPrimary: true, // TODO: test isPrimary
-            name: 'session_id',
-            type: 'varchar',
-          },
-          {
-            isNullable: false,
-            name: 'session_content',
-            type: 'text',
-          },
-          {
-            isNullable: false,
-            name: 'created_at',
-            type: 'bigint',
-          },
-          {
-            isNullable: false,
-            name: 'updated_at',
-            type: 'bigint',
-          },
-        ],
-        name: 'foal_session',
-      });
-      const queryRunner = connection.createQueryRunner();
-      try {
-        await queryRunner.createTable(table, true);
-      } catch (error) {
-        throw error;
-      } finally {
-        await queryRunner.release();
-      }
-      this.tableCreated = true;
-    }
-    return connection;
+    await getRepository(FoalSession)
+      .createQueryBuilder()
+      .delete()
+      .where([
+        { created_at: LessThan(Date.now() - expiredTimeouts.absolute * 1000) },
+        { updated_at: LessThan(Date.now() - expiredTimeouts.inactivity * 1000) }
+      ])
+      .execute();
   }
 
 }

--- a/packages/typeorm/src/typeorm-store.service.ts
+++ b/packages/typeorm/src/typeorm-store.service.ts
@@ -1,5 +1,5 @@
 import { Session, SessionOptions, SessionStore } from '@foal/core';
-import {  Column, Entity, getRepository,  LessThan, PrimaryColumn } from 'typeorm';
+import {  Column, Entity, getRepository, LessThan, PrimaryColumn } from 'typeorm';
 
 @Entity()
 export class DatabaseSession {
@@ -47,8 +47,8 @@ export class TypeORMStore extends SessionStore {
       .createQueryBuilder()
       .update()
       .set({
-        createdAt: session.createdAt,
         content: JSON.stringify(session.getContent()),
+        createdAt: session.createdAt,
         updatedAt: Date.now()
       })
       .where({ id: session.sessionID })

--- a/packages/typeorm/src/typeorm-store.service.ts
+++ b/packages/typeorm/src/typeorm-store.service.ts
@@ -30,14 +30,17 @@ export class TypeORMStore extends SessionStore {
 
     const date = Date.now();
 
-    const databaseSession = new DatabaseSession();
-    databaseSession.id = sessionID;
-    databaseSession.content = JSON.stringify(sessionContent),
-    databaseSession.updatedAt = date;
-    databaseSession.createdAt = date;
-
+    // TODO: test that the method throws if the ID is already taken.
     await getRepository(DatabaseSession)
-      .save(databaseSession);
+      .createQueryBuilder()
+      .insert()
+      .values({
+        content: JSON.stringify(sessionContent),
+        createdAt: date,
+        id: sessionID,
+        updatedAt: date,
+      })
+      .execute();
 
     return new Session(this, sessionID, sessionContent, date);
   }


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Resolves #766 

# Solution and steps

- [x] Add and export `DatabaseSession`.
- [x] Update `TypeORMStore`.
- [x] Update acceptance tests
- [x] Add tests on the entity.

# Breaking changes

- All users will be logged out when upgrading to v2.
- The session table must be created with migrations. A migration file can be created from `DatabaseSession`.

# Optional

- The old `foal_session` table can be manually removed.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
