### PR TITLE
Make CLI exit with code 1 when a command fails.

### DIFF
--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -136,9 +136,6 @@ if grep -Ril "../../Users/loicp" .; then
     exit 1
 fi
 
-# Test the generators
-foal g model flight
-
 # Test linting
 npm run lint
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,13 @@ import { ClientError } from './generate/file-system';
 import { rmdir } from './rmdir';
 import { runScript } from './run-script';
 
+function displayError(...lines: string[]): void {
+  console.error();
+  lines.forEach(line => console.error(red(line)));
+  console.error();
+  process.exitCode = 1;
+}
+
 // tslint:disable-next-line:no-var-requires
 const pkg = require('../package.json');
 
@@ -86,13 +93,13 @@ program
         connectVue(path);
         break;
       default:
-        console.error();
-        console.error(red(`Unknown framework ${yellow(framework)}. Please provide a valid one:`));
-        console.error();
-        console.error(red('  angular'));
-        console.error(red('  react'));
-        console.error(red('  vue'));
-        console.error();
+        displayError(
+          `Unknown framework ${yellow(framework)}. Please provide a valid one:`,
+          '',
+          ' - angular',
+          ' - react',
+          ' - vue',
+        );
     }
   });
 
@@ -122,9 +129,7 @@ program
   })
   .action(async (type: GenerateType, name: string, options: { register: boolean, auth: boolean }) => {
     if (!name && type !== 'vscode-config') {
-      console.error();
-      console.error(red(`Argument "name" is required when creating a ${type}. Please provide one.`));
-      console.error();
+      displayError(`Argument "name" is required when creating a ${type}. Please provide one.`);
       return;
     }
     try {
@@ -151,17 +156,15 @@ program
           createVSCodeConfig();
           break;
         default:
-          console.error();
-          console.error(red(`Unknown type ${yellow(type)}. Please provide a valid one:`));
-          console.error();
-          generateTypes.forEach(t => console.error(red(`  ${t}`)));
-          console.error();
+          displayError(
+            `Unknown type ${yellow(type)}. Please provide a valid one:`,
+            '',
+            ...generateTypes.map(t => `  ${t}`)
+          );
       }
     } catch (error) {
       if (error instanceof ClientError) {
-        console.error();
-        console.error(red(error.message));
-        console.error();
+        displayError(error.message);
         return;
       }
       throw error;
@@ -177,7 +180,7 @@ program
       await rmdir(name);
     } catch (error) {
       if (error.code === 'ENOTDIR') {
-        console.error(red(error.message));
+        displayError(error.message);
         return;
       }
       throw error;
@@ -187,9 +190,7 @@ program
 program
   .on('command:*', (commands: string[]) => {
     program.outputHelp();
-    console.error();
-    console.error(red(`  Unknown command ${yellow(commands[0])}.`));
-    console.error();
+    displayError(`Unknown command ${yellow(commands[0])}.`);
   });
 
 program.parse(process.argv);


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

When a CLI command fails and displays an error, the exit code is still 0. This is annoying when using commands in a CI because the pipeline is not notified.

# Solution and steps

Exit with code 1 when a command fails

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
