### PR TITLE
[MongoStore] Use sessionID instead of _id

### DIFF
--- a/docs/authentication-and-access-control/session-tokens.md
+++ b/docs/authentication-and-access-control/session-tokens.md
@@ -470,36 +470,6 @@ npm install typeorm @foal/typeorm
 
 This store uses the default TypeORM connection which is usually specified in `ormconfig.{json|yml|js}`. This means that session states are saved in your SQL database (using the table `foal_session`).
 
-Due to the nature of SQL databases, not all expired sessions are deleted by default (we cannot define a time period after which a SQL row must be deleted). However, the session store provides us with a `cleanUpExpiredSessions` function to manually delete all expired sessions. It is recommended to periodically call this method using, for example, a shell script.
-
-*src/scripts/clean-up-expired-sessions.ts*
-```typescript
-import { createService } from '@foal/core';
-import { TypeORMStore } from '@foal/typeorm';
-import { createConnection } from 'typeorm';
-
-export async function main() {
-  await createConnection();
-
-  const store = createService(TypeORMStore);
-  await store.cleanUpExpiredSessions();
-}
-```
-
-Build the script.
-
-> warning: version 2
-
-```
-npm run build
-```
-
-Run the script.
-
-```
-foal run clean-up-expired-sessions
-```
-
 ### RedisStore
 
 ```
@@ -525,7 +495,8 @@ In order to use this store, you must provide the redis URI in either:
 npm install @foal/mongodb
 ```
 
-This store saves your session states in a MongoDB database (using the collection `foalSessions`). In order to use it, you must provide the MongoDB URI in either:
+This store saves your session states in a MongoDB database (using the collection `sessions`). In order to use it, you must provide the MongoDB URI in either:
+
 - a configuration file
 
     *Example with config/default.yml*
@@ -538,32 +509,7 @@ This store saves your session states in a MongoDB database (using the collection
     MONGODB_URI=mongodb://localhost:27017
     ```
 
-Due to the nature of MongoDB databases, not all expired sessions are deleted by default (we cannot define a time period after which a document must be deleted). However, the session store provides us with a `cleanUpExpiredSessions` function to manually delete all expired sessions. It is recommended to periodically call this method using, for example, a shell script.
 
-*src/scripts/clean-up-expired-sessions.ts*
-```typescript
-import { createService } from '@foal/core';
-import { MongoDBStore } from '@foal/mongodb';
-
-export async function main() {
-  const store = createService(MongoDBStore);
-  await store.cleanUpExpiredSessions();
-}
-```
-
-Build the script.
-
-> warning: version 2
-
-```
-npm run build
-```
-
-Run the script.
-
-```
-foal run clean-up-expired-sessions
-```
 
 ### Custom Store
 

--- a/packages/mongodb/src/mongodb-store.service.spec.ts
+++ b/packages/mongodb/src/mongodb-store.service.spec.ts
@@ -43,7 +43,13 @@ describe('MongoDBStore', () => {
       process.env.MONGODB_URI = MONGODB_URI;
 
       mongoDBClient = await MongoClient.connect(MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true });
-      await mongoDBClient.db().collection(COLLECTION_NAME).dropIndexes();
+      try {
+        await mongoDBClient.db().collection(COLLECTION_NAME).dropIndexes();
+      } catch (error) {
+        if (!(error.message.includes('ns not found'))) {
+          throw error;
+        }
+      }
       store = createService(MongoDBStore);
       await store.boot();
     });


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Fixes #797.

# Solution and steps

- [x] Use `sessionID` instead of `_id`
- [x] Auto-create a unique index on `sessionID` if it does not exist.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
