### PR TITLE
Pretiffy the welcome and the "500 error" pages

### DIFF
--- a/packages/cli/src/generate/specs/app/public/index.html
+++ b/packages/cli/src/generate/specs/app/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>Welcome to the future!</title>
+  <title>Foal TS App</title>
   <link rel="shortcut icon" href="logo.png">
   <style>
     html, body {
@@ -13,57 +13,40 @@
       margin: 0;
       text-align: center;
       font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+      background-color: #282c34;
     }
     .wrapper {
-      height: 80%;
+      height: 95%;
       display: flex;
       flex-direction: column;
       justify-content: center;
-      position: relative;
     }
     h1 {
       color: white;
       font-weight: bold;
-      margin-bottom: 40px
+      margin-bottom: 40px;
+      letter-spacing: 2px;
     }
     a {
-      box-shadow: 0 2px 5px 0 rgba(0,0,0,.26);
-      color: rgb(22, 110, 219);
-      background-color: white;
-      border-color: white;
-      border-radius: 30px;
-      padding: 0.75rem 2.25rem;
-      text-decoration: none;
+      color: rgb(56 135 231);
+      letter-spacing: 1px;
+      font-size: 1.3rem;
       font-weight: bold;
-      margin: 0px 10px;
     }
-    img{
+    img {
       width: 260px;
-    }
-    .background {
-      background: linear-gradient(to bottom right, #0169e0, #92c5ff);
-      position: absolute;
-      top: -200px;
-      width: 100%;
-      height: 800px;
-      transform: skewY(-10deg);
     }
   </style>
 </head>
 <body>
-  <div class="background">
-
-  </div>
   <div class="wrapper">
-    <div class="img-container">
+    <div>
       <img src="logo.png" alt="FoalTS logo">
     </div>
-    <h1>Welcome to the future ✨</h1>
+    <h1>Welcome on board ✨</h1>
     <div>
-      <a href="https://twitter.com/FoalTs">TWITTER</a>
-      <a href="https://foalts.gitbook.io/docs/">DOCUMENTATION</a>
-      <a href="https://foalts.org/">WEBSITE</a>
-    </div>
+      <a href="https://foalts.gitbook.io/docs/">Learn Foal TS</a>
+    </div> 
   </div>
 </body>
 </html>

--- a/packages/cli/src/generate/templates/app/public/index.html
+++ b/packages/cli/src/generate/templates/app/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>Welcome to the future!</title>
+  <title>Foal TS App</title>
   <link rel="shortcut icon" href="logo.png">
   <style>
     html, body {
@@ -13,57 +13,40 @@
       margin: 0;
       text-align: center;
       font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+      background-color: #282c34;
     }
     .wrapper {
-      height: 80%;
+      height: 95%;
       display: flex;
       flex-direction: column;
       justify-content: center;
-      position: relative;
     }
     h1 {
       color: white;
       font-weight: bold;
-      margin-bottom: 40px
+      margin-bottom: 40px;
+      letter-spacing: 2px;
     }
     a {
-      box-shadow: 0 2px 5px 0 rgba(0,0,0,.26);
-      color: rgb(22, 110, 219);
-      background-color: white;
-      border-color: white;
-      border-radius: 30px;
-      padding: 0.75rem 2.25rem;
-      text-decoration: none;
+      color: rgb(56 135 231);
+      letter-spacing: 1px;
+      font-size: 1.3rem;
       font-weight: bold;
-      margin: 0px 10px;
     }
-    img{
+    img {
       width: 260px;
-    }
-    .background {
-      background: linear-gradient(to bottom right, #0169e0, #92c5ff);
-      position: absolute;
-      top: -200px;
-      width: 100%;
-      height: 800px;
-      transform: skewY(-10deg);
     }
   </style>
 </head>
 <body>
-  <div class="background">
-
-  </div>
   <div class="wrapper">
-    <div class="img-container">
+    <div>
       <img src="logo.png" alt="FoalTS logo">
     </div>
-    <h1>Welcome to the future ✨</h1>
+    <h1>Welcome on board ✨</h1>
     <div>
-      <a href="https://twitter.com/FoalTs">TWITTER</a>
-      <a href="https://foalts.gitbook.io/docs/">DOCUMENTATION</a>
-      <a href="https://foalts.org/">WEBSITE</a>
-    </div>
+      <a href="https://foalts.gitbook.io/docs/">Learn Foal TS</a>
+    </div> 
   </div>
 </body>
 </html>

--- a/packages/core/src/common/utils/500.debug.html
+++ b/packages/core/src/common/utils/500.debug.html
@@ -6,60 +6,97 @@
   <style>
     html, body {
       height: 100%;
-      }
+    }
+
     body {
+      background-color: #f7f7f7;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    }
+
+    .box {
+      width: 700px;
+      background-color: #fff;
+      box-shadow: 0 12px 44px 0 rgba(0,0,0,.06);
+      margin: auto;
+      margin-top: 100px;
+      border-radius: 5px;
+    }
+
+    .top-banner {
+      height: 5px;
+      background-color: #ff5555;
+      border-top-left-radius: 5px;
+      border-top-right-radius: 5px;
+    }
+
+    .content {
+      padding: 30px;
+    }
+
+    h2 {
       margin: 0;
-      font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+      margin-bottom: 20px;
     }
+
+    .section {
+      margin-bottom: 30px;
+    }
+
+    .filename {
+      font-style: italic;
+      margin-top: -10px;
+      margin-bottom: 20px;
+      font-size: 0.95rem;
+    }
+
+    .location {
+      float: right;
+    }
+
+    .message {
+      font-size: 1.2rem;
+    }
+
+    .stack {
+      background-color: #f3f3f3;
+      padding: 10px;
+      border-radius: 5px;
+    }
+
     pre {
-      white-space: pre-line;
-      border: 1px solid #3887e7;
-      border-radius: 3px;
-      padding: 15px;
+      overflow-x: scroll;
+      margin: 0;
     }
-    h1 {
-      color: black;
-      font-weight: bold;
-      margin-bottom: 10px;
+
+    .caption {
+      margin-top: 20px;
+      color: darkgrey;
+      text-align: justify;
+      font-size: 0.9rem;
     }
-    h3 {
-      color: #176edb;
-    }
-    .container {
-      margin: 10% 10% 0 10%;
-    }
-    .container-error-stack {
-      margin: 5% 10%;
-    }
-    .text-container {
-      margin-top: 50px;
-      line-height: 1.5;
-    }
-    img {
-      max-width: 100px;
-      float: left; 
-      display: block;
-      margin: 0px 15px 15px 0px;
-      }
   </style>
 </head>
 <body>
- <div class="container">
-    <div>    
-      <a href="https://foalts.org">
-        <img src="https://foalts.org/assets/img/logo_400.png" alt="Foal Logo">
-      </a>
-    </div>
-    <div class="text-container">
-        <h1>{{ name }}</h1>
-        <h3>{{ message }}</h3>
-    </div>
- </div>
- <div class="container-error-stack">
-    <pre>{{ stack }}</pre>
-    <span>
-      You are seeing this error because you have settings.debug set to true in your configuration file.
-    </span>
- </div>
+   <div class="box">
+      <div class="top-banner">    
+      </div>
+      <div class="content">
+        <div class="section">
+          <h2>{{ name }}</h2>
+          <div class="filename">
+            <span>{{ filename }}</span>
+            <span class="location">row {{ row }}, column {{ column }}</span>
+          </div>
+          <pre class="message">{{ message }}</pre>
+        </div>
+          <h2>Call Stack</h2>
+          <div class="stack">
+            <pre>{{ stack }}</pre>
+          </div>
+        <div class="caption">
+          You are seeing this error because you have settings.debug set to true in your configuration file.
+        </div>
+      </div>
+   </div>
 </body>
 </html>

--- a/packages/core/src/common/utils/500.debug.html
+++ b/packages/core/src/common/utils/500.debug.html
@@ -85,7 +85,7 @@
           <h2>{{ name }}</h2>
           <div class="filename">
             <span>{{ filename }}</span>
-            <span class="location">row {{ row }}, column {{ column }}</span>
+            <span class="location">line {{ line }}, column {{ column }}</span>
           </div>
           <pre class="message">{{ message }}</pre>
         </div>

--- a/packages/core/src/common/utils/render-error.util.spec.ts
+++ b/packages/core/src/common/utils/render-error.util.spec.ts
@@ -73,11 +73,14 @@ describe('renderError', () => {
         strictEqual(text.includes('<span>render-error.util.spec.ts</span>'), true);
       });
 
-      it('should contain the row and the column where the error was thrown.', async () => {
+      it('should contain the line and the column where the error was thrown.', async () => {
         const response = await renderError(error, ctx);
 
         const text: string = response.body;
-        strictEqual(text.includes('<span class="location">row 19, column 13</span>'), true);
+        const rex = /<span class="location">line (\d+), column (\d+)<\/span>/;
+        if (!rex.exec(text)) {
+          throw new Error('Line and/or column not found.');
+        }
       });
 
       it('should contain the message of the error.', async () => {

--- a/packages/core/src/common/utils/render-error.util.spec.ts
+++ b/packages/core/src/common/utils/render-error.util.spec.ts
@@ -10,9 +10,13 @@ describe('renderError', () => {
   let ctx: Context;
   let error: Error;
 
+  class PermissionError extends Error {
+    readonly name = 'PermissionError';
+  }
+
   beforeEach(() => {
     ctx = new Context({});
-    error = new Error('Error used in renderError');
+    error = new PermissionError('Error used in renderError');
   });
 
   function testErrorObject() {
@@ -53,19 +57,50 @@ describe('renderError', () => {
 
     testErrorObject();
 
-    it('should return a response with the proper body.', async () => {
-      const response = await renderError(error, ctx);
+    describe('returns a response whose body', () => {
 
-      const text: string = response.body;
-      strictEqual(text.includes(`Error: ${error.message}`), true, '"Error: This is an error" not found');
-      strictEqual(text.includes('at Context.'), true, '"at Context." not found');
-      strictEqual(
-        text.includes(
-          'You are seeing this error because you have settings.debug set to true in your configuration file.'
-        ),
-        true,
-        '"You are seeing this error because" not found.'
-      );
+      it('should contain the name of the error.', async () => {
+        const response = await renderError(error, ctx);
+
+        const text: string = response.body;
+        strictEqual(text.includes(`<h2>${error.name}</h2>`), true);
+      });
+
+      it('should contain the filename where the error was thrown.', async () => {
+        const response = await renderError(error, ctx);
+
+        const text: string = response.body;
+        strictEqual(text.includes('<span>render-error.util.spec.ts</span>'), true);
+      });
+
+      it('should contain the row and the column where the error was thrown.', async () => {
+        const response = await renderError(error, ctx);
+
+        const text: string = response.body;
+        strictEqual(text.includes('<span class="location">row 19, column 13</span>'), true);
+      });
+
+      it('should contain the message of the error.', async () => {
+        const response = await renderError(error, ctx);
+
+        const text: string = response.body;
+        strictEqual(text.includes(`<pre class="message">${error.message}</pre>`), true);
+      });
+
+      it('should contain the call stack of the error.', async () => {
+        const response = await renderError(error, ctx);
+
+        const text: string = response.body;
+        strictEqual(text.includes(`<pre>${error.stack}</pre>`), true);
+      });
+
+      it('should contain an information regarding the configuration.', async () => {
+        const response = await renderError(error, ctx);
+
+        const text: string = response.body;
+        strictEqual(text.includes('You are seeing this error because you have settings.debug set to true in your configuration file.'), true);
+      });
+
     });
 
   });

--- a/packages/core/src/common/utils/render-error.util.ts
+++ b/packages/core/src/common/utils/render-error.util.ts
@@ -1,6 +1,6 @@
 // std
 import { readFile } from 'fs';
-import { join } from 'path';
+import { basename, join } from 'path';
 import { promisify } from 'util';
 
 // FoalTS
@@ -24,10 +24,17 @@ export async function renderError(error: Error, ctx: Context): Promise<HttpRespo
 
   if (Config.get('settings.debug', 'boolean')) {
     const template = await promisify(readFile)(join(__dirname, '500.debug.html'), 'utf8');
+
+    const rex = /at (.*) \((.*):(\d+):(\d+)\)/;
+    const [ , , path, row, column ] = Array.from(rex.exec(error.stack || '') || []);
+
     body = renderToString(template, {
+      column,
+      filename: basename(path),
       message: error.message,
       name: error.name,
-      stack: error.stack
+      row,
+      stack: error.stack,
     });
   }
 

--- a/packages/core/src/common/utils/render-error.util.ts
+++ b/packages/core/src/common/utils/render-error.util.ts
@@ -26,14 +26,14 @@ export async function renderError(error: Error, ctx: Context): Promise<HttpRespo
     const template = await promisify(readFile)(join(__dirname, '500.debug.html'), 'utf8');
 
     const rex = /at (.*) \((.*):(\d+):(\d+)\)/;
-    const [ , , path, row, column ] = Array.from(rex.exec(error.stack || '') || []);
+    const [ , , path, line, column ] = Array.from(rex.exec(error.stack || '') || []);
 
     body = renderToString(template, {
       column,
       filename: basename(path),
+      line,
       message: error.message,
       name: error.name,
-      row,
       stack: error.stack,
     });
   }


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

The welcome page (when creating a new project) and the debugging page (when a 500 error is thrown) are not very nice. This PR makes them prettier.

This debug page displays also more information (file name and numbers of the row and the column).

# Solution and steps

*Before*
![500 before](https://user-images.githubusercontent.com/13604533/100640132-5909d800-3336-11eb-9dbb-a6c29604fc5a.png)

*After*
![500 after](https://user-images.githubusercontent.com/13604533/100640145-5d35f580-3336-11eb-994b-57dfe7c2e20e.png)

*Before*
![welcome before](https://user-images.githubusercontent.com/13604533/100640165-61621300-3336-11eb-9b03-bce397614151.png)

*After*
![welcome after](https://user-images.githubusercontent.com/13604533/100640182-67f08a80-3336-11eb-97f4-88d38ed87952.png)

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
