### PR TITLE
fix rest-api deprecations

### DIFF
--- a/.github/CONTRIBUTING.MD
+++ b/.github/CONTRIBUTING.MD
@@ -18,7 +18,7 @@ PRs that correct grammatical errors or small bugs can be submitted directly.
 
 ## Development Environment
 
-The framework development environment uses [lerna](https://lernajs.io/) for managing packages and [docker](https://www.docker.com/) for database provisioning.
+The framework development environment uses [lerna](https://lerna.js.org/) for managing packages and [docker](https://www.docker.com/) for database provisioning.
 
 **Steps:**
 1. Install docker.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ In recent years Node.js has become one of the most popular servers on the web. A
 
 But when it comes to setting up a complete and scalable project, things get harder. You have to put everything in place. The authorization system, database migrations, development tools or even hashing of passwords are just the tip of the iceberg. Working on this is time consuming and may slow down the release frequency or even lead to undesired bugs. As the codebase grows up and the complexity increases, it becomes harder and harder to develop new features and maintain the app.
 
-This is where FoalTS comes in. Based on express, this lightweight framework provides everything needed to create enterprise-grade applications. From the support of TypeScript to the integration of security tools, it offers the basic bricks to build robust webapps. But FoalTS does not pretend to be a closed framework. You can still import and use your favorite librairies from the rich ecosystem of Node.js.
+This is where FoalTS comes in. Based on express, this lightweight framework provides everything needed to create enterprise-grade applications. From the support of TypeScript to the integration of security tools, it offers the basic bricks to build robust webapps. But FoalTS does not pretend to be a closed framework. You can still import and use your favorite libraries from the rich ecosystem of Node.js.
 
 ## Philosophy
 

--- a/packages/cli/src/generate/specs/rest-api/test-foo-bar.controller.ts
+++ b/packages/cli/src/generate/specs/rest-api/test-foo-bar.controller.ts
@@ -2,7 +2,7 @@ import {
   ApiOperationDescription, ApiOperationId, ApiOperationSummary, ApiResponse,
   ApiUseTag, Context, Delete, Get, HttpResponseCreated,
   HttpResponseNoContent, HttpResponseNotFound, HttpResponseOK, Patch, Post,
-  Put, ValidateBody, ValidateParams, ValidateQuery
+  Put, ValidateBody, ValidatePathParam, ValidateQueryParam
 } from '@foal/core';
 import { getRepository } from 'typeorm';
 
@@ -29,13 +29,8 @@ export class TestFooBarController {
   )
   @ApiResponse(400, { description: 'Invalid query parameters.' })
   @ApiResponse(200, { description: 'Returns a list of testFooBars.' })
-  @ValidateQuery({
-    properties: {
-      skip: { type: 'number' },
-      take: { type: 'number' },
-    },
-    type: 'object',
-  })
+  @ValidateQueryParam('skip', { type: 'number' }, { required: false })
+  @ValidateQueryParam('take', { type: 'number' }, { required: false })
   async findTestFooBars(ctx: Context) {
     const testFooBars = await getRepository(TestFooBar).find({
       skip: ctx.request.query.skip,
@@ -49,7 +44,7 @@ export class TestFooBarController {
   @ApiOperationSummary('Find a testFooBar by ID.')
   @ApiResponse(404, { description: 'TestFooBar not found.' })
   @ApiResponse(200, { description: 'Returns the testFooBar.' })
-  @ValidateParams({ properties: { testFooBarId: { type: 'number' } }, type: 'object' })
+  @ValidatePathParam('testFooBarId', { type: 'integer' })
   async findTestFooBarById(ctx: Context) {
     const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.testFooBarId);
 
@@ -77,7 +72,7 @@ export class TestFooBarController {
   @ApiResponse(400, { description: 'Invalid testFooBar.' })
   @ApiResponse(404, { description: 'TestFooBar not found.' })
   @ApiResponse(200, { description: 'TestFooBar successfully updated. Returns the testFooBar.' })
-  @ValidateParams({ properties: { testFooBarId: { type: 'number' } }, type: 'object' })
+  @ValidatePathParam('testFooBarId', { type: 'integer' })
   @ValidateBody({ ...testFooBarSchema, required: [] })
   async modifyTestFooBar(ctx: Context) {
     const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.testFooBarId);
@@ -99,7 +94,7 @@ export class TestFooBarController {
   @ApiResponse(400, { description: 'Invalid testFooBar.' })
   @ApiResponse(404, { description: 'TestFooBar not found.' })
   @ApiResponse(200, { description: 'TestFooBar successfully updated. Returns the testFooBar.' })
-  @ValidateParams({ properties: { testFooBarId: { type: 'number' } }, type: 'object' })
+  @ValidatePathParam('testFooBarId', { type: 'integer' })
   @ValidateBody(testFooBarSchema)
   async replaceTestFooBar(ctx: Context) {
     const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.testFooBarId);
@@ -120,7 +115,7 @@ export class TestFooBarController {
   @ApiOperationSummary('Delete a testFooBar.')
   @ApiResponse(404, { description: 'TestFooBar not found.' })
   @ApiResponse(204, { description: 'TestFooBar successfully deleted.' })
-  @ValidateParams({ properties: { testFooBarId: { type: 'number' } }, type: 'object' })
+  @ValidatePathParam('testFooBarId', { type: 'integer' })
   async deleteTestFooBar(ctx: Context) {
     const testFooBar = await getRepository(TestFooBar).findOne(ctx.request.params.testFooBarId);
 

--- a/packages/cli/src/generate/templates/rest-api/controller.ts
+++ b/packages/cli/src/generate/templates/rest-api/controller.ts
@@ -2,7 +2,7 @@ import {
   ApiOperationDescription, ApiOperationId, ApiOperationSummary, ApiResponse,
   ApiUseTag, Context, Delete, Get, HttpResponseCreated,
   HttpResponseNoContent, HttpResponseNotFound, HttpResponseOK, Patch, Post,
-  Put, ValidateBody, ValidateParams, ValidateQuery
+  Put, ValidateBody, ValidatePathParam, ValidateQueryParam
 } from '@foal/core';
 import { getRepository } from 'typeorm';
 
@@ -29,13 +29,8 @@ export class /* upperFirstCamelName */Controller {
   )
   @ApiResponse(400, { description: 'Invalid query parameters.' })
   @ApiResponse(200, { description: 'Returns a list of /* camelName */s.' })
-  @ValidateQuery({
-    properties: {
-      skip: { type: 'number' },
-      take: { type: 'number' },
-    },
-    type: 'object',
-  })
+  @ValidateQueryParam('skip', { type: 'number' }, { required: false })
+  @ValidateQueryParam('take', { type: 'number' }, { required: false })
   async find/* upperFirstCamelName */s(ctx: Context) {
     const /* camelName */s = await getRepository(/* upperFirstCamelName */).find({
       skip: ctx.request.query.skip,
@@ -49,7 +44,7 @@ export class /* upperFirstCamelName */Controller {
   @ApiOperationSummary('Find a /* camelName */ by ID.')
   @ApiResponse(404, { description: '/* upperFirstCamelName */ not found.' })
   @ApiResponse(200, { description: 'Returns the /* camelName */.' })
-  @ValidateParams({ properties: { /* camelName */Id: { type: 'number' } }, type: 'object' })
+  @ValidatePathParam('/* camelName */Id', { type: 'integer' })
   async find/* upperFirstCamelName */ById(ctx: Context) {
     const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params./* camelName */Id);
 
@@ -77,7 +72,7 @@ export class /* upperFirstCamelName */Controller {
   @ApiResponse(400, { description: 'Invalid /* camelName */.' })
   @ApiResponse(404, { description: '/* upperFirstCamelName */ not found.' })
   @ApiResponse(200, { description: '/* upperFirstCamelName */ successfully updated. Returns the /* camelName */.' })
-  @ValidateParams({ properties: { /* camelName */Id: { type: 'number' } }, type: 'object' })
+  @ValidatePathParam('/* camelName */Id', { type: 'integer' })
   @ValidateBody({ .../* camelName */Schema, required: [] })
   async modify/* upperFirstCamelName */(ctx: Context) {
     const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params./* camelName */Id);
@@ -99,7 +94,7 @@ export class /* upperFirstCamelName */Controller {
   @ApiResponse(400, { description: 'Invalid /* camelName */.' })
   @ApiResponse(404, { description: '/* upperFirstCamelName */ not found.' })
   @ApiResponse(200, { description: '/* upperFirstCamelName */ successfully updated. Returns the /* camelName */.' })
-  @ValidateParams({ properties: { /* camelName */Id: { type: 'number' } }, type: 'object' })
+  @ValidatePathParam('/* camelName */Id', { type: 'integer' })
   @ValidateBody(/* camelName */Schema)
   async replace/* upperFirstCamelName */(ctx: Context) {
     const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params./* camelName */Id);
@@ -120,7 +115,7 @@ export class /* upperFirstCamelName */Controller {
   @ApiOperationSummary('Delete a /* camelName */.')
   @ApiResponse(404, { description: '/* upperFirstCamelName */ not found.' })
   @ApiResponse(204, { description: '/* upperFirstCamelName */ successfully deleted.' })
-  @ValidateParams({ properties: { /* camelName */Id: { type: 'number' } }, type: 'object' })
+  @ValidatePathParam('/* camelName */Id', { type: 'integer' })
   async delete/* upperFirstCamelName */(ctx: Context) {
     const /* camelName */ = await getRepository(/* upperFirstCamelName */).findOne(ctx.request.params./* camelName */Id);
 


### PR DESCRIPTION
# Issue
- [x] change ValidateParams to ValidatePathParam
- [x] change ValidateQuery to ValidateQueryParam

# Solution and steps
I used the rest-api command yesterday and I saw those deprecation warnings.

# Checklist

- [ ] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.