### PR TITLE
fix(SwaggerValidation): Allow hierarchy in paths

### DIFF
--- a/packages/core/src/openapi/create-open-api-document.spec.ts
+++ b/packages/core/src/openapi/create-open-api-document.spec.ts
@@ -1,5 +1,5 @@
 // std
-import { deepStrictEqual, strictEqual } from 'assert';
+import { deepStrictEqual, notStrictEqual, strictEqual } from 'assert';
 
 // FoalTS
 import { controller } from '../common';
@@ -42,7 +42,9 @@ describe('createOpenApiDocument', () => {
           '/test/path/{parameter_2}': {}
         });
         throw new Error('Expected an exception here');
-      } catch { }
+      } catch (err) {
+        notStrictEqual(err.message, 'Expected an exception here');
+      }
     });
 
     it('hierarchical paths dont throw error', () => {

--- a/packages/core/src/openapi/create-open-api-document.spec.ts
+++ b/packages/core/src/openapi/create-open-api-document.spec.ts
@@ -4,7 +4,7 @@ import { deepStrictEqual, strictEqual } from 'assert';
 // FoalTS
 import { controller } from '../common';
 import { Get, Post, ServiceManager } from '../core';
-import { createOpenApiDocument } from './create-open-api-document';
+import { canonicalisePath, createOpenApiDocument, throwErrorIfDuplicatePaths } from './create-open-api-document';
 import {
   ApiDefineCallback, ApiDefineTag, ApiDeprecated, ApiExternalDoc, ApiInfo,
   ApiOperation, ApiParameter, ApiRequestBody, ApiResponse, ApiSecurityRequirement, ApiServer, ApiUseTag
@@ -27,6 +27,30 @@ describe('createOpenApiDocument', () => {
 
     const document = createOpenApiDocument(Controller);
     strictEqual(document.openapi, '3.0.0');
+  });
+
+  describe('path validation', () => {
+    it('consistient canonicalisation', () => {
+      strictEqual(canonicalisePath('/test/path/{parameter}'), '/test/path/#');
+      strictEqual(canonicalisePath('/test/path/{parameter}/sub/{sub_parameter}'), '/test/path/#/sub/#');
+    });
+
+    it('duplicate paths throws error', () => {
+      try {
+        throwErrorIfDuplicatePaths({
+          '/test/path/{parameter_1}': {},
+          '/test/path/{parameter_2}': {}
+        });
+        throw new Error('Expected an exception here');
+      } catch { }
+    });
+
+    it('hierarchical paths dont throw error', () => {
+        throwErrorIfDuplicatePaths({
+          '/test/path/{parameter}': {},
+          '/test/path/{parameter}/sub/{sub_parameter}': {}
+        });
+    });
   });
 
   describe('should return from the root controller', () => {

--- a/packages/core/src/openapi/create-open-api-document.ts
+++ b/packages/core/src/openapi/create-open-api-document.ts
@@ -6,12 +6,16 @@ import { IApiComponents, IApiOperation, IApiPaths, IApiTag, IOpenAPI } from './i
 import { getApiCompleteOperation, getApiComponents, getApiInfo, getApiTags } from './metadata-getters';
 import { mergeComponents, mergeOperations, mergeTags } from './utils';
 
-function throwErrorIfDuplicatePaths(paths: IApiPaths): void {
+export function canonicalisePath(path: string): string {
+  return path.replace(/{.*?}/g, () => '#');
+}
+
+export function throwErrorIfDuplicatePaths(paths: IApiPaths): void {
   const originalPaths: string[] = [];
   const convertedPaths: string[] = [];
   // tslint:disable-next-line:forin
   for (const path in paths) {
-    const convertedPath = path.replace(/{.*}/g, () => '#');
+    const convertedPath = canonicalisePath(path);
     const index = convertedPaths.indexOf(convertedPath);
     if (index !== -1) {
       throw new Error(


### PR DESCRIPTION
Regex used to test for duplicate paths uses greedy matching causing valid RESTful hierarchy to be
flagged as an error:

fix #821 