### PR TITLE
[V2] Officially support authenticated sessions and allow to perform certain actions on them.

### DIFF
--- a/docs/authentication-and-access-control/session-tokens.md
+++ b/docs/authentication-and-access-control/session-tokens.md
@@ -405,6 +405,32 @@ export class ApiController {
 }
 ```
 
+## Query All Sessions of a Given User
+
+> *This feature is only available with the TypeORM store.*
+
+```typescript
+const user = { id: 1 };
+const sessions = await this.store.getSessionsOf(user);
+```
+
+## Query All Connected Users
+
+> *This feature is only available with the TypeORM store.*
+
+```typescript
+const ids = await this.store.getAuthenticatedUserIds();
+```
+
+## Force the Disconnection of a Given User
+
+> *This feature is only available with the TypeORM store.*
+
+```typescript
+const user = { id: 1 };
+await this.store.destroyAllSessionsOf(user);
+```
+
 ## Session Stores
 
 FoalTS currently offers three built-in session stores: `TypeORMStore`, `MongoDBStore` `RedisStore`. Others will come in the future. If you need a specific one, you can submit a Github issue or even create your own store (see section below).

--- a/packages/core/src/sessions/session-store.spec.ts
+++ b/packages/core/src/sessions/session-store.spec.ts
@@ -196,7 +196,7 @@ describe('SessionStore', () => {
       class Store extends SessionStore {
         async createAndSaveSession(sessionContent: object, options: SessionOptions = {}): Promise<Session> {
           await this.applySessionOptions(sessionContent, options);
-          return new Session(this, 'xxx', sessionContent, 36);
+          return new Session({ store: this, id: 'xxx', content: sessionContent, createdAt: 36 });
         }
         update(session: Session): Promise<void> {
           throw new Error('Method not implemented.');

--- a/packages/core/src/sessions/session-store.spec.ts
+++ b/packages/core/src/sessions/session-store.spec.ts
@@ -196,7 +196,13 @@ describe('SessionStore', () => {
       class Store extends SessionStore {
         async createAndSaveSession(sessionContent: object, options: SessionOptions = {}): Promise<Session> {
           await this.applySessionOptions(sessionContent, options);
-          return new Session({ store: this, id: 'xxx', content: sessionContent, createdAt: 36 });
+          return new Session({
+            content: sessionContent,
+            createdAt: 36,
+            id: 'xxx',
+            store: this,
+            userId: options.userId
+          });
         }
         update(session: Session): Promise<void> {
           throw new Error('Method not implemented.');
@@ -226,8 +232,8 @@ describe('SessionStore', () => {
 
       strictEqual(session.store, store);
       strictEqual(session.sessionID, 'xxx');
+      strictEqual(session.userId, 1);
       const content: any = session.getContent();
-      strictEqual(content.userId, 1);
       strictEqual(typeof content.csrfToken, 'string');
       strictEqual(session.createdAt, 36);
     });

--- a/packages/core/src/sessions/session-store.ts
+++ b/packages/core/src/sessions/session-store.ts
@@ -6,6 +6,7 @@ import { Session } from './session';
 
 export interface SessionOptions {
   csrfToken?: boolean;
+  userId?: number|string;
 }
 
 /**
@@ -78,7 +79,10 @@ export abstract class Store {
    * @memberof Store
    */
   createAndSaveSessionFromUser(user: { id: string|number }, options?: SessionOptions): Promise<Session> {
-    return this.createAndSaveSession({ userId: user.id }, options);
+    return this.createAndSaveSession({}, {
+      ...options,
+      userId: user.id
+    });
   }
 
   /**

--- a/packages/core/src/sessions/session.spec.ts
+++ b/packages/core/src/sessions/session.spec.ts
@@ -35,14 +35,14 @@ describe('Session', () => {
 
     it('should set three readonly properties "store", "sessionID" and "createdAt" from the given arguments.', () => {
       const store = new ConcreteSessionStore();
-      const session = new Session(store, 'xxx', {}, 3);
+      const session = new Session({ store, id: 'xxx', content: {}, createdAt: 3 });
       strictEqual((session as any).store, store);
       strictEqual(session.sessionID, 'xxx');
       strictEqual(session.createdAt, 3);
     });
 
     it('should not be "modified".', () => {
-      const session = new Session(new ConcreteSessionStore(), 'xxx', {}, 0);
+      const session = new Session({ store: new ConcreteSessionStore(), id: 'xxx', content: {}, createdAt: 0 });
       strictEqual(session.isModified, false);
     });
 
@@ -50,18 +50,18 @@ describe('Session', () => {
 
   describe('has a "get" method that', () => {
 
-    it('should return the value of the key given in the param "sessionContent" during instantiation.', () => {
-      const session = new Session(new ConcreteSessionStore(), '', { foo: 'bar' }, 0);
+    it('should return the value of the key given in the param "content" during instantiation.', () => {
+      const session = new Session({ store: new ConcreteSessionStore(), id: '', content: { foo: 'bar' }, createdAt: 0 });
       strictEqual(session.get('foo'), 'bar');
     });
 
     it('should return the default value if the key does not exist.', () => {
-      const session = new Session(new ConcreteSessionStore(), '', { foo: 'bar' }, 0);
+      const session = new Session({ store: new ConcreteSessionStore(), id: '', content: { foo: 'bar' }, createdAt: 0 });
       strictEqual(session.get<string>('foobar', 'barfoo'), 'barfoo');
     });
 
     it('should return undefined if there is no default value and if the key does not exist.', () => {
-      const session = new Session(new ConcreteSessionStore(), '', { foo: 'bar' }, 0);
+      const session = new Session({ store: new ConcreteSessionStore(), id: '', content: { foo: 'bar' }, createdAt: 0 });
       strictEqual(session.get('foobar'), undefined);
     });
 
@@ -70,13 +70,13 @@ describe('Session', () => {
   describe('has a "set" method that', () => {
 
     it('should modify the session content...', () => {
-      const session = new Session(new ConcreteSessionStore(), '', {}, 0);
+      const session = new Session({ store: new ConcreteSessionStore(), id: '', content: {}, createdAt: 0 });
       session.set('foo', 'bar');
       strictEqual(session.get('foo'), 'bar');
     });
 
     it('...and mark it as modified.', () => {
-      const session = new Session(new ConcreteSessionStore(), '', {}, 0);
+      const session = new Session({ store: new ConcreteSessionStore(), id: '', content: {}, createdAt: 0 });
       strictEqual(session.isModified, false);
 
       session.set('foo', 'bar');
@@ -89,7 +89,7 @@ describe('Session', () => {
 
     it('should return the session ID.', () => {
       const sessionID = 'zMd0TkVoMlj7qrJ54+G3idn0plDwQGqS/n6VVwKC4qM=';
-      const session = new Session(new ConcreteSessionStore(), sessionID, {}, 0);
+      const session = new Session({ store: new ConcreteSessionStore(), id: sessionID, content: {}, createdAt: 0 });
       const token = session.getToken();
 
       strictEqual(
@@ -104,7 +104,7 @@ describe('Session', () => {
 
     it('should return a copy of the session content', () => {
       const content = { foo: 'bar' };
-      const session = new Session(new ConcreteSessionStore(), 'a', content, 0);
+      const session = new Session({ store: new ConcreteSessionStore(), id: 'a', content, createdAt: 0 });
 
       deepStrictEqual(session.getContent(), content);
       notStrictEqual(session.getContent(), content);
@@ -124,7 +124,7 @@ describe('Session', () => {
 
     it('should call the "destroy" method of the store to destroy itself.', async () => {
       const store = new ConcreteSessionStore2();
-      const session = new Session(store, 'a', {}, 0);
+      const session = new Session({ store, id: 'a', content: {}, createdAt: 0 });
 
       await session.destroy();
       strictEqual(store.calledWith, 'a');
@@ -132,7 +132,7 @@ describe('Session', () => {
 
     it('should make this.isDestroyed return "true".', async () => {
       const store = new ConcreteSessionStore2();
-      const session = new Session(store, 'a', {}, 0);
+      const session = new Session({ store, id: 'a', content: {}, createdAt: 0 });
 
       strictEqual(session.isDestroyed, false);
       await session.destroy();

--- a/packages/core/src/sessions/session.spec.ts
+++ b/packages/core/src/sessions/session.spec.ts
@@ -36,9 +36,22 @@ describe('Session', () => {
     it('should set three readonly properties "store", "sessionID" and "createdAt" from the given arguments.', () => {
       const store = new ConcreteSessionStore();
       const session = new Session({ store, id: 'xxx', content: {}, createdAt: 3 });
-      strictEqual((session as any).store, store);
+      strictEqual(session.store, store);
       strictEqual(session.sessionID, 'xxx');
       strictEqual(session.createdAt, 3);
+    });
+
+    it('should set the readonly property "userId" if it is property in the constructor', () => {
+      const store = new ConcreteSessionStore();
+
+      const session1 = new Session({ store, id: 'xxx', content: {}, createdAt: 3 });
+      strictEqual((session1 as any).userId, undefined);
+
+      const session2 = new Session({ store, id: 'xxx', content: {}, createdAt: 3, userId: 'e' });
+      strictEqual((session2 as any).userId, 'e');
+
+      const session3 = new Session({ store, id: 'xxx', content: {}, createdAt: 3, userId: 22 });
+      strictEqual((session3 as any).userId, 22);
     });
 
     it('should not be "modified".', () => {

--- a/packages/core/src/sessions/session.spec.ts
+++ b/packages/core/src/sessions/session.spec.ts
@@ -45,13 +45,13 @@ describe('Session', () => {
       const store = new ConcreteSessionStore();
 
       const session1 = new Session({ store, id: 'xxx', content: {}, createdAt: 3 });
-      strictEqual((session1 as any).userId, undefined);
+      strictEqual(session1.userId, undefined);
 
       const session2 = new Session({ store, id: 'xxx', content: {}, createdAt: 3, userId: 'e' });
-      strictEqual((session2 as any).userId, 'e');
+      strictEqual(session2.userId, 'e');
 
       const session3 = new Session({ store, id: 'xxx', content: {}, createdAt: 3, userId: 22 });
-      strictEqual((session3 as any).userId, 22);
+      strictEqual(session3.userId, 22);
     });
 
     it('should not be "modified".', () => {

--- a/packages/core/src/sessions/session.spec.ts
+++ b/packages/core/src/sessions/session.spec.ts
@@ -33,16 +33,6 @@ describe('Session', () => {
 
   describe('when it is instanciated', () => {
 
-    it('should throw an error if the sessionID includes a dot.', () => {
-      try {
-        // tslint:disable-next-line:no-unused-expression
-        new Session(new ConcreteSessionStore(), 'xxx.yyy', {}, 0);
-        throw new Error('An error should have been thrown during instanciation.');
-      } catch (error) {
-        strictEqual(error.message, 'A session ID cannot include dots.');
-      }
-    });
-
     it('should set three readonly properties "store", "sessionID" and "createdAt" from the given arguments.', () => {
       const store = new ConcreteSessionStore();
       const session = new Session(store, 'xxx', {}, 3);

--- a/packages/core/src/sessions/session.ts
+++ b/packages/core/src/sessions/session.ts
@@ -34,21 +34,24 @@ export class Session {
   readonly store: SessionStore;
   readonly sessionID: string;
   readonly createdAt: number;
+  readonly userId: number|string|undefined;
 
   private modified = false;
   private destroyed = false;
   private sessionContent: any;
 
   constructor(options: {
-    store: SessionStore,
-    id: string,
     content: any,
-    createdAt: number
+    createdAt: number,
+    id: string,
+    store: SessionStore,
+    userId?: number|string,
   }) {
     this.store = options.store;
     this.sessionID = options.id;
     this.sessionContent = options.content;
     this.createdAt = options.createdAt;
+    this.userId = options.userId;
   }
 
   /**

--- a/packages/core/src/sessions/session.ts
+++ b/packages/core/src/sessions/session.ts
@@ -9,16 +9,6 @@ import { SessionStore } from './session-store';
  */
 export class Session {
 
-  private modified = false;
-  private destroyed = false;
-
-  constructor(
-    readonly store: SessionStore,
-    readonly sessionID: string,
-    private sessionContent: any,
-    readonly createdAt: number
-  ) {}
-
   /**
    * Return true if an element was added/replaced in the session
    *
@@ -39,6 +29,26 @@ export class Session {
    */
   get isDestroyed(): boolean {
     return this.destroyed;
+  }
+
+  readonly store: SessionStore;
+  readonly sessionID: string;
+  readonly createdAt: number;
+
+  private modified = false;
+  private destroyed = false;
+  private sessionContent: any;
+
+  constructor(options: {
+    store: SessionStore,
+    id: string,
+    content: any,
+    createdAt: number
+  }) {
+    this.store = options.store;
+    this.sessionID = options.id;
+    this.sessionContent = options.content;
+    this.createdAt = options.createdAt;
   }
 
   /**

--- a/packages/core/src/sessions/session.ts
+++ b/packages/core/src/sessions/session.ts
@@ -17,11 +17,7 @@ export class Session {
     readonly sessionID: string,
     private sessionContent: any,
     readonly createdAt: number
-  ) {
-    if (sessionID.includes('.')) {
-      throw new Error('A session ID cannot include dots.');
-    }
-  }
+  ) {}
 
   /**
    * Return true if an element was added/replaced in the session

--- a/packages/core/src/sessions/token.hook.spec.ts
+++ b/packages/core/src/sessions/token.hook.spec.ts
@@ -51,9 +51,10 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     async createAndSaveSession(sessionContent: object, options: SessionOptions = {}): Promise<Session> {
       const sessionID = await this.generateSessionID();
       const session = new Session({
-        store: this, id: sessionID,
         content: sessionContent,
         createdAt: Date.now(),
+        id: sessionID,
+        store: this,
         userId: options.userId
       });
       this.sessions.push(session);

--- a/packages/core/src/sessions/token.hook.spec.ts
+++ b/packages/core/src/sessions/token.hook.spec.ts
@@ -50,7 +50,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     }
     async createAndSaveSession(sessionContent: object): Promise<Session> {
       const sessionID = await this.generateSessionID();
-      const session = new Session(this, sessionID, sessionContent, Date.now());
+      const session = new Session({ store: this, id: sessionID, content: sessionContent, createdAt: Date.now() });
       this.sessions.push(session);
       return session;
     }

--- a/packages/core/src/sessions/token.hook.spec.ts
+++ b/packages/core/src/sessions/token.hook.spec.ts
@@ -20,7 +20,7 @@ import {
 } from '../core';
 import { SESSION_DEFAULT_COOKIE_NAME } from './constants';
 import { Session } from './session';
-import { SessionStore } from './session-store';
+import { SessionOptions, SessionStore } from './session-store';
 import { TokenOptional } from './token-optional.hook';
 import { TokenRequired } from './token-required.hook';
 
@@ -48,9 +48,14 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     cleanUpExpiredSessions(): Promise<void> {
       throw new Error('Method not implemented.');
     }
-    async createAndSaveSession(sessionContent: object): Promise<Session> {
+    async createAndSaveSession(sessionContent: object, options: SessionOptions = {}): Promise<Session> {
       const sessionID = await this.generateSessionID();
-      const session = new Session({ store: this, id: sessionID, content: sessionContent, createdAt: Date.now() });
+      const session = new Session({
+        store: this, id: sessionID,
+        content: sessionContent,
+        createdAt: Date.now(),
+        userId: options.userId
+      });
       this.sessions.push(session);
       return session;
     }
@@ -242,7 +247,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
   describe('should verify the session ID and', () => {
 
     it('should return an HttpResponseUnauthorized object if no session matching the ID is found.', async () => {
-      const session = await services.get(Store).createAndSaveSession({ userId: 22 });
+      const session = await services.get(Store).createAndSaveSessionFromUser({ id: 2 });
       const token = session.getToken();
 
       await services.get(Store).clear();
@@ -267,7 +272,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
 
     it('should return an HttpResponseRedirect object if no session matching the ID is found'
         + ' (options.redirectTo is defined).', async () => {
-      const session = await services.get(Store).createAndSaveSession({ userId: 22 });
+      const session = await services.get(Store).createAndSaveSessionFromUser({ id: 2 });
       const token = session.getToken();
 
       await services.get(Store).clear();
@@ -288,7 +293,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     describe('given options.cookie is false or not defined', () => {
 
       it('should not set a cookie in the response if no session matching the ID is found.', async () => {
-        const session = await services.get(Store).createAndSaveSession({ userId: 23 });
+        const session = await services.get(Store).createAndSaveSessionFromUser({ id: 3 });
         const token = session.getToken();
 
         await services.get(Store).clear();
@@ -311,7 +316,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
       it('should remove the cookie in the response if no session matching the ID is found.', async () => {
         const hook = getHookFunction(Token({ store: Store, cookie: true }));
 
-        const session = await services.get(Store).createAndSaveSession({ userId: 24 });
+        const session = await services.get(Store).createAndSaveSessionFromUser({ id: 4 });
         const token = session.getToken();
 
         await services.get(Store).clear();
@@ -342,7 +347,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     describe('given options.user is not defined', () => {
 
       it('with the user id (header).', async () => {
-        const session = await services.get(Store).createAndSaveSession({ userId: 36 });
+        const session = await services.get(Store).createAndSaveSessionFromUser({ id: 36 });
         const token = session.getToken();
 
         const ctx = new Context({
@@ -358,7 +363,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
       it('with the user id (cookie).', async () => {
         const hook = getHookFunction(Token({ store: Store, cookie: true }));
 
-        const session = await services.get(Store).createAndSaveSession({ userId: 35 });
+        const session = await services.get(Store).createAndSaveSessionFromUser({ id: 35 });
         const token = session.getToken();
 
         const ctx = new Context({
@@ -378,7 +383,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
         process.env.SETTINGS_SESSION_COOKIE_NAME = 'auth2';
         const hook = getHookFunction(Token({ store: Store, cookie: true }));
 
-        const session = await services.get(Store).createAndSaveSession({ userId: 34 });
+        const session = await services.get(Store).createAndSaveSessionFromUser({ id: 34 });
         const token = session.getToken();
 
         const ctx = new Context({
@@ -402,7 +407,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
         const fetchUser = async (id: number|string) => id === 1 ? user : null;
         const hook = getHookFunction(Token({ store: Store, user: fetchUser }));
 
-        const session = await services.get(Store).createAndSaveSession({ userId: 1 });
+        const session = await services.get(Store).createAndSaveSessionFromUser({ id: 1 });
         const token = session.getToken();
 
         const ctx = new Context({
@@ -418,7 +423,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
         const fetchUser = async (id: number|string) => id === '1' ? user : null;
         const hook = getHookFunction(Token({ store: Store, user: fetchUser }));
 
-        const session = await services.get(Store).createAndSaveSession({ userId: '1' });
+        const session = await services.get(Store).createAndSaveSessionFromUser({ id: '1' });
         const token = session.getToken();
 
         const ctx = new Context({
@@ -430,33 +435,10 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
         strictEqual(ctx.user, user);
       });
 
-      it('with the user retrieved from the database (userId is a MongoDB ObjectID).', async () => {
-        const fetchUser = async (id: number|string) => id === 'xjeldksjqkd' ? user : null;
+      it('or throw an Error if the session userId is not of type "string" or "number".', async () => {
         const hook = getHookFunction(Token({ store: Store, user: fetchUser }));
 
-        // "MongoDB ObjectID"
-        const objectId = {
-          toString() {
-            return 'xjeldksjqkd';
-          }
-        };
-        const session = await services.get(Store).createAndSaveSession({ userId: objectId });
-        const token = session.getToken();
-
-        const ctx = new Context({
-          get(str: string) { return str === 'Authorization' ? `Bearer ${token}` : undefined; }
-        });
-
-        const response = await hook(ctx, services);
-        strictEqual(isHttpResponse(response), false);
-        strictEqual(ctx.user, user);
-      });
-
-      it('or throw an Error if the session userId is not of type "string" or "number" or'
-          + 'does not have a "toString" method.', async () => {
-        const hook = getHookFunction(Token({ store: Store, user: fetchUser }));
-
-        const session = await services.get(Store).createAndSaveSession({ userId: null });
+        const session = await services.get(Store).createAndSaveSessionFromUser({ id: null } as any);
         const sessionID = session.sessionID;
         const token = session.getToken();
 
@@ -479,7 +461,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
           + 'with the given user Id.', async () => {
         const hook = getHookFunction(Token({ store: Store, user: fetchUser }));
 
-        const session = await services.get(Store).createAndSaveSession({ userId: 2 });
+        const session = await services.get(Store).createAndSaveSessionFromUser({ id: 2 });
         const token = session.getToken();
 
         const ctx = new Context({
@@ -504,7 +486,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
           + 'with the given user Id (options.redirectTo is defined).', async () => {
         const hook = getHookFunction(Token({ store: Store, user: fetchUser, redirectTo: '/foo' }));
 
-        const session = await services.get(Store).createAndSaveSession({ userId: 2 });
+        const session = await services.get(Store).createAndSaveSessionFromUser({ id: 2 });
         const token = session.getToken();
 
         const ctx = new Context({
@@ -530,7 +512,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     });
 
     it('should update the session and extend its lifetime if it has been modified.', async () => {
-      const session = await services.get(Store).createAndSaveSession({ userId: 47 });
+      const session = await services.get(Store).createAndSaveSessionFromUser({ id: 7 });
       const token = session.getToken();
 
       const ctx = new Context({
@@ -552,7 +534,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     });
 
     it('should extend the session lifetime if it has not been modified.', async () => {
-      const session = await services.get(Store).createAndSaveSession({ userId: 48 });
+      const session = await services.get(Store).createAndSaveSessionFromUser({ id: 8 });
       const token = session.getToken();
 
       const ctx = new Context({
@@ -575,7 +557,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
 
     it('should not update the session or extend its lifetime if session.isDestroyed is true'
       + ' (isModified === true).', async () => {
-        const session = await services.get(Store).createAndSaveSession({ userId: 47 });
+        const session = await services.get(Store).createAndSaveSessionFromUser({ id: 7 });
         const token = session.getToken();
 
         const ctx = new Context({
@@ -599,7 +581,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     );
 
     it('should not extend the session lifetime if session.isDestroyed is true (isModified === false).', async () => {
-      const session = await services.get(Store).createAndSaveSession({ userId: 48 });
+      const session = await services.get(Store).createAndSaveSessionFromUser({ id: 8 });
       const token = session.getToken();
 
       const ctx = new Context({
@@ -624,7 +606,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     describe('given options.cookie is false or not defined', () => {
 
       it('should not set a cookie in the response.', async () => {
-        const session = await services.get(Store).createAndSaveSession({ userId: 48 });
+        const session = await services.get(Store).createAndSaveSessionFromUser({ id: 8 });
         const token = session.getToken();
 
         const ctx = new Context({
@@ -649,7 +631,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
     describe('given options.cookie is true', () => {
 
       it('should set a cookie in the response with the token to extend its lifetime on the client.', async () => {
-        const session = await services.get(Store).createAndSaveSession({ userId: 48 });
+        const session = await services.get(Store).createAndSaveSessionFromUser({ id: 8 });
         const token = session.getToken();
 
         const hook = getHookFunction(Token({ store: Store, cookie: true }));
@@ -677,7 +659,7 @@ export function testSuite(Token: typeof TokenRequired|typeof TokenOptional, requ
       });
 
       it('should remove the session cookie if session.isDestroyed is true.', async () => {
-        const session = await services.get(Store).createAndSaveSession({ userId: 48 });
+        const session = await services.get(Store).createAndSaveSessionFromUser({ id: 8 });
         const token = session.getToken();
 
         const hook = getHookFunction(Token({ store: Store, cookie: true }));

--- a/packages/core/src/sessions/token.hook.ts
+++ b/packages/core/src/sessions/token.hook.ts
@@ -117,14 +117,11 @@ export function Token(required: boolean, options: TokenOptions): HookDecorator {
 
     /* Verify the session content */
 
-    let userId: any = session.get('userId');
+    const userId = session.userId;
 
     if (!options.user) {
       ctx.user = userId;
     } else {
-      if (typeof userId === 'object' && userId !== null) {
-        userId = userId.toString();
-      }
       if (typeof userId !== 'number' && typeof userId !== 'string') {
         throw new Error(
           `The "userId" value of the session ${sessionID} must be a string or a number. Got "${typeof userId}".`

--- a/packages/csrf/src/csrf-token-required.hook.spec.ts
+++ b/packages/csrf/src/csrf-token-required.hook.spec.ts
@@ -47,7 +47,7 @@ describe('CsrfTokenRequired', () => {
 
     it('should throw if the session content has no CSRF token.', async () => {
       const ctx = new Context({});
-      ctx.session = new Session({} as any, 'a', {}, 0);
+      ctx.session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
       try {
         await hook(ctx, services);
         throw new Error('An error should have been thrown.');
@@ -63,7 +63,7 @@ describe('CsrfTokenRequired', () => {
 
       it('should return an HttpResponseForbidden object if the token is incorrect.', async () => {
         const ctx = new Context<any, Session>({ body: { _csrf: 'xxx' }, headers: {} });
-        ctx.session = new Session({} as any, 'a', { csrfToken: 'bbb' }, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: { csrfToken: 'bbb' }, createdAt: 0 });
 
         const response = await hook(ctx, services);
         if (!isHttpResponseForbidden(response)) {
@@ -74,41 +74,41 @@ describe('CsrfTokenRequired', () => {
 
       it('should not return an HttpResponseForbidden object if the token is correct (body._csrf).', async () => {
         const ctx = new Context<any, Session>({ body: { _csrf: 'xxx' }, headers: {} });
-        ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: { csrfToken: 'xxx' }, createdAt: 0 });
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct (query._csrf).', async () => {
         const ctx = new Context<any, Session>({ query: { _csrf: 'xxx' }, headers: {} });
-        ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: { csrfToken: 'xxx' }, createdAt: 0 });
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["csrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'csrf-token': 'xxx' } });
-        ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: { csrfToken: 'xxx' }, createdAt: 0 });
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["xsrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'xsrf-token': 'xxx' } });
-        ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: { csrfToken: 'xxx' }, createdAt: 0 });
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["x-csrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'x-csrf-token': 'xxx' } });
-        ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: { csrfToken: 'xxx' }, createdAt: 0 });
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["x-xsrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'x-xsrf-token': 'xxx' } });
-        ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: { csrfToken: 'xxx' }, createdAt: 0 });
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
@@ -116,19 +116,19 @@ describe('CsrfTokenRequired', () => {
 
     it('should not return an HttpResponseForbidden object if the method is GET.', async () => {
       const ctx = new Context<any, Session>({ headers: {}, method: 'GET' });
-      ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
+      ctx.session = new Session({ store: {} as any, id: 'a', content: { csrfToken: 'xxx' }, createdAt: 0 });
       strictEqual(await hook(ctx, services), undefined);
     });
 
     it('should not return an HttpResponseForbidden object if the method is HEAD.', async () => {
       const ctx = new Context<any, Session>({ headers: {}, method: 'HEAD' });
-      ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
+      ctx.session = new Session({ store: {} as any, id: 'a', content: { csrfToken: 'xxx' }, createdAt: 0 });
       strictEqual(await hook(ctx, services), undefined);
     });
 
     it('should not return an HttpResponseForbidden object if the method is OPTIONS.', async () => {
       const ctx = new Context<any, Session>({ headers: {}, method: 'OPTIONS' });
-      ctx.session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
+      ctx.session = new Session({ store: {} as any, id: 'a', content: { csrfToken: 'xxx' }, createdAt: 0 });
       strictEqual(await hook(ctx, services), undefined);
     });
 
@@ -166,7 +166,7 @@ describe('CsrfTokenRequired', () => {
 
     it('should return an HttpResponseForbidden object if the "csrfToken" cookie is not found.', async () => {
       const ctx = new Context<any, Session>({ cookies: {} });
-      ctx.session = new Session({} as any, 'a', {}, 0);
+      ctx.session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
 
       const response = await hook(ctx, services);
       if (!isHttpResponseForbidden(response)) {
@@ -179,7 +179,7 @@ describe('CsrfTokenRequired', () => {
       process.env.SETTINGS_CSRF_COOKIE_NAME = 'csrf';
 
       const ctx = new Context<any, Session>({ cookies: { csrfToken: 'xxx' } });
-      ctx.session = new Session({} as any, 'a', {}, 0);
+      ctx.session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
 
       const response = await hook(ctx, services);
       if (!isHttpResponseForbidden(response)) {
@@ -194,7 +194,7 @@ describe('CsrfTokenRequired', () => {
           + ' is incorrect.', async () => {
         const token = 'xxx';
         const ctx = new Context<any, Session>({ body: { _csrf: 'xxx' }, cookies: { csrfToken: token } });
-        ctx.session = new Session({} as any, 'a', {}, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
 
         const response = await hook(ctx, services);
         if (!isHttpResponseForbidden(response)) {
@@ -205,7 +205,7 @@ describe('CsrfTokenRequired', () => {
 
       it('should return an HttpResponseForbidden object if the token is incorrect.', async () => {
         const ctx = new Context<any, Session>({ body: { _csrf: 'xxx' }, cookies: { csrfToken: token } });
-        ctx.session = new Session({} as any, 'a', {}, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
 
         const response = await hook(ctx, services);
         if (!isHttpResponseForbidden(response)) {
@@ -216,41 +216,41 @@ describe('CsrfTokenRequired', () => {
 
       it('should not return an HttpResponseForbidden object if the token is correct (body._csrf).', async () => {
         const ctx = new Context<any, Session>({ body: { _csrf: token }, cookies: { csrfToken: token } });
-        ctx.session = new Session({} as any, 'a', {}, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct (query._csrf).', async () => {
         const ctx = new Context<any, Session>({ query: { _csrf: token }, cookies: { csrfToken: token } });
-        ctx.session = new Session({} as any, 'a', {}, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["csrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'csrf-token': token }, cookies: { csrfToken: token } });
-        ctx.session = new Session({} as any, 'a', {}, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["xsrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'xsrf-token': token }, cookies: { csrfToken: token } });
-        ctx.session = new Session({} as any, 'a', {}, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["x-csrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'x-csrf-token': token }, cookies: { csrfToken: token } });
-        ctx.session = new Session({} as any, 'a', {}, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
       it('should not return an HttpResponseForbidden object if the token is correct '
           + '(headers["x-xsrf-token"]).', async () => {
         const ctx = new Context<any, Session>({ headers: { 'x-xsrf-token': token }, cookies: { csrfToken: token } });
-        ctx.session = new Session({} as any, 'a', {}, 0);
+        ctx.session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
         strictEqual(isHttpResponse(await hook(ctx, services)), false);
       });
 
@@ -258,19 +258,19 @@ describe('CsrfTokenRequired', () => {
 
     it('should not return an HttpResponseForbidden object if the method is GET.', async () => {
       const ctx = new Context<any, Session>({ headers: {}, method: 'GET', cookies: { csrfToken: token } });
-      ctx.session = new Session({} as any, 'a', {}, 0);
+      ctx.session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
       strictEqual(await hook(ctx, services), undefined);
     });
 
     it('should not return an HttpResponseForbidden object if the method is HEAD.', async () => {
       const ctx = new Context<any, Session>({ headers: {}, method: 'HEAD', cookies: { csrfToken: token } });
-      ctx.session = new Session({} as any, 'a', {}, 0);
+      ctx.session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
       strictEqual(await hook(ctx, services), undefined);
     });
 
     it('should not return an HttpResponseForbidden object if the method is OPTIONS.', async () => {
       const ctx = new Context<any, Session>({ headers: {}, method: 'OPTIONS', cookies: { csrfToken: token } });
-      ctx.session = new Session({} as any, 'a', {}, 0);
+      ctx.session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
       strictEqual(await hook(ctx, services), undefined);
     });
 

--- a/packages/csrf/src/get-csrf-token.util.spec.ts
+++ b/packages/csrf/src/get-csrf-token.util.spec.ts
@@ -44,7 +44,7 @@ describe('getCsrfToken', () => {
   describe('given session is defined.', () => {
 
     it('should throw an error if the session key "csrfToken" is empty.', async () => {
-      const session = new Session({} as any, 'a', {}, 0);
+      const session = new Session({ store: {} as any, id: 'a', content: {}, createdAt: 0 });
       try {
         await getCsrfToken(session);
         throw new Error('An error should have been thrown.');
@@ -57,7 +57,7 @@ describe('getCsrfToken', () => {
     });
 
     it('should return the value of the session key "csrfToken".', async () => {
-      const session = new Session({} as any, 'a', { csrfToken: 'xxx' }, 0);
+      const session = new Session({ store: {} as any, id: 'a', content: { csrfToken: 'xxx' }, createdAt: 0 });
       const csrfToken = await getCsrfToken(session);
       strictEqual(csrfToken, 'xxx');
     });

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "docs": "typedoc --out ../../docs/api/mongodb src/index.ts --readme none --theme markdown",
     "test": "mocha --require ts-node/register \"./src/**/*.spec.ts\"",
-    "dev:test": "mocha --require ts-node/register --watch --watch-extensions ts \"./src/**/*.spec.ts\"",
+    "dev:test": "mocha --require ts-node/register --watch --watch-files \"./src/**/*.ts\" \"./src/**/*.spec.ts\"",
     "build": "rimraf lib && copy-cli \"./src/**.txt.gz\" lib && tsc -p tsconfig-build.json",
     "prepublish": "npm run build"
   },

--- a/packages/mongodb/src/mongodb-store.service.spec.ts
+++ b/packages/mongodb/src/mongodb-store.service.spec.ts
@@ -18,21 +18,22 @@ interface PlainSession {
 
 describe('MongoDBStore', () => {
   const MONGODB_URI = 'mongodb://localhost:27017/db';
+  const COLLECTION_NAME = 'sessions';
 
   let store: MongoDBStore;
   let mongoDBClient: any;
 
   async function insertSessionIntoDB(session: PlainSession): Promise<PlainSession> {
-    await mongoDBClient.db().collection('foalSessions').insertOne(session);
+    await mongoDBClient.db().collection(COLLECTION_NAME).insertOne(session);
     return session;
   }
 
   async function readSessionsFromDB(): Promise<PlainSession[]> {
-    return mongoDBClient.db().collection('foalSessions').find({}).toArray();
+    return mongoDBClient.db().collection(COLLECTION_NAME).find({}).toArray();
   }
 
   async function findByID(sessionID: string): Promise<PlainSession> {
-    const session = await mongoDBClient.db().collection('foalSessions').findOne({ _id: sessionID });
+    const session = await mongoDBClient.db().collection(COLLECTION_NAME).findOne({ _id: sessionID });
     if (!session) {
       throw new Error('Session not found');
     }
@@ -68,7 +69,7 @@ describe('MongoDBStore', () => {
       await store.boot();
     });
 
-    beforeEach(() => mongoDBClient.db().collection('foalSessions').deleteMany({}));
+    beforeEach(() => mongoDBClient.db().collection(COLLECTION_NAME).deleteMany({}));
 
     after(async () => {
       delete process.env.MONGODB_URI;

--- a/packages/mongodb/src/mongodb-store.service.spec.ts
+++ b/packages/mongodb/src/mongodb-store.service.spec.ts
@@ -11,7 +11,7 @@ import { MongoDBStore } from './mongodb-store.service';
 interface PlainSession {
   _id: string;
   userId?: string;
-  sessionContent: object;
+  content: object;
   createdAt: number;
   updatedAt: number;
 }
@@ -92,7 +92,7 @@ describe('MongoDBStore', () => {
 
         notStrictEqual(sessionA._id, undefined);
         strictEqual(sessionA.userId, 'xxx');
-        deepStrictEqual(sessionA.sessionContent, { foo: 'bar' });
+        deepStrictEqual(sessionA.content, { foo: 'bar' });
 
         const createdAt = sessionA.createdAt;
         strictEqual(dateBefore <= createdAt, true);
@@ -129,14 +129,14 @@ describe('MongoDBStore', () => {
       it('should update the content of the session if the session exists.', async () => {
         const session1 = await insertSessionIntoDB({
           _id: 'a',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now(),
         });
         const session2 = await insertSessionIntoDB({
           _id: 'b',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now(),
         });
 
@@ -148,31 +148,31 @@ describe('MongoDBStore', () => {
         }));
 
         const sessionA = await findByID(session1._id);
-        deepStrictEqual(sessionA.sessionContent, { bar: 'foo' });
+        deepStrictEqual(sessionA.content, { bar: 'foo' });
         deepStrictEqual(sessionA.createdAt, session1.createdAt);
 
         const sessionB = await findByID(session2._id);
-        deepStrictEqual(sessionB.sessionContent, {});
+        deepStrictEqual(sessionB.content, {});
         deepStrictEqual(sessionB.createdAt, session2.createdAt);
       });
 
       it('should update the lifetime (inactiviy) if the session exists.', async () => {
         const session1 = await insertSessionIntoDB({
           _id: 'a',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now(),
         });
         const session2 = await insertSessionIntoDB({
           _id: 'b',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now(),
         });
 
         const dateBefore = Date.now();
         await store.update(new Session({
-          content: session1.sessionContent,
+          content: session1.content,
           createdAt: session1.createdAt,
           id: session1._id,
           store: {} as any,
@@ -195,14 +195,14 @@ describe('MongoDBStore', () => {
       it('should delete the session from its ID.', async () => {
         const session1 = await insertSessionIntoDB({
           _id: 'a',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now(),
         });
         const session2 = await insertSessionIntoDB({
           _id: 'b',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now(),
         });
 
@@ -233,8 +233,8 @@ describe('MongoDBStore', () => {
 
         const session1 = await insertSessionIntoDB({
           _id: 'a',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now() - inactivity * 1000,
         });
 
@@ -246,14 +246,14 @@ describe('MongoDBStore', () => {
         const inactivity = SessionStore.getExpirationTimeouts().inactivity;
         const session1 = await insertSessionIntoDB({
           _id: 'a',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now(),
         });
         const session2 = await insertSessionIntoDB({
           _id: 'b',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now() - inactivity * 1000,
         });
 
@@ -275,8 +275,8 @@ describe('MongoDBStore', () => {
 
         const session1 = await insertSessionIntoDB({
           _id: 'a',
+          content: {},
           createdAt: Date.now() - absolute * 1000,
-          sessionContent: {},
           updatedAt: Date.now(),
         });
 
@@ -289,14 +289,14 @@ describe('MongoDBStore', () => {
 
         const session1 = await insertSessionIntoDB({
           _id: 'a',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now(),
         });
         const session2 = await insertSessionIntoDB({
           _id: 'b',
+          content: {},
           createdAt: Date.now() - absolute * 1000,
-          sessionContent: {},
           updatedAt: Date.now(),
         });
 
@@ -316,14 +316,14 @@ describe('MongoDBStore', () => {
       it('should return the session.', async () => {
         await insertSessionIntoDB({
           _id: 'a',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now(),
         });
         const session2 = await insertSessionIntoDB({
           _id: 'b',
+          content: { foo: 'bar' },
           createdAt: Date.now(),
-          sessionContent: { foo: 'bar' },
           updatedAt: Date.now(),
           userId: 'xxx'
         });
@@ -348,14 +348,14 @@ describe('MongoDBStore', () => {
 
         const session1 = await insertSessionIntoDB({
           _id: 'a',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now() - Math.round(inactivity * 1000 / 2),
         });
         const session2 = await insertSessionIntoDB({
           _id: 'b',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now() - Math.round(inactivity * 1000 / 2),
         });
 
@@ -383,14 +383,14 @@ describe('MongoDBStore', () => {
       it('should remove all sessions.', async () => {
         await insertSessionIntoDB({
           _id: 'a',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now(),
         });
         await insertSessionIntoDB({
           _id: 'b',
+          content: { foo: 'bar' },
           createdAt: Date.now(),
-          sessionContent: { foo: 'bar' },
           updatedAt: Date.now(),
         });
 
@@ -410,14 +410,14 @@ describe('MongoDBStore', () => {
 
         const currentSession = await insertSessionIntoDB({
           _id: 'a',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now() - inactivityTimeout * 1000 + 5000,
         });
         const expiredSession = await insertSessionIntoDB({
           _id: 'b',
+          content: {},
           createdAt: Date.now(),
-          sessionContent: {},
           updatedAt: Date.now() - inactivityTimeout * 1000,
         });
 
@@ -439,14 +439,14 @@ describe('MongoDBStore', () => {
 
         const currentSession = await insertSessionIntoDB({
           _id: 'a',
+          content: {},
           createdAt: Date.now() - absoluteTimeout * 1000 + 5000,
-          sessionContent: {},
           updatedAt: Date.now(),
         });
         const expiredSession = await insertSessionIntoDB({
           _id: 'b',
+          content: {},
           createdAt: Date.now() - absoluteTimeout * 1000,
-          sessionContent: {},
           updatedAt: Date.now(),
         });
 

--- a/packages/mongodb/src/mongodb-store.service.spec.ts
+++ b/packages/mongodb/src/mongodb-store.service.spec.ts
@@ -137,7 +137,12 @@ describe('MongoDBStore', () => {
           updatedAt: Date.now(),
         });
 
-        await store.update(new Session({} as any, session1._id, { bar: 'foo' }, session1.createdAt));
+        await store.update(new Session({
+          content: { bar: 'foo' },
+          createdAt: session1.createdAt,
+          id: session1._id,
+          store: {} as any,
+        }));
 
         const sessionA = await findByID(session1._id);
         deepStrictEqual(sessionA.sessionContent, { bar: 'foo' });
@@ -163,7 +168,12 @@ describe('MongoDBStore', () => {
         });
 
         const dateBefore = Date.now();
-        await store.update(new Session({} as any, session1._id, session1.sessionContent, session1.createdAt));
+        await store.update(new Session({
+          content: session1.sessionContent,
+          createdAt: session1.createdAt,
+          id: session1._id,
+          store: {} as any,
+        }));
         const dateAfter = Date.now();
 
         const sessionA = await findByID(session1._id);

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -42,7 +42,7 @@ export class MongoDBStore extends SessionStore {
       updatedAt: date,
     });
 
-    return new Session(this, sessionID, sessionContent, date);
+    return new Session({ store: this, id: sessionID, content: sessionContent, createdAt: date });
   }
 
   async update(session: Session): Promise<void> {
@@ -83,7 +83,7 @@ export class MongoDBStore extends SessionStore {
       return undefined;
     }
 
-    return new Session(this, session._id, session.sessionContent, session.createdAt);
+    return new Session({ store: this, id: session._id, content: session.sessionContent, createdAt: session.createdAt });
   }
 
   async extendLifeTime(sessionID: string): Promise<void> {

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -28,7 +28,7 @@ export class MongoDBStore extends SessionStore {
       'You must provide the URI of your database when using MongoDBStore.'
     );
     this.mongoDBClient = await MongoClient.connect(mongoDBURI, { useNewUrlParser: true, useUnifiedTopology: true });
-    this.collection = this.mongoDBClient.db().collection('foalSessions');
+    this.collection = this.mongoDBClient.db().collection('sessions');
   }
 
   async createAndSaveSession(content: object, options: SessionOptions = {}): Promise<Session> {

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -4,7 +4,7 @@ import { MongoClient } from 'mongodb';
 export interface DatabaseSession {
   _id: string;
   userId?: string;
-  sessionContent: object;
+  content: object;
   createdAt: number;
   updatedAt: number;
 }
@@ -31,21 +31,21 @@ export class MongoDBStore extends SessionStore {
     this.collection = this.mongoDBClient.db().collection('foalSessions');
   }
 
-  async createAndSaveSession(sessionContent: object, options: SessionOptions = {}): Promise<Session> {
+  async createAndSaveSession(content: object, options: SessionOptions = {}): Promise<Session> {
     const sessionID = await this.generateSessionID();
-    await this.applySessionOptions(sessionContent, options);
+    await this.applySessionOptions(content, options);
 
     const date = Date.now();
     await this.collection.insertOne({
       _id: sessionID,
+      content,
       createdAt: date,
-      sessionContent,
       updatedAt: date,
       userId: options.userId,
     });
 
     return new Session({
-      content: sessionContent,
+      content,
       createdAt: date,
       id: sessionID,
       store: this,
@@ -60,7 +60,7 @@ export class MongoDBStore extends SessionStore {
       },
       {
         $set: {
-          sessionContent: session.getContent(),
+          content: session.getContent(),
           updatedAt: Date.now()
         }
       }
@@ -91,7 +91,7 @@ export class MongoDBStore extends SessionStore {
     }
 
     return new Session({
-      content: session.sessionContent,
+      content: session.content,
       createdAt: session.createdAt,
       id: session._id,
       store: this,

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "docs": "typedoc --out ../../docs/api/redis src/index.ts --readme none --theme markdown",
     "test": "mocha --require ts-node/register \"./src/**/*.spec.ts\"",
-    "dev:test": "mocha --require ts-node/register --watch --watch-extensions ts \"./src/**/*.spec.ts\"",
+    "dev:test": "mocha --require ts-node/register --watch --watch-files \"./src/**/*.ts\" \"./src/**/*.spec.ts\"",
     "build": "rimraf lib && tsc -p tsconfig-build.json",
     "prepublish": "npm run build"
   },

--- a/packages/redis/src/redis-store.service.spec.ts
+++ b/packages/redis/src/redis-store.service.spec.ts
@@ -10,6 +10,7 @@ describe('RedisStore', () => {
 
   let store: RedisStore;
   const REDIS_URI = 'redis://localhost:6379';
+  const COLLECTION_NAME =  'sessions';
   let redisClient: any;
 
   before(async () => {
@@ -111,8 +112,8 @@ describe('RedisStore', () => {
       const session = await store.createAndSaveSession({ foo: 'bar' }, { userId: 3 });
 
       notStrictEqual(session.sessionID, undefined);
-      strictEqual(await asyncTTL(`session:${session.sessionID}`), inactivity);
-      const data = JSON.parse(await asyncGet(`session:${session.sessionID}`));
+      strictEqual(await asyncTTL(`${COLLECTION_NAME}:${session.sessionID}`), inactivity);
+      const data = JSON.parse(await asyncGet(`${COLLECTION_NAME}:${session.sessionID}`));
       deepStrictEqual(data, {
         content: { foo: 'bar' },
         createdAt: session.createdAt,
@@ -127,8 +128,8 @@ describe('RedisStore', () => {
     it('should update the content of the session if the session exists.', async () => {
       const createdAt = Date.now();
       const data = { content: { foo: 'bar' }, createdAt };
-      await asyncSet('session:a', JSON.stringify(data));
-      strictEqual(await asyncGet('session:a'), JSON.stringify(data));
+      await asyncSet(`${COLLECTION_NAME}:a`, JSON.stringify(data));
+      strictEqual(await asyncGet(`${COLLECTION_NAME}:a`), JSON.stringify(data));
 
       const session = new Session({
         content: data.content,
@@ -141,7 +142,7 @@ describe('RedisStore', () => {
 
       await store.update(session);
 
-      const data2 = JSON.parse(await asyncGet('session:a'));
+      const data2 = JSON.parse(await asyncGet(`${COLLECTION_NAME}:a`));
       deepStrictEqual(data2, {
         content: { foo: 'foobar' },
         createdAt,
@@ -154,19 +155,19 @@ describe('RedisStore', () => {
 
       const createdAt = Date.now();
       const data = { content: { foo: 'bar' }, createdAt };
-      await asyncSet('session:a', JSON.stringify(data));
-      strictEqual(await asyncGet('session:a'), JSON.stringify(data));
+      await asyncSet(`${COLLECTION_NAME}:a`, JSON.stringify(data));
+      strictEqual(await asyncGet(`${COLLECTION_NAME}:a`), JSON.stringify(data));
 
       const session = new Session({ store: {} as any, id: 'a', content: data.content, createdAt: data.createdAt });
       session.set('foo', 'foobar');
 
       await store.update(session);
 
-      strictEqual(await asyncTTL('session:a'), inactivity);
+      strictEqual(await asyncTTL(`${COLLECTION_NAME}:a`), inactivity);
     });
 
     it('should create the session if it does not exist (with the proper lifetime).', async () => {
-      strictEqual(await asyncGet('session:a'), null);
+      strictEqual(await asyncGet(`${COLLECTION_NAME}:a`), null);
 
       const session = new Session({
         content: { foo: 'bar' },
@@ -178,7 +179,7 @@ describe('RedisStore', () => {
 
       await store.update(session);
 
-      const sessionA = await asyncGet('session:a');
+      const sessionA = await asyncGet(`${COLLECTION_NAME}:a`);
       notStrictEqual(sessionA, null);
 
       deepStrictEqual(JSON.parse(sessionA), {
@@ -193,12 +194,12 @@ describe('RedisStore', () => {
   describe('has a "destroy" method that', () => {
 
     it('should delete the session from its ID.', async () => {
-      await asyncSet('session:a', '{}');
-      strictEqual(await asyncGet('session:a'), '{}');
+      await asyncSet(`${COLLECTION_NAME}:a`, '{}');
+      strictEqual(await asyncGet(`${COLLECTION_NAME}:a`), '{}');
 
       await store.destroy('a');
 
-      strictEqual(await asyncGet('session:a'), null);
+      strictEqual(await asyncGet(`${COLLECTION_NAME}:a`), null);
     });
 
     it('should not throw if no session matches the given session ID.', async () => {
@@ -214,8 +215,8 @@ describe('RedisStore', () => {
     });
 
     it('should return undefined if the session has expired (inactivity).', async () => {
-      await asyncSet('session:aaa', '{}');
-      await asyncExpire('session:aaa', 0);
+      await asyncSet(`${COLLECTION_NAME}:aaa`, '{}');
+      await asyncExpire(`${COLLECTION_NAME}:aaa`, 0);
       strictEqual(await store.read('aaa'), undefined);
     });
 
@@ -223,7 +224,7 @@ describe('RedisStore', () => {
       const absolute = SessionStore.getExpirationTimeouts().absolute;
 
       const sessionA = { content: {}, createdAt: Date.now() - absolute * 1000 };
-      await asyncSet('session:a', JSON.stringify(sessionA));
+      await asyncSet(`${COLLECTION_NAME}:a`, JSON.stringify(sessionA));
       // The line below fixes Travis test failures.
       await new Promise(resolve => setTimeout(resolve, 200));
 
@@ -235,21 +236,21 @@ describe('RedisStore', () => {
       const absolute = SessionStore.getExpirationTimeouts().absolute;
 
       const sessionA = { content: {}, createdAt: Date.now() - absolute * 1000 };
-      await asyncSet('session:a', JSON.stringify(sessionA));
+      await asyncSet(`${COLLECTION_NAME}:a`, JSON.stringify(sessionA));
       // The line below fixes Travis test failures.
       await new Promise(resolve => setTimeout(resolve, 200));
 
       await store.read('a');
 
-      strictEqual(await asyncGet('session:a'), null);
+      strictEqual(await asyncGet(`${COLLECTION_NAME}:a`), null);
     });
 
     it('should return the session.', async () => {
       const createdAt = Date.now();
       const sessionA = { content: {}, createdAt };
-      await asyncSet('session:a', JSON.stringify(sessionA));
+      await asyncSet(`${COLLECTION_NAME}:a`, JSON.stringify(sessionA));
       const sessionB = { content: { foo: 'bar' }, createdAt, userId: 3 };
-      await asyncSet('session:b', JSON.stringify(sessionB));
+      await asyncSet(`${COLLECTION_NAME}:b`, JSON.stringify(sessionB));
 
       const session = await store.read('b');
       if (!session) {
@@ -269,19 +270,19 @@ describe('RedisStore', () => {
     it('should extend the lifetime of session (inactivity).', async () => {
       const inactivity = SessionStore.getExpirationTimeouts().inactivity;
 
-      await asyncSet('session:aaa', '{}');
-      await asyncExpire('session:aaa', 5);
-      strictEqual(await asyncTTL('session:aaa'), 5);
+      await asyncSet(`${COLLECTION_NAME}:aaa`, '{}');
+      await asyncExpire(`${COLLECTION_NAME}:aaa`, 5);
+      strictEqual(await asyncTTL(`${COLLECTION_NAME}:aaa`), 5);
 
       await store.extendLifeTime('aaa');
 
-      strictEqual(await asyncTTL('session:aaa'), inactivity);
+      strictEqual(await asyncTTL(`${COLLECTION_NAME}:aaa`), inactivity);
     });
 
     it('should not throw if no session matches the given session ID.', async () => {
       await store.extendLifeTime('c');
 
-      strictEqual(await asyncTTL('session:c'), -2);
+      strictEqual(await asyncTTL(`${COLLECTION_NAME}:c`), -2);
     });
 
   });
@@ -289,13 +290,13 @@ describe('RedisStore', () => {
   describe('has a "clear" method that', () => {
 
     it('should remove all sessions.', async () => {
-      await asyncSet('session:aaa', '{}');
-      const sessionA = await asyncGet('session:aaa');
+      await asyncSet(`${COLLECTION_NAME}:aaa`, '{}');
+      const sessionA = await asyncGet(`${COLLECTION_NAME}:aaa`);
       strictEqual(sessionA, '{}');
 
       await store.clear();
 
-      strictEqual(await asyncGet('session:aaa'), null);
+      strictEqual(await asyncGet(`${COLLECTION_NAME}:aaa`), null);
     });
 
   });

--- a/packages/redis/src/redis-store.service.spec.ts
+++ b/packages/redis/src/redis-store.service.spec.ts
@@ -128,7 +128,7 @@ describe('RedisStore', () => {
       await asyncSet('session:a', JSON.stringify(data));
       strictEqual(await asyncGet('session:a'), JSON.stringify(data));
 
-      const session = new Session({} as any, 'a', data.content, data.createdAt);
+      const session = new Session({ store: {} as any, id: 'a', content: data.content, createdAt: data.createdAt });
       session.set('foo', 'foobar');
 
       await store.update(session);
@@ -148,7 +148,7 @@ describe('RedisStore', () => {
       await asyncSet('session:a', JSON.stringify(data));
       strictEqual(await asyncGet('session:a'), JSON.stringify(data));
 
-      const session = new Session({} as any, 'a', data.content, data.createdAt);
+      const session = new Session({ store: {} as any, id: 'a', content: data.content, createdAt: data.createdAt });
       session.set('foo', 'foobar');
 
       await store.update(session);
@@ -159,7 +159,7 @@ describe('RedisStore', () => {
     it('should create the session if it does not exist (with the proper lifetime).', async () => {
       strictEqual(await asyncGet('session:a'), null);
 
-      const session = new Session({} as any, 'a', { foo: 'bar' }, Date.now());
+      const session = new Session({ store: {} as any, id: 'a', content: { foo: 'bar' }, createdAt: Date.now() });
 
       await store.update(session);
 

--- a/packages/redis/src/redis-store.service.ts
+++ b/packages/redis/src/redis-store.service.ts
@@ -17,21 +17,21 @@ export class RedisStore extends SessionStore {
     this.redisClient = createClient(redisURI);
   }
 
-  async createAndSaveSession(sessionContent: object, options: SessionOptions = {}): Promise<Session> {
+  async createAndSaveSession(content: object, options: SessionOptions = {}): Promise<Session> {
     const inactivity = SessionStore.getExpirationTimeouts().inactivity;
 
     const createdAt = Date.now();
     const sessionID = await this.generateSessionID();
-    await this.applySessionOptions(sessionContent, options);
+    await this.applySessionOptions(content, options);
 
     return new Promise<Session>((resolve, reject) => {
-      const data = JSON.stringify({ content: sessionContent, createdAt, userId: options.userId });
+      const data = JSON.stringify({ content, createdAt, userId: options.userId });
       this.redisClient.set(`session:${sessionID}`, data, 'NX', 'EX', inactivity, (err: any) => {
         if (err) {
           return reject(err);
         }
         const session = new Session({
-          content: sessionContent,
+          content,
           createdAt,
           id: sessionID,
           store: this,

--- a/packages/redis/src/redis-store.service.ts
+++ b/packages/redis/src/redis-store.service.ts
@@ -26,7 +26,7 @@ export class RedisStore extends SessionStore {
 
     return new Promise<Session>((resolve, reject) => {
       const data = JSON.stringify({ content, createdAt, userId: options.userId });
-      this.redisClient.set(`session:${sessionID}`, data, 'NX', 'EX', inactivity, (err: any) => {
+      this.redisClient.set(`sessions:${sessionID}`, data, 'NX', 'EX', inactivity, (err: any) => {
         if (err) {
           return reject(err);
         }
@@ -51,7 +51,7 @@ export class RedisStore extends SessionStore {
         createdAt: session.createdAt,
         userId: session.userId
       });
-      this.redisClient.set(`session:${session.sessionID}`, data, 'EX', inactivity, (err: any) => {
+      this.redisClient.set(`sessions:${session.sessionID}`, data, 'EX', inactivity, (err: any) => {
         if (err) {
           return reject(err);
         }
@@ -62,7 +62,7 @@ export class RedisStore extends SessionStore {
 
   destroy(sessionID: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.redisClient.del(`session:${sessionID}`, (err: any) => {
+      this.redisClient.del(`sessions:${sessionID}`, (err: any) => {
         if (err) {
           return reject(err);
         }
@@ -75,7 +75,7 @@ export class RedisStore extends SessionStore {
     const absolute = SessionStore.getExpirationTimeouts().absolute;
 
     return new Promise<Session | undefined>((resolve, reject) => {
-      this.redisClient.get(`session:${sessionID}`, async (err: any, val: string|null) => {
+      this.redisClient.get(`sessions:${sessionID}`, async (err: any, val: string|null) => {
         if (err) {
           return reject(err);
         }
@@ -105,7 +105,7 @@ export class RedisStore extends SessionStore {
     const inactivity = SessionStore.getExpirationTimeouts().inactivity;
 
     return new Promise<void>((resolve, reject) => {
-      this.redisClient.expire(`session:${sessionID}`, inactivity, (err: any) => {
+      this.redisClient.expire(`sessions:${sessionID}`, inactivity, (err: any) => {
         if (err) {
           return reject(err);
         }

--- a/packages/redis/src/redis-store.service.ts
+++ b/packages/redis/src/redis-store.service.ts
@@ -30,7 +30,7 @@ export class RedisStore extends SessionStore {
         if (err) {
           return reject(err);
         }
-        const session = new Session(this, sessionID, sessionContent, createdAt);
+        const session = new Session({ store: this, id: sessionID, content: sessionContent, createdAt });
         resolve(session);
       });
     });
@@ -73,7 +73,12 @@ export class RedisStore extends SessionStore {
           return resolve(undefined);
         }
         const data = JSON.parse(val);
-        const session = new Session(this, sessionID, data.content, data.createdAt);
+        const session = new Session({
+          content: data.content,
+          createdAt: data.createdAt,
+          id: sessionID,
+          store: this,
+        });
 
         if (Date.now() - session.createdAt > absolute * 1000) {
           await this.destroy(sessionID);

--- a/packages/typeorm/src/typeorm-store.service.spec.ts
+++ b/packages/typeorm/src/typeorm-store.service.spec.ts
@@ -188,7 +188,12 @@ function storeTestSuite(type: DBType) {
 
         await getRepository(DatabaseSession).save([ session1, session2 ]);
 
-        await store.update(new Session({} as any, session1.id, { bar: 'foo' }, session1.createdAt));
+        await store.update(new Session({
+          content: { bar: 'foo' },
+          createdAt: session1.createdAt,
+          id: session1.id,
+          store: {} as any,
+        }));
 
         const sessionA = await getRepository(DatabaseSession).findOneOrFail({ id: session1.id });
         deepStrictEqual(sessionA.content, JSON.stringify({ bar: 'foo' }));
@@ -216,7 +221,12 @@ function storeTestSuite(type: DBType) {
         await getRepository(DatabaseSession).save([ session1, session2 ]);
 
         const dateBefore = Date.now();
-        await store.update(new Session({} as any, session1.id, session1.content, session1.createdAt));
+        await store.update(new Session({
+          content: session1.content,
+          createdAt: session1.createdAt,
+          id: session1.id,
+          store: {} as any,
+        }));
         const dateAfter = Date.now();
 
         const sessionA = await getRepository(DatabaseSession).findOneOrFail({ id: session1.id });

--- a/packages/typeorm/src/typeorm-store.service.spec.ts
+++ b/packages/typeorm/src/typeorm-store.service.spec.ts
@@ -64,9 +64,9 @@ function entityTestSuite(type: DBType) {
     it('should has an id which is unique.', async () => {
       const session1 = getRepository(DatabaseSession).create({
         content: '',
-        createdAt: 0,
+        created_at: 0,
         id: 'a',
-        updatedAt: 0,
+        updated_at: 0,
       });
 
       await getRepository(DatabaseSession).save(session1);
@@ -77,9 +77,9 @@ function entityTestSuite(type: DBType) {
           .insert()
           .values({
             content: '',
-            createdAt: 0,
+            created_at: 0,
             id: 'a',
-            updatedAt: 0,
+            updated_at: 0,
           })
           .execute()
       );
@@ -94,9 +94,9 @@ function entityTestSuite(type: DBType) {
             + 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             + 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
         }),
-        createdAt: 0,
+        created_at: 0,
         id: 'a',
-        updatedAt: 0,
+        updated_at: 0,
       });
       await getRepository(DatabaseSession).save(session1);
     });
@@ -148,14 +148,14 @@ function storeTestSuite(type: DBType) {
         const sessionA = sessions[0];
 
         notStrictEqual(sessionA.id, undefined);
-        strictEqual(sessionA.userId, 2);
+        strictEqual(sessionA.user_id, 2);
         deepStrictEqual(sessionA.content, JSON.stringify({ foo: 'bar' }));
 
-        const createdAt = parseInt(sessionA.createdAt.toString(), 10);
+        const createdAt = parseInt(sessionA.created_at.toString(), 10);
         strictEqual(dateBefore <= createdAt, true);
         strictEqual(createdAt <= dateAfter, true);
 
-        const updatedAt = parseInt(sessionA.updatedAt.toString(), 10);
+        const updatedAt = parseInt(sessionA.created_at.toString(), 10);
         strictEqual(dateBefore <= updatedAt, true);
         strictEqual(updatedAt <= dateAfter, true);
       });
@@ -168,10 +168,10 @@ function storeTestSuite(type: DBType) {
         const sessionA = sessions[0];
 
         strictEqual(session.store, store);
-        strictEqual(session.userId, sessionA.userId);
+        strictEqual(session.userId, sessionA.user_id);
         strictEqual(session.sessionID, sessionA.id);
         deepStrictEqual(session.getContent(), { foo: 'bar' });
-        strictEqual(session.createdAt, parseInt(sessionA.createdAt.toString(), 10));
+        strictEqual(session.createdAt, parseInt(sessionA.created_at.toString(), 10));
       });
 
       it('should support session options.', async () => {
@@ -186,47 +186,47 @@ function storeTestSuite(type: DBType) {
       it('should update the content of the session if the session exists.', async () => {
         const session1 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'a',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
         const session2 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'b',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
 
         await getRepository(DatabaseSession).save([ session1, session2 ]);
 
         await store.update(new Session({
           content: { bar: 'foo' },
-          createdAt: session1.createdAt,
+          createdAt: session1.created_at,
           id: session1.id,
           store: {} as any,
         }));
 
         const sessionA = await getRepository(DatabaseSession).findOneOrFail({ id: session1.id });
         deepStrictEqual(sessionA.content, JSON.stringify({ bar: 'foo' }));
-        deepStrictEqual(parseInt(sessionA.createdAt.toString(), 10), session1.createdAt);
+        deepStrictEqual(parseInt(sessionA.created_at.toString(), 10), session1.created_at);
 
         const sessionB = await getRepository(DatabaseSession).findOneOrFail({ id: session2.id });
         deepStrictEqual(sessionB.content, JSON.stringify({}));
-        deepStrictEqual(parseInt(sessionB.createdAt.toString(), 10), session2.createdAt);
+        deepStrictEqual(parseInt(sessionB.created_at.toString(), 10), session2.created_at);
       });
 
       it('should update the lifetime (inactiviy) if the session exists.', async () => {
         const session1 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'a',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
         const session2 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'b',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
 
         await getRepository(DatabaseSession).save([ session1, session2 ]);
@@ -234,19 +234,19 @@ function storeTestSuite(type: DBType) {
         const dateBefore = Date.now();
         await store.update(new Session({
           content: session1.content,
-          createdAt: session1.createdAt,
+          createdAt: session1.created_at,
           id: session1.id,
           store: {} as any,
         }));
         const dateAfter = Date.now();
 
         const sessionA = await getRepository(DatabaseSession).findOneOrFail({ id: session1.id });
-        const updatedAtA = parseInt(sessionA.updatedAt.toString(), 10);
+        const updatedAtA = parseInt(sessionA.updated_at.toString(), 10);
         strictEqual(dateBefore <= updatedAtA, true);
         strictEqual(updatedAtA <= dateAfter, true);
 
         const sessionB = await getRepository(DatabaseSession).findOneOrFail({ id: session2.id });
-        strictEqual(parseInt(sessionB.updatedAt.toString(), 10), session2.updatedAt);
+        strictEqual(parseInt(sessionB.updated_at.toString(), 10), session2.updated_at);
       });
 
     });
@@ -256,15 +256,15 @@ function storeTestSuite(type: DBType) {
       it('should delete the session from its ID.', async () => {
         const session1 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'a',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
         const session2 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'b',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
 
         await getRepository(DatabaseSession).save([ session1, session2 ]);
@@ -296,9 +296,9 @@ function storeTestSuite(type: DBType) {
 
         const session1 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'a',
-          updatedAt: Date.now() - inactivity * 1000,
+          updated_at: Date.now() - inactivity * 1000,
         });
 
         await getRepository(DatabaseSession).save(session1);
@@ -311,15 +311,15 @@ function storeTestSuite(type: DBType) {
         const inactivity = SessionStore.getExpirationTimeouts().inactivity;
         const session1 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'a',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
         const session2 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'b',
-          updatedAt: Date.now() - inactivity * 1000,
+          updated_at: Date.now() - inactivity * 1000,
         });
 
         await getRepository(DatabaseSession).save([ session1, session2 ]);
@@ -342,9 +342,9 @@ function storeTestSuite(type: DBType) {
 
         const session1 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now() - absolute * 1000,
+          created_at: Date.now() - absolute * 1000,
           id: 'a',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
 
         await getRepository(DatabaseSession).save(session1);
@@ -358,15 +358,15 @@ function storeTestSuite(type: DBType) {
 
         const session1 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'a',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
         const session2 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now() - absolute * 1000,
+          created_at: Date.now() - absolute * 1000,
           id: 'b',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
 
         await getRepository(DatabaseSession).save([ session1, session2 ]);
@@ -387,16 +387,16 @@ function storeTestSuite(type: DBType) {
       it('should return the session.', async () => {
         const session1 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'a',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
         const session2 = getRepository(DatabaseSession).create({
           content: JSON.stringify({ foo: 'bar' }),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'b',
-          updatedAt: Date.now(),
-          userId: 2,
+          updated_at: Date.now(),
+          user_id: 2,
         });
 
         await getRepository(DatabaseSession).save([ session1, session2 ]);
@@ -409,7 +409,7 @@ function storeTestSuite(type: DBType) {
         strictEqual(session.userId, 2);
         strictEqual(session.sessionID, session2.id);
         strictEqual(session.get('foo'), 'bar');
-        strictEqual(session.createdAt, session2.createdAt);
+        strictEqual(session.createdAt, session2.created_at);
       });
 
     });
@@ -421,15 +421,15 @@ function storeTestSuite(type: DBType) {
 
         const session1 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'a',
-          updatedAt: Date.now() - Math.round(inactivity * 1000 / 2),
+          updated_at: Date.now() - Math.round(inactivity * 1000 / 2),
         });
         const session2 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'b',
-          updatedAt: Date.now() - Math.round(inactivity * 1000 / 2),
+          updated_at: Date.now() - Math.round(inactivity * 1000 / 2),
         });
 
         await getRepository(DatabaseSession).save([ session1, session2 ]);
@@ -439,12 +439,12 @@ function storeTestSuite(type: DBType) {
         const dateAfter = Date.now();
 
         const session = await getRepository(DatabaseSession).findOneOrFail({ id: session1.id });
-        notStrictEqual(session1.updatedAt, session.updatedAt);
-        strictEqual(dateBefore <= session.updatedAt, true);
-        strictEqual(session.updatedAt <= dateAfter, true);
+        notStrictEqual(session1.updated_at, session.updated_at);
+        strictEqual(dateBefore <= session.updated_at, true);
+        strictEqual(session.updated_at <= dateAfter, true);
 
         const sessionB = await getRepository(DatabaseSession).findOneOrFail({ id: session2.id });
-        strictEqual(session2.updatedAt.toString(), sessionB.updatedAt.toString());
+        strictEqual(session2.updated_at.toString(), sessionB.updated_at.toString());
       });
 
       it('should not throw if no session matches the given session ID.', () => {
@@ -458,15 +458,15 @@ function storeTestSuite(type: DBType) {
       it('should remove all sessions.', async () => {
         const session1 = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'a',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
         const session2 = getRepository(DatabaseSession).create({
           content: JSON.stringify({ foo: 'bar' }),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'b',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
 
         await getRepository(DatabaseSession).save([ session1, session2 ]);
@@ -487,15 +487,15 @@ function storeTestSuite(type: DBType) {
 
         const currentSession = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'a',
-          updatedAt: Date.now() - inactivityTimeout * 1000 + 5000,
+          updated_at: Date.now() - inactivityTimeout * 1000 + 5000,
         });
         const expiredSession = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now(),
+          created_at: Date.now(),
           id: 'b',
-          updatedAt: Date.now() - inactivityTimeout * 1000,
+          updated_at: Date.now() - inactivityTimeout * 1000,
         });
 
         await getRepository(DatabaseSession).save([ currentSession, expiredSession ]);
@@ -518,15 +518,15 @@ function storeTestSuite(type: DBType) {
 
         const currentSession = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now() - absoluteTimeout * 1000 + 5000,
+          created_at: Date.now() - absoluteTimeout * 1000 + 5000,
           id: 'a',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
         const expiredSession = getRepository(DatabaseSession).create({
           content: JSON.stringify({}),
-          createdAt: Date.now() - absoluteTimeout * 1000,
+          created_at: Date.now() - absoluteTimeout * 1000,
           id: 'b',
-          updatedAt: Date.now(),
+          updated_at: Date.now(),
         });
 
         await getRepository(DatabaseSession).save([ currentSession, expiredSession ]);
@@ -542,6 +542,50 @@ function storeTestSuite(type: DBType) {
         strictEqual(sessions.length, 1);
         notStrictEqual(sessions.find(session => session.id === currentSession.id), undefined);
         strictEqual(sessions.find(session => session.id === expiredSession.id), undefined);
+      });
+
+    });
+
+    describe('has a "getAuthenticatedUsers" method that', () => {
+
+      beforeEach(async () => {
+        const sessions = getRepository(DatabaseSession).create([
+          {
+            content: '{}',
+            created_at: 1,
+            id: 'a',
+            updated_at: 2,
+          },
+          {
+            content: '{}',
+            created_at: 3,
+            id: 'b',
+            updated_at: 4,
+            user_id: 1,
+          },
+          {
+            content: '{}',
+            created_at: 5,
+            id: 'c',
+            updated_at: 6,
+            user_id: 2,
+          },
+          {
+            content: '{}',
+            created_at: 7,
+            id: 'd',
+            updated_at: 8,
+            user_id: 2
+          }
+        ]);
+
+        await getRepository(DatabaseSession).save(sessions);
+      });
+
+      it('should return the IDs of the authenticated users (distinct).', async () => {
+        const sessions = await store.getAuthenticatedUserIds();
+        // No null or dupplicated values.
+        deepStrictEqual(sessions, [ 1, 2 ]);
       });
 
     });

--- a/packages/typeorm/src/typeorm-store.service.spec.ts
+++ b/packages/typeorm/src/typeorm-store.service.spec.ts
@@ -590,7 +590,7 @@ function storeTestSuite(type: DBType) {
 
     });
 
-    describe('has a "getAuthenticatedUserIds" method that', () => {
+    describe('has a "destroyAllSessionsOf" method that', () => {
 
       beforeEach(async () => {
         const sessions = getRepository(DatabaseSession).create([
@@ -634,6 +634,68 @@ function storeTestSuite(type: DBType) {
         strictEqual(sessions.length, 2);
         strictEqual(sessions[0].id, 'a');
         strictEqual(sessions[1].id, 'b');
+      });
+
+    });
+
+    describe('has a "getSessionsOf" method that', () => {
+
+      beforeEach(async () => {
+        const sessions = getRepository(DatabaseSession).create([
+          {
+            content: '{}',
+            created_at: 1,
+            id: 'a',
+            updated_at: 2,
+          },
+          {
+            content: '{}',
+            created_at: 3,
+            id: 'b',
+            updated_at: 4,
+            user_id: 1,
+          },
+          {
+            content: '{ "foo": "bar" }',
+            created_at: 5,
+            id: 'c',
+            updated_at: 6,
+            user_id: 2,
+          },
+          {
+            content: '{ "bar": "foo" }',
+            created_at: 7,
+            id: 'd',
+            updated_at: 8,
+            user_id: 2
+          }
+        ]);
+
+        await getRepository(DatabaseSession).save(sessions);
+      });
+
+      it('should return an empty array if the user ID does not match any users.', async () => {
+        const user = { id: 0 };
+        const sessions = await store.getSessionsOf(user);
+        strictEqual(sessions.length, 0);
+      });
+
+      it('should return the sessions associated with the given user.', async () => {
+        const user = { id: 2 };
+        const sessions = await store.getSessionsOf(user);
+        strictEqual(sessions.length, 2);
+
+        deepStrictEqual(sessions[0].getContent(), { foo: 'bar' });
+        strictEqual(sessions[0].sessionID, 'c');
+        strictEqual(sessions[0].userId, 2);
+        strictEqual(sessions[0].createdAt, 5);
+        strictEqual(sessions[0].store, store);
+
+        deepStrictEqual(sessions[1].getContent(), { bar: 'foo' });
+        strictEqual(sessions[1].sessionID, 'd');
+        strictEqual(sessions[1].userId, 2);
+        strictEqual(sessions[1].createdAt, 7);
+        strictEqual(sessions[1].store, store);
       });
 
     });

--- a/packages/typeorm/src/typeorm-store.service.spec.ts
+++ b/packages/typeorm/src/typeorm-store.service.spec.ts
@@ -590,6 +590,54 @@ function storeTestSuite(type: DBType) {
 
     });
 
+    describe('has a "getAuthenticatedUserIds" method that', () => {
+
+      beforeEach(async () => {
+        const sessions = getRepository(DatabaseSession).create([
+          {
+            content: '{}',
+            created_at: 1,
+            id: 'a',
+            updated_at: 2,
+          },
+          {
+            content: '{}',
+            created_at: 3,
+            id: 'b',
+            updated_at: 4,
+            user_id: 1,
+          },
+          {
+            content: '{}',
+            created_at: 5,
+            id: 'c',
+            updated_at: 6,
+            user_id: 2,
+          },
+          {
+            content: '{}',
+            created_at: 7,
+            id: 'd',
+            updated_at: 8,
+            user_id: 2
+          }
+        ]);
+
+        await getRepository(DatabaseSession).save(sessions);
+      });
+
+      it('destroy all the sessions of the given user.', async () => {
+        const user = { id: 2 };
+        await store.destroyAllSessionsOf(user);
+
+        const sessions = await getRepository(DatabaseSession).find();
+        strictEqual(sessions.length, 2);
+        strictEqual(sessions[0].id, 'a');
+        strictEqual(sessions[1].id, 'b');
+      });
+
+    });
+
   });
 
 }

--- a/packages/typeorm/src/typeorm-store.service.ts
+++ b/packages/typeorm/src/typeorm-store.service.ts
@@ -154,4 +154,15 @@ export class TypeORMStore extends SessionStore {
     await getRepository(DatabaseSession).delete({ user_id: user.id });
   }
 
+  async getSessionsOf(user: { id: number }): Promise<Session[]> {
+    const databaseSessions = await getRepository(DatabaseSession).find({ user_id: user.id });
+    return databaseSessions.map(databaseSession => new Session({
+      content: JSON.parse(databaseSession.content),
+      createdAt: parseInt(databaseSession.created_at.toString(), 10),
+      id: databaseSession.id,
+      store: this,
+      userId: user.id,
+    }));
+  }
+
 }

--- a/packages/typeorm/src/typeorm-store.service.ts
+++ b/packages/typeorm/src/typeorm-store.service.ts
@@ -42,7 +42,7 @@ export class TypeORMStore extends SessionStore {
       })
       .execute();
 
-    return new Session(this, sessionID, sessionContent, date);
+    return new Session({ store: this, id: sessionID, content: sessionContent, createdAt: date });
   }
 
   async update(session: Session): Promise<void> {
@@ -85,7 +85,7 @@ export class TypeORMStore extends SessionStore {
       return undefined;
     }
 
-    return new Session(this, session.id, sessionContent, createdAt);
+    return new Session({ store: this, id: session.id, content: sessionContent, createdAt });
   }
 
   async extendLifeTime(sessionID: string): Promise<void> {

--- a/packages/typeorm/src/typeorm-store.service.ts
+++ b/packages/typeorm/src/typeorm-store.service.ts
@@ -33,13 +33,13 @@ export class DatabaseSession {
  * @extends {SessionStore}
  */
 export class TypeORMStore extends SessionStore {
-  async createAndSaveSession(sessionContent: object, options: SessionOptions = {}): Promise<Session> {
+  async createAndSaveSession(content: object, options: SessionOptions = {}): Promise<Session> {
     if (typeof options.userId === 'string') {
       throw new Error('[TypeORMStore] Impossible to save the session. The user ID must be a number.');
     }
 
     const sessionID = await this.generateSessionID();
-    await this.applySessionOptions(sessionContent, options);
+    await this.applySessionOptions(content, options);
 
     const date = Date.now();
 
@@ -48,7 +48,7 @@ export class TypeORMStore extends SessionStore {
       .createQueryBuilder()
       .insert()
       .values({
-        content: JSON.stringify(sessionContent),
+        content: JSON.stringify(content),
         created_at: date,
         id: sessionID,
         updated_at: date,
@@ -57,7 +57,7 @@ export class TypeORMStore extends SessionStore {
       .execute();
 
     return new Session({
-      content: sessionContent,
+      content,
       createdAt: date,
       id: sessionID,
       store: this,
@@ -92,7 +92,7 @@ export class TypeORMStore extends SessionStore {
 
     const createdAt = parseInt(session.created_at.toString(), 10);
     const updatedAt = parseInt(session.updated_at.toString(), 10);
-    const sessionContent = JSON.parse(session.content);
+    const content = JSON.parse(session.content);
 
     if (Date.now() - updatedAt > timeouts.inactivity * 1000) {
       await this.destroy(sessionID);
@@ -105,7 +105,7 @@ export class TypeORMStore extends SessionStore {
     }
 
     return new Session({
-      content: sessionContent,
+      content,
       createdAt,
       id: session.id,
       store: this,

--- a/packages/typeorm/src/typeorm-store.service.ts
+++ b/packages/typeorm/src/typeorm-store.service.ts
@@ -150,4 +150,8 @@ export class TypeORMStore extends SessionStore {
     return sessions.map(({ user_id }) => user_id);
   }
 
+  async destroyAllSessionsOf(user: { id: number }): Promise<void> {
+    await getRepository(DatabaseSession).delete({ user_id: user.id });
+  }
+
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Resolves #510.
Resolves #778.
Resolves #779.

# Solution and steps

- [x] Use an object argument in the `Session` constructor for better readability.
- [x] Add an optional field `userId` to `Session`.
- [x] Make all the three stores use `Session.userId` when saving and reading the session (and updating from redis).
- [x] Make `@TokenRequired` use `Session.userId` to authenticate the session.
- [x] Add `TypeORMStore.getAuthenticatedUserIds()`
- [x] Add `TypeORMStore.destroyAllSessionsOf(user)`
- [x] Add `TypeORMStore.getSessionsOf(user)`

# Breaking changes

- Interface of the `Session` constructor.
- `TypeORMStore` only support numbers (not strings) as user IDs.
- The `userId` is not stored in the session content.
- Redis session key now starts with `sessions:` instead of `session:`.
- MongoDB collection is now named `sessions` instead of `foalSessions`.

When migrating to v2, all users will be logged out.

When migrating to v2 (optional) :
- remove the old TypeORM table,
- remove the old  MongoDB `foalSessions` collection.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
