### PR TITLE
[Docs] Update docusaurus dependencies to alpha 70

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -75,55 +75,55 @@ module.exports = {
         },
       ],
     },
-    // footer: {
-    //   style: 'dark',
-    //   links: [
-    //     {
-    //       title: 'Docs',
-    //       items: [
-    //         {
-    //           label: 'Style Guide',
-    //           to: 'docs/',
-    //         },
-    //         {
-    //           label: 'Second Doc',
-    //           to: 'docs/doc2/',
-    //         },
-    //       ],
-    //     },
-    //     {
-    //       title: 'Community',
-    //       items: [
-    //         {
-    //           label: 'Stack Overflow',
-    //           href: 'https://stackoverflow.com/questions/tagged/docusaurus',
-    //         },
-    //         {
-    //           label: 'Discord',
-    //           href: 'https://discordapp.com/invite/docusaurus',
-    //         },
-    //         {
-    //           label: 'Twitter',
-    //           href: 'https://twitter.com/docusaurus',
-    //         },
-    //       ],
-    //     },
-    //     {
-    //       title: 'More',
-    //       items: [
-    //         {
-    //           label: 'Blog',
-    //           to: 'blog',
-    //         },
-    //         {
-    //           label: 'GitHub',
-    //           href: 'https://github.com/facebook/docusaurus',
-    //         },
-    //       ],
-    //     },
-    //   ],
-    //   copyright: `Copyright © ${new Date().getFullYear()} My Project, Inc. Built with Docusaurus.`,
-    // },
+    footer: {
+      // style: 'dark',
+      links: [
+        // {
+        //   title: 'Docs',
+        //   items: [
+        //     {
+        //       label: 'Style Guide',
+        //       to: 'docs/',
+        //     },
+        //     {
+        //       label: 'Second Doc',
+        //       to: 'docs/doc2/',
+        //     },
+        //   ],
+        // },
+        // {
+        //   title: 'Community',
+        //   items: [
+        //     {
+        //       label: 'Stack Overflow',
+        //       href: 'https://stackoverflow.com/questions/tagged/docusaurus',
+        //     },
+        //     {
+        //       label: 'Discord',
+        //       href: 'https://discordapp.com/invite/docusaurus',
+        //     },
+        //     {
+        //       label: 'Twitter',
+        //       href: 'https://twitter.com/docusaurus',
+        //     },
+        //   ],
+        // },
+        // {
+        //   title: 'More',
+        //   items: [
+        //     {
+        //       label: 'Blog',
+        //       to: 'blog',
+        //     },
+        //     {
+        //       label: 'GitHub',
+        //       href: 'https://github.com/facebook/docusaurus',
+        //     },
+        //   ],
+        // },
+      ],
+      // copyright: `Copyright © ${new Date().getFullYear()} My Project, Inc. Built with Docusaurus.`,
+    },
   },
   plugins: [
     'docusaurus-plugin-sass',

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -4,6 +4,27 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@algolia/autocomplete-core": {
+      "version": "1.0.0-alpha.38",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.0.0-alpha.38.tgz",
+      "integrity": "sha512-mN/cMSNqMvkodkUZ8yMZUof8RquKCjNMGJwt+sejpLuvq4/kTzZZmsJQW7pplWxp+E/axXkdfMwkh/OdRTa8vA==",
+      "requires": {
+        "@algolia/autocomplete-shared": "1.0.0-alpha.38"
+      }
+    },
+    "@algolia/autocomplete-preset-algolia": {
+      "version": "1.0.0-alpha.38",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.0.0-alpha.38.tgz",
+      "integrity": "sha512-wwdU1kjUWkOa0XrGi9Smp2eS6R3hfOze1O0AUnAFQ+kGLOpo02DmydU1yXRFfXnYgW3mW97CvsMpMe73BWKkDA==",
+      "requires": {
+        "@algolia/autocomplete-shared": "1.0.0-alpha.38"
+      }
+    },
+    "@algolia/autocomplete-shared": {
+      "version": "1.0.0-alpha.38",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.0.0-alpha.38.tgz",
+      "integrity": "sha512-4GPHme9Wm8JN2ZTQWZaOgfJk28Z3WdC9XUaAhdd0Vii0GZkBMXSwlpeLPvKyrpuaocnkrMPafKJOMRHU0baMGQ=="
+    },
     "@algolia/cache-browser-local-storage": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.8.3.tgz",
@@ -120,9 +141,9 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
       "requires": {
         "@babel/highlight": "^7.10.4"
       }
@@ -133,24 +154,23 @@
       "integrity": "sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw=="
     },
     "@babel/core": {
-      "version": "7.12.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
-      "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.10.tgz",
+      "integrity": "sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.5",
+        "@babel/generator": "^7.12.10",
         "@babel/helper-module-transforms": "^7.12.1",
         "@babel/helpers": "^7.12.5",
-        "@babel/parser": "^7.12.7",
+        "@babel/parser": "^7.12.10",
         "@babel/template": "^7.12.7",
-        "@babel/traverse": "^7.12.9",
-        "@babel/types": "^7.12.7",
+        "@babel/traverse": "^7.12.10",
+        "@babel/types": "^7.12.10",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.2",
         "lodash": "^4.17.19",
-        "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
       },
@@ -163,21 +183,21 @@
       }
     },
     "@babel/generator": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-      "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+      "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
       "requires": {
-        "@babel/types": "^7.12.5",
+        "@babel/types": "^7.12.11",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
-      "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz",
+      "integrity": "sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==",
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.10"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -199,13 +219,13 @@
       }
     },
     "@babel/helper-builder-react-jsx-experimental": {
-      "version": "7.12.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.4.tgz",
-      "integrity": "sha512-AjEa0jrQqNk7eDQOo0pTfUOwQBMF+xVqrausQwT9/rTKy0g04ggFNaJpaE09IQMn9yExluigWMJcj0WC7bq+Og==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.11.tgz",
+      "integrity": "sha512-4oGVOekPI8dh9JphkPXC68iIuP6qp/RPbaPmorRmEFbRAHZjSqxPjqHudn18GVDPgCuFM/KdFXc63C17Ygfa9w==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.4",
-        "@babel/helper-module-imports": "^7.12.1",
-        "@babel/types": "^7.12.1"
+        "@babel/helper-annotate-as-pure": "^7.12.10",
+        "@babel/helper-module-imports": "^7.12.5",
+        "@babel/types": "^7.12.11"
       }
     },
     "@babel/helper-compilation-targets": {
@@ -266,21 +286,21 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+      "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
       "requires": {
-        "@babel/helper-get-function-arity": "^7.10.4",
-        "@babel/template": "^7.10.4",
-        "@babel/types": "^7.10.4"
+        "@babel/helper-get-function-arity": "^7.12.10",
+        "@babel/template": "^7.12.7",
+        "@babel/types": "^7.12.11"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+      "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
       "requires": {
-        "@babel/types": "^7.10.4"
+        "@babel/types": "^7.12.10"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -324,11 +344,11 @@
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.7.tgz",
-      "integrity": "sha512-I5xc9oSJ2h59OwyUqjv95HRyzxj53DAubUERgQMrpcCEYQyToeHA+NEcUEsVWB4j53RDeskeBJ0SgRAYHDBckw==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+      "integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
       "requires": {
-        "@babel/types": "^7.12.7"
+        "@babel/types": "^7.12.10"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -347,14 +367,14 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-      "integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+      "integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.12.1",
-        "@babel/helper-optimise-call-expression": "^7.10.4",
-        "@babel/traverse": "^7.12.5",
-        "@babel/types": "^7.12.5"
+        "@babel/helper-member-expression-to-functions": "^7.12.7",
+        "@babel/helper-optimise-call-expression": "^7.12.10",
+        "@babel/traverse": "^7.12.10",
+        "@babel/types": "^7.12.11"
       }
     },
     "@babel/helper-simple-access": {
@@ -374,22 +394,22 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+      "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
       "requires": {
-        "@babel/types": "^7.11.0"
+        "@babel/types": "^7.12.11"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
     },
     "@babel/helper-validator-option": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz",
-      "integrity": "sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A=="
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
+      "integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw=="
     },
     "@babel/helper-wrap-function": {
       "version": "7.12.3",
@@ -435,9 +455,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
-      "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg=="
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+      "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.12.1",
@@ -698,9 +718,9 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz",
-      "integrity": "sha512-zJyAC9sZdE60r1nVQHblcfCj29Dh2Y0DOvlMkcqSo0ckqjiCwNiUezUKw+RjOCwGfpLRwnAeQ2XlLpsnGkvv9w==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.11.tgz",
+      "integrity": "sha512-atR1Rxc3hM+VPg/NvNvfYw0npQEAcHuJ+MGZnFn6h3bo+1U3BWXMdFMlvVRApBTWKQMX7SOwRJZA5FBF/JQbvA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
@@ -925,40 +945,24 @@
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.7.tgz",
-      "integrity": "sha512-YFlTi6MEsclFAPIDNZYiCRbneg1MFGao9pPG9uD5htwE0vDbPaMUMeYd6itWjw7K4kro4UbdQf3ljmFl9y48dQ==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.11.tgz",
+      "integrity": "sha512-5nWOw6mTylaFU72BdZfa0dP1HsGdY3IMExpxn8LBE8dNmkQjB+W+sR+JwIdtbzkPvVuFviT3zyNbSUkuVTVxbw==",
       "requires": {
         "@babel/helper-builder-react-jsx": "^7.10.4",
-        "@babel/helper-builder-react-jsx-experimental": "^7.12.4",
+        "@babel/helper-builder-react-jsx-experimental": "^7.12.11",
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-jsx": "^7.12.1"
       }
     },
     "@babel/plugin-transform-react-jsx-development": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.7.tgz",
-      "integrity": "sha512-Rs3ETtMtR3VLXFeYRChle5SsP/P9Jp/6dsewBQfokDSzKJThlsuFcnzLTDRALiUmTC48ej19YD9uN1mupEeEDg==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.11.tgz",
+      "integrity": "sha512-5MvsGschXeXJsbzQGR/BH89ATMzCsM7rx95n+R7/852cGoK2JgMbacDw/A9Pmrfex4tArdMab0L5SBV4SB/Nxg==",
       "requires": {
-        "@babel/helper-builder-react-jsx-experimental": "^7.12.4",
+        "@babel/helper-builder-react-jsx-experimental": "^7.12.11",
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-syntax-jsx": "^7.12.1"
-      }
-    },
-    "@babel/plugin-transform-react-jsx-self": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.12.1.tgz",
-      "integrity": "sha512-FbpL0ieNWiiBB5tCldX17EtXgmzeEZjFrix72rQYeq9X6nUK38HCaxexzVQrZWXanxKJPKVVIU37gFjEQYkPkA==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      }
-    },
-    "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.12.1.tgz",
-      "integrity": "sha512-keQ5kBfjJNRc6zZN1/nVHCd6LLIHq4aUKcVnvE/2l+ZZROSbqoiGFRtT5t3Is89XJxBQaP7NLZX2jgGHdZvvFQ==",
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
     "@babel/plugin-transform-react-pure-annotations": {
@@ -987,13 +991,12 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.1.tgz",
-      "integrity": "sha512-Ac/H6G9FEIkS2tXsZjL4RAdS3L3WHxci0usAnz7laPWUmFiGtj7tIASChqKZMHTSQTQY6xDbOq+V1/vIq3QrWg==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.10.tgz",
+      "integrity": "sha512-xOrUfzPxw7+WDm9igMgQCbO3cJKymX7dFdsgRr1eu9n3KjjyU4pptIXbXPseQDquw+W+RuJEJMHKHNsPNNm3CA==",
       "requires": {
-        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-module-imports": "^7.12.5",
         "@babel/helper-plugin-utils": "^7.10.4",
-        "resolve": "^1.8.1",
         "semver": "^5.5.1"
       },
       "dependencies": {
@@ -1038,9 +1041,9 @@
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.1.tgz",
-      "integrity": "sha512-EPGgpGy+O5Kg5pJFNDKuxt9RdmTgj5sgrus2XVeMp/ZIbOESadgILUbm50SNpghOh3/6yrbsH+NB5+WJTmsA7Q==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.10.tgz",
+      "integrity": "sha512-JQ6H8Rnsogh//ijxspCjc21YPd3VLVoYtAwv3zQmqAt8YGYUtdo5usNhdl4b9/Vir2kPFZl6n1h0PfUz4hJhaA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
@@ -1073,15 +1076,15 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.7.tgz",
-      "integrity": "sha512-OnNdfAr1FUQg7ksb7bmbKoby4qFOHw6DKWWUNB9KqnnCldxhxJlP+21dpyaWFmf2h0rTbOkXJtAGevY3XW1eew==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.11.tgz",
+      "integrity": "sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==",
       "requires": {
         "@babel/compat-data": "^7.12.7",
         "@babel/helper-compilation-targets": "^7.12.5",
         "@babel/helper-module-imports": "^7.12.5",
         "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/helper-validator-option": "^7.12.1",
+        "@babel/helper-validator-option": "^7.12.11",
         "@babel/plugin-proposal-async-generator-functions": "^7.12.1",
         "@babel/plugin-proposal-class-properties": "^7.12.1",
         "@babel/plugin-proposal-dynamic-import": "^7.12.1",
@@ -1110,7 +1113,7 @@
         "@babel/plugin-transform-arrow-functions": "^7.12.1",
         "@babel/plugin-transform-async-to-generator": "^7.12.1",
         "@babel/plugin-transform-block-scoped-functions": "^7.12.1",
-        "@babel/plugin-transform-block-scoping": "^7.12.1",
+        "@babel/plugin-transform-block-scoping": "^7.12.11",
         "@babel/plugin-transform-classes": "^7.12.1",
         "@babel/plugin-transform-computed-properties": "^7.12.1",
         "@babel/plugin-transform-destructuring": "^7.12.1",
@@ -1136,12 +1139,12 @@
         "@babel/plugin-transform-spread": "^7.12.1",
         "@babel/plugin-transform-sticky-regex": "^7.12.7",
         "@babel/plugin-transform-template-literals": "^7.12.1",
-        "@babel/plugin-transform-typeof-symbol": "^7.12.1",
+        "@babel/plugin-transform-typeof-symbol": "^7.12.10",
         "@babel/plugin-transform-unicode-escapes": "^7.12.1",
         "@babel/plugin-transform-unicode-regex": "^7.12.1",
         "@babel/preset-modules": "^0.1.3",
-        "@babel/types": "^7.12.7",
-        "core-js-compat": "^3.7.0",
+        "@babel/types": "^7.12.11",
+        "core-js-compat": "^3.8.0",
         "semver": "^5.5.0"
       },
       "dependencies": {
@@ -1165,16 +1168,14 @@
       }
     },
     "@babel/preset-react": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.12.7.tgz",
-      "integrity": "sha512-wKeTdnGUP5AEYCYQIMeXMMwU7j+2opxrG0WzuZfxuuW9nhKvvALBjl67653CWamZJVefuJGI219G591RSldrqQ==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.12.10.tgz",
+      "integrity": "sha512-vtQNjaHRl4DUpp+t+g4wvTHsLQuye+n0H/wsXIZRn69oz/fvNC7gQ4IK73zGJBaxvHoxElDvnYCthMcT7uzFoQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-transform-react-display-name": "^7.12.1",
-        "@babel/plugin-transform-react-jsx": "^7.12.7",
+        "@babel/plugin-transform-react-jsx": "^7.12.10",
         "@babel/plugin-transform-react-jsx-development": "^7.12.7",
-        "@babel/plugin-transform-react-jsx-self": "^7.12.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.12.1",
         "@babel/plugin-transform-react-pure-annotations": "^7.12.1"
       }
     },
@@ -1216,27 +1217,27 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.12.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
-      "integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.10.tgz",
+      "integrity": "sha512-6aEtf0IeRgbYWzta29lePeYSk+YAFIC3kyqESeft8o5CkFlYIMX+EQDDWEiAQ9LHOA3d0oHdgrSsID/CKqXJlg==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.12.5",
+        "@babel/generator": "^7.12.10",
         "@babel/helper-function-name": "^7.10.4",
         "@babel/helper-split-export-declaration": "^7.11.0",
-        "@babel/parser": "^7.12.7",
-        "@babel/types": "^7.12.7",
+        "@babel/parser": "^7.12.10",
+        "@babel/types": "^7.12.10",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
       }
     },
     "@babel/types": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
-      "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.11.tgz",
+      "integrity": "sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/helper-validator-identifier": "^7.12.11",
         "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
@@ -1247,27 +1248,28 @@
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
     "@docsearch/css": {
-      "version": "1.0.0-alpha.28",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-1.0.0-alpha.28.tgz",
-      "integrity": "sha512-1AhRzVdAkrWwhaxTX6/R7SnFHz8yLz1W8I/AldlTrfbNvZs9INk1FZiEFTJdgHaP68nhgQNWSGlQiDiI3y2RYg=="
+      "version": "3.0.0-alpha.32",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.0.0-alpha.32.tgz",
+      "integrity": "sha512-wafLX/jT1NPAwifPhzMJX394PjKdqf5TA4cz/JgvBYR1/+MiErLk/pyCmocXkawWGR17/6u2qw3wYvXu/Qe/DQ=="
     },
     "@docsearch/react": {
-      "version": "1.0.0-alpha.28",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-1.0.0-alpha.28.tgz",
-      "integrity": "sha512-XjJOnCBXn+UZmtuDmgzlVIHnnvh6yHVwG4aFq8AXN6xJEIX3f180FvGaowFWAxgdtHplJxFGux0Xx4piHqBzIw==",
+      "version": "3.0.0-alpha.32",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.0.0-alpha.32.tgz",
+      "integrity": "sha512-2jqzPJu4y0mWiwwm+Kfgf/97Q8XaGxj1+jJfGJpJLkJyD8S2tK4OikyIRWI9gI9k3m48HxFm0+P8uAYYtIyjqA==",
       "requires": {
-        "@docsearch/css": "^1.0.0-alpha.28",
-        "@francoischalifour/autocomplete-core": "^1.0.0-alpha.28",
-        "@francoischalifour/autocomplete-preset-algolia": "^1.0.0-alpha.28",
+        "@algolia/autocomplete-core": "^1.0.0-alpha.35",
+        "@algolia/autocomplete-preset-algolia": "^1.0.0-alpha.35",
+        "@docsearch/css": "3.0.0-alpha.32",
         "algoliasearch": "^4.0.0"
       }
     },
     "@docusaurus/core": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-dJGbZ91QH9I5Nrhm0W6ZHe4j8Qv0RBclQkx3WayExxFSHgQUlBM0hBReJxAbTKc1uSJgG7OPpEWnzbZjyK9t/Q==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-ccDcr5eb5T3C6k7VoqTclBFwjVkIHK1zISdhqzRNVl8AZTql1bYMvGUJP+2WbF6RSdmsGTNWreaUlrJc00dQqw==",
       "requires": {
         "@babel/core": "^7.12.3",
+        "@babel/generator": "^7.12.5",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
         "@babel/plugin-proposal-optional-chaining": "^7.12.1",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
@@ -1277,10 +1279,11 @@
         "@babel/preset-typescript": "^7.12.1",
         "@babel/runtime": "^7.12.5",
         "@babel/runtime-corejs3": "^7.12.5",
-        "@docusaurus/cssnano-preset": "2.0.0-alpha.69",
-        "@docusaurus/types": "2.0.0-alpha.69",
-        "@docusaurus/utils": "2.0.0-alpha.69",
-        "@docusaurus/utils-validation": "2.0.0-alpha.69",
+        "@babel/traverse": "^7.12.5",
+        "@docusaurus/cssnano-preset": "2.0.0-alpha.70",
+        "@docusaurus/types": "2.0.0-alpha.70",
+        "@docusaurus/utils": "2.0.0-alpha.70",
+        "@docusaurus/utils-validation": "2.0.0-alpha.70",
         "@endiliey/static-site-generator-webpack-plugin": "^4.0.0",
         "@svgr/webpack": "^5.4.0",
         "babel-loader": "^8.2.1",
@@ -1345,9 +1348,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-Gv75LL4e2XnApNMPQ1mYVotH+0RKsg3WewPh7zSfEJvyzD6F+SHxIcu+tNSwkRMexlCLy6BHgOyEwvhom+VoaA==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-Zwk3SrlE5r/z5j/tjDcs4XoyeoyymCtEovoxLWLV7wb+iR1qb+Jdso4TRShAepbW/ff6SzjCZ8hRy8ahXPD9TA==",
       "requires": {
         "cssnano-preset-advanced": "^4.0.7",
         "postcss": "^7.0.2",
@@ -1356,14 +1359,14 @@
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-yieXX7RhzLasN1bBj/tMj43l+DRu3VEyFRC63khYwfAZyhKtlMEL9eEaKMN3eqvnZD2u6G+nxXafwpqLdqNAWg==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-CDR4O4z7wO5/S8O3TAggCynnuBIGIlUT9q9uhhkDe8h5XDhF8n8d6bwqir0O+fUMN3EnyrMq6z1g4IDRB5G2vw==",
       "requires": {
         "@babel/parser": "^7.12.5",
         "@babel/traverse": "^7.12.5",
-        "@docusaurus/core": "2.0.0-alpha.69",
-        "@docusaurus/utils": "2.0.0-alpha.69",
+        "@docusaurus/core": "2.0.0-alpha.70",
+        "@docusaurus/utils": "2.0.0-alpha.70",
         "@mdx-js/mdx": "^1.6.21",
         "@mdx-js/react": "^1.6.21",
         "escape-html": "^1.0.3",
@@ -1381,15 +1384,15 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-zN3c8ZiYpOid5f6YbxGZhVN8E5a4HmkyVJWTXts5tE0pdeiTuk0cfB5Iko4rnIDTztz7pJJCToIzKu07DcImww==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-qWXlSDovkhCZLJR0Wz4e3YcNjlelpuSNkS1rJ8sI1ehs/n32lj7A/nVoRfS/LnOMfIciY48vVPr64VLb6dfEeg==",
       "requires": {
-        "@docusaurus/core": "2.0.0-alpha.69",
-        "@docusaurus/mdx-loader": "2.0.0-alpha.69",
-        "@docusaurus/types": "2.0.0-alpha.69",
-        "@docusaurus/utils": "2.0.0-alpha.69",
-        "@docusaurus/utils-validation": "2.0.0-alpha.69",
+        "@docusaurus/core": "2.0.0-alpha.70",
+        "@docusaurus/mdx-loader": "2.0.0-alpha.70",
+        "@docusaurus/types": "2.0.0-alpha.70",
+        "@docusaurus/utils": "2.0.0-alpha.70",
+        "@docusaurus/utils-validation": "2.0.0-alpha.70",
         "chalk": "^3.0.0",
         "feed": "^4.2.1",
         "fs-extra": "^9.0.1",
@@ -1423,15 +1426,15 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-u+2juUJWFd/v/x8NU4UzQf6k5tc21oZj6s/IFQDTse/5QeHkMrkw0aqUeHbGWet4foBRnx+021vmrPPqxeV/dQ==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-LZre12Q0sxLgi2XgjQbNQMV+jFG7v0+8hRzgBL+iCRiLCa4NlV7+M6mEHJGJJXSKqbfH7CelaUOESqEgPpVQXQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-alpha.69",
-        "@docusaurus/mdx-loader": "2.0.0-alpha.69",
-        "@docusaurus/types": "2.0.0-alpha.69",
-        "@docusaurus/utils": "2.0.0-alpha.69",
-        "@docusaurus/utils-validation": "2.0.0-alpha.69",
+        "@docusaurus/core": "2.0.0-alpha.70",
+        "@docusaurus/mdx-loader": "2.0.0-alpha.70",
+        "@docusaurus/types": "2.0.0-alpha.70",
+        "@docusaurus/utils": "2.0.0-alpha.70",
+        "@docusaurus/utils-validation": "2.0.0-alpha.70",
         "chalk": "^3.0.0",
         "execa": "^3.4.0",
         "fs-extra": "^9.0.1",
@@ -1515,18 +1518,19 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-RmEuhKFGagLyH42ggTweWHjaf82qbD9Xp7rXx10iHAUW2bJsMyGioag6gAw0Q+DeMMeHtMJdPsU99cuYqUdTpw==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-HiFa5l1RDs155ATyYKkPtyIs/d6WJgSAyVfY5ji0Bsixp/K/Kh9YUZYMeTfeMIdhGYe3AAJz+PSZHYRpwTo1wA==",
       "requires": {
-        "@docusaurus/core": "2.0.0-alpha.69",
-        "@docusaurus/mdx-loader": "2.0.0-alpha.69",
-        "@docusaurus/types": "2.0.0-alpha.69",
-        "@docusaurus/utils": "2.0.0-alpha.69",
-        "@docusaurus/utils-validation": "2.0.0-alpha.69",
+        "@docusaurus/core": "2.0.0-alpha.70",
+        "@docusaurus/mdx-loader": "2.0.0-alpha.70",
+        "@docusaurus/types": "2.0.0-alpha.70",
+        "@docusaurus/utils": "2.0.0-alpha.70",
+        "@docusaurus/utils-validation": "2.0.0-alpha.70",
         "globby": "^10.0.1",
         "joi": "^17.2.1",
         "loader-utils": "^1.2.3",
+        "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "remark-admonitions": "^1.2.1",
         "slash": "^3.0.0",
@@ -1554,73 +1558,74 @@
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-wvLBvntbuh25RCkKEeuwLl2h9OzMXZLIQWNa6FvAtmc8Xaomn3JkYnWn/fAKiBiOExN1ZEf9XomKVLNIUJ9xOg==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-h/x5KtS/YJerhY6C6sJOaP9gMaSVnjj1qZ6r9E/IFujQJ7bSKnk1unqBQpVXADkQhP081ENPL01ubc0/JbE1Mw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-alpha.69",
-        "@docusaurus/types": "2.0.0-alpha.69",
-        "@docusaurus/utils": "2.0.0-alpha.69",
+        "@docusaurus/core": "2.0.0-alpha.70",
+        "@docusaurus/types": "2.0.0-alpha.70",
+        "@docusaurus/utils": "2.0.0-alpha.70",
         "react-json-view": "^1.19.1"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-CrGy8DeJqMZdNmbLNyfgLtjMcapOoqY8jbJiKYCELI8SZ8Ns28i8Yh5W9qe4KxGqSQXvVWHg36xJVG/xAF/6jA==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-Ah9W83ZnA0VvmflKNuGq5f/CaEjWJxhjkISQn09/ykEvXfWV33000Bhck4RoCr5YxD+GBEBT5suG5LKH7Qkigw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-alpha.69"
+        "@docusaurus/core": "2.0.0-alpha.70"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-mDAKBRkB3UJMuAUPqC43mNr8PPu3QuUbCLisJIvg7VMp9XoAcOImNZWmY2Smd+Law2tJkW3cBFPvm3fcVvJ1vA==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-K3s894PqMPQnGXEZs0bSs2bRE3bVXFYSb/RN+K9sNd7zxGuOX4UytuvpXP+1r0Hj/YTwQIjj7AKsND0ZpDJHyw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-alpha.69"
+        "@docusaurus/core": "2.0.0-alpha.70"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-DqrXm1PiWWNN5wbY1iVg0sdkCL3KZEj7uyjmZfXIfMQaEF2ErqJDY07QAwANrl27huPQmmc9tYwW3FqgKbVlbA==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-ev9yNLPoeHP03jTz67daGd7yA7YhUwHeoWz14SyiKuU7OYtwL/8SJTn/V5kMDRl7o8FRQt9T//mRkpa270hmXw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-alpha.69",
-        "@docusaurus/types": "2.0.0-alpha.69",
+        "@docusaurus/core": "2.0.0-alpha.70",
+        "@docusaurus/types": "2.0.0-alpha.70",
         "fs-extra": "^9.0.1",
         "joi": "^17.2.1",
         "sitemap": "^3.2.2"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-4RiLXB+1vYzgTxGRnZqrYU/7gSsqUWYbofy7Ce5i4NF+L65B0mnBGaBhU0j1ZQJUMuozByRbf54wExZB25Re0A==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-Zx98KryJjHiqzGisWKR0glXl0HXuf/YbcK9yUl6ySyS+6cIMAuGMS0HGLgbvvEmYjywz7nMLpijzGderEOihjQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-alpha.69",
-        "@docusaurus/plugin-content-blog": "2.0.0-alpha.69",
-        "@docusaurus/plugin-content-docs": "2.0.0-alpha.69",
-        "@docusaurus/plugin-content-pages": "2.0.0-alpha.69",
-        "@docusaurus/plugin-debug": "2.0.0-alpha.69",
-        "@docusaurus/plugin-google-analytics": "2.0.0-alpha.69",
-        "@docusaurus/plugin-google-gtag": "2.0.0-alpha.69",
-        "@docusaurus/plugin-sitemap": "2.0.0-alpha.69",
-        "@docusaurus/theme-classic": "2.0.0-alpha.69",
-        "@docusaurus/theme-search-algolia": "2.0.0-alpha.69"
+        "@docusaurus/core": "2.0.0-alpha.70",
+        "@docusaurus/plugin-content-blog": "2.0.0-alpha.70",
+        "@docusaurus/plugin-content-docs": "2.0.0-alpha.70",
+        "@docusaurus/plugin-content-pages": "2.0.0-alpha.70",
+        "@docusaurus/plugin-debug": "2.0.0-alpha.70",
+        "@docusaurus/plugin-google-analytics": "2.0.0-alpha.70",
+        "@docusaurus/plugin-google-gtag": "2.0.0-alpha.70",
+        "@docusaurus/plugin-sitemap": "2.0.0-alpha.70",
+        "@docusaurus/theme-classic": "2.0.0-alpha.70",
+        "@docusaurus/theme-search-algolia": "2.0.0-alpha.70"
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-BterTyQvGrHS4oC/USXDG6GHt90oWUFyDg7oQ8WAa2zfkZTgcM3LiZeUYbn8vwy/HVU7hOWCixPTtY3R9iNZ9Q==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-lKU+fgSd08fo3LNYTw31Wty7RgAdFm8bEOwBNkKZcCFnatTSG4qyDbrDZclCQT/SpXSv9XIEKUc0irg2IH6Qrg==",
       "requires": {
-        "@docusaurus/core": "2.0.0-alpha.69",
-        "@docusaurus/plugin-content-blog": "2.0.0-alpha.69",
-        "@docusaurus/plugin-content-docs": "2.0.0-alpha.69",
-        "@docusaurus/plugin-content-pages": "2.0.0-alpha.69",
-        "@docusaurus/theme-common": "2.0.0-alpha.69",
-        "@docusaurus/types": "2.0.0-alpha.69",
-        "@docusaurus/utils-validation": "2.0.0-alpha.69",
+        "@docusaurus/core": "2.0.0-alpha.70",
+        "@docusaurus/plugin-content-blog": "2.0.0-alpha.70",
+        "@docusaurus/plugin-content-docs": "2.0.0-alpha.70",
+        "@docusaurus/plugin-content-pages": "2.0.0-alpha.70",
+        "@docusaurus/theme-common": "2.0.0-alpha.70",
+        "@docusaurus/types": "2.0.0-alpha.70",
+        "@docusaurus/utils": "2.0.0-alpha.70",
+        "@docusaurus/utils-validation": "2.0.0-alpha.70",
         "@mdx-js/mdx": "^1.6.21",
         "@mdx-js/react": "^1.6.21",
         "@types/react-toggle": "^4.0.2",
@@ -1638,25 +1643,26 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-6Pq+gmmYOey86z0HaOOyIWMg+ftcl8KR0bamNQD3wkBtiEy7ymcHMlck887W+fFxttWLPo4+/HzfYFUqSoCHkQ==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-Ge/dLGPCJhtyvumSMg0BlWcF00d1Qd2KnHf8kL/0nTxe257yNTHIOK95LKhIPAdcVgxG+ge9N0XcBm4KaubASQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-alpha.69",
-        "@docusaurus/plugin-content-blog": "2.0.0-alpha.69",
-        "@docusaurus/plugin-content-docs": "2.0.0-alpha.69",
-        "@docusaurus/plugin-content-pages": "2.0.0-alpha.69",
-        "@docusaurus/types": "2.0.0-alpha.69"
+        "@docusaurus/core": "2.0.0-alpha.70",
+        "@docusaurus/plugin-content-blog": "2.0.0-alpha.70",
+        "@docusaurus/plugin-content-docs": "2.0.0-alpha.70",
+        "@docusaurus/plugin-content-pages": "2.0.0-alpha.70",
+        "@docusaurus/types": "2.0.0-alpha.70"
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-hPg54EwZudgqjs7D6QbWMbG3XmI10XtcqED9VMg6R3LPBG3317UhtuEGa1jJrF6hDN/HHbzWZOQ00LLBHpf9+Q==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-xuoWZ+HUKzn1A5vPlNZM8mtyRL5uo15o34OX/i7HkTRmBVymWO1bBE0lECfDVJU2JUYGmwjpDXhZzNLDZmZRWg==",
       "requires": {
-        "@docsearch/react": "^1.0.0-alpha.27",
-        "@docusaurus/core": "2.0.0-alpha.69",
-        "@docusaurus/utils": "2.0.0-alpha.69",
+        "@docsearch/react": "^3.0.0-alpha.31",
+        "@docusaurus/core": "2.0.0-alpha.70",
+        "@docusaurus/theme-common": "2.0.0-alpha.70",
+        "@docusaurus/utils": "2.0.0-alpha.70",
         "algoliasearch": "^4.0.0",
         "algoliasearch-helper": "^3.1.1",
         "clsx": "^1.1.1",
@@ -1666,9 +1672,9 @@
       }
     },
     "@docusaurus/types": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-8TgHmUMH5q+5D93nyugk/dtUeGPblRE++gxxrwjNYnJucRUNDKRC8kJhEozODGcSfXddTeMalPvbRKSz9Pxj2g==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-QoHmMiJhRDq5P/4o3eUIiJebdwRjShFlal01DST5B8MZo4k0ogl57FNHqJvIHc93NgonZzFlvC/auLlBnc/d4Q==",
       "requires": {
         "@types/webpack": "^4.41.0",
         "commander": "^4.0.1",
@@ -1677,15 +1683,16 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-RpxqcjPT0L+MxLyS/4QOHp/2hlKPcPoDyvfqtTJiS9DPtUzkH573a5/yMbfzz8IbPeYWRCPL2qxWtmN7XCZ/sQ==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-xNSUcE7fGcneH00CPCEY0SP5V7H6pLEcu620UiU/m1367tCMsmv+MZcnII2ACcjAtvhjS22v/KLippM3VeTXqQ==",
       "requires": {
-        "@docusaurus/types": "2.0.0-alpha.69",
+        "@docusaurus/types": "2.0.0-alpha.70",
         "chalk": "^3.0.0",
         "escape-string-regexp": "^2.0.0",
         "fs-extra": "^9.0.1",
         "gray-matter": "^4.0.2",
+        "lodash": "^4.17.20",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
         "resolve-pathname": "^3.0.0"
@@ -1699,11 +1706,11 @@
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.0.0-alpha.69",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-alpha.69.tgz",
-      "integrity": "sha512-kjSZS8WOCVlqCLHOhbIDqztmSAPkBva51oT/oohs4WaNdvT6e0PdLycUA2Dg3pXLw1FXsiMxluCYyC8BGX0B+Q==",
+      "version": "2.0.0-alpha.70",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-alpha.70.tgz",
+      "integrity": "sha512-GJonaRjiJtlCk1+RfKA9f0YwRsSRGFMVbl6DrFidTgs4FmRb0hQsN4fnllsBvBJtbDZYwPTQ3T7c4cKJ/Ll7bQ==",
       "requires": {
-        "@docusaurus/utils": "2.0.0-alpha.69",
+        "@docusaurus/utils": "2.0.0-alpha.70",
         "chalk": "^3.0.0",
         "joi": "^17.2.1"
       }
@@ -1719,16 +1726,6 @@
         "url": "^0.11.0",
         "webpack-sources": "^1.4.3"
       }
-    },
-    "@francoischalifour/autocomplete-core": {
-      "version": "1.0.0-alpha.28",
-      "resolved": "https://registry.npmjs.org/@francoischalifour/autocomplete-core/-/autocomplete-core-1.0.0-alpha.28.tgz",
-      "integrity": "sha512-rL9x+72btViw+9icfBKUJjZj87FgjFrD2esuTUqtj4RAX3s4AuVZiN8XEsfjQBSc6qJk31cxlvqZHC/BIyYXgg=="
-    },
-    "@francoischalifour/autocomplete-preset-algolia": {
-      "version": "1.0.0-alpha.28",
-      "resolved": "https://registry.npmjs.org/@francoischalifour/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.0.0-alpha.28.tgz",
-      "integrity": "sha512-bprfNmYt1opFUFEtD2XfY/kEsm13bzHQgU80uMjhuK0DJ914IjolT1GytpkdM6tJ4MBvyiJPP+bTtWO+BZ7c7w=="
     },
     "@hapi/hoek": {
       "version": "9.1.0",
@@ -1767,6 +1764,36 @@
         "unified": "9.2.0",
         "unist-builder": "2.0.3",
         "unist-util-visit": "2.0.3"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.12.9",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
+          "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.12.5",
+            "@babel/helper-module-transforms": "^7.12.1",
+            "@babel/helpers": "^7.12.5",
+            "@babel/parser": "^7.12.7",
+            "@babel/template": "^7.12.7",
+            "@babel/traverse": "^7.12.9",
+            "@babel/types": "^7.12.7",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.2",
+            "lodash": "^4.17.19",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "@mdx-js/react": {
@@ -2012,9 +2039,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "14.14.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.11.tgz",
-      "integrity": "sha512-BJ97wAUuU3NUiUCp44xzUFquQEvnk1wu7q4CMEUYKJWjdkr0YWYDsm4RFtAvxYsNjLsKcrFt6RvK8r+mnzMbEQ=="
+      "version": "14.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
+      "integrity": "sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -3100,13 +3127,13 @@
       }
     },
     "browserslist": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.15.0.tgz",
-      "integrity": "sha512-IJ1iysdMkGmjjYeRlDU8PQejVwxvVO5QOfXH7ylW31GO6LwNRSmm/SgRXtNsEXqMLl2e+2H5eEJ7sfynF8TCaQ==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.0.tgz",
+      "integrity": "sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001164",
+        "caniuse-lite": "^1.0.30001165",
         "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.612",
+        "electron-to-chromium": "^1.3.621",
         "escalade": "^3.1.1",
         "node-releases": "^1.1.67"
       }
@@ -3354,9 +3381,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001165",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz",
-      "integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA=="
+      "version": "1.0.30001168",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz",
+      "integrity": "sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -3951,9 +3978,9 @@
       "integrity": "sha512-WRvoIdnTs1rgPMkgA2pUOa/M4Enh2uzCwdKsOMYNAJiz/4ZvEJgmbF4OmninPmlFdAWisfeh0tH+Cpf7ni3RqQ=="
     },
     "copy-webpack-plugin": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.4.0.tgz",
-      "integrity": "sha512-p4eIA0ZWk4UI+xewyxOBTDCSDfjK6nCkr3zhDenoi7SFd+NgDNH/D14IZeFaCEFcK/psNDcAUMOB+sAxZ3SsAA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-6.4.1.tgz",
+      "integrity": "sha512-MXyPCjdPVx5iiWyl40Va3JGh27bKzOTNY3NjUTrosD2q7dR/cLD0013uqJ3BpFbUjyONINjb6qI7nDIJujrMbA==",
       "requires": {
         "cacache": "^15.0.5",
         "fast-glob": "^3.2.4",
@@ -4835,9 +4862,9 @@
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
     },
     "electron-to-chromium": {
-      "version": "1.3.620",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.620.tgz",
-      "integrity": "sha512-YbgWXUR2Mu+Fp6rm3GZ5YJdNo8SgZKLUTNSl2PNvdOcM8OIz07jRJnRkIaV9vdszFv9UUuGChh19w9qSuoLJgw=="
+      "version": "1.3.629",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.629.tgz",
+      "integrity": "sha512-iSPPJtPvHrMAvYOt+9cdbDmTasPqwnwz4lkP8Dn200gDNUBQOLQ96xUsWXBwXslAo5XxdoXAoQQ3RAy4uao9IQ=="
     },
     "elliptic": {
       "version": "6.5.3",
@@ -4955,9 +4982,9 @@
       "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
     },
     "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
       "requires": {
         "prr": "~1.0.1"
       }
@@ -5967,9 +5994,9 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -6049,11 +6076,18 @@
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
     },
     "global-dirs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
-      "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
+      "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
       "requires": {
-        "ini": "^1.3.5"
+        "ini": "1.3.7"
+      },
+      "dependencies": {
+        "ini": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+          "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ=="
+        }
       }
     },
     "global-modules": {
@@ -6483,9 +6517,9 @@
       "integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ=="
     },
     "html-entities": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
-      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA=="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.3.tgz",
+      "integrity": "sha512-/VulV3SYni1taM7a4RMdceqzJWR39gpZHjBwUnsCFKWV/GJkD14CJ5F7eWcZozmHJK0/f/H5U3b3SiPkuvxMgg=="
     },
     "html-minifier-terser": {
       "version": "5.1.1",
@@ -6929,9 +6963,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.6.tgz",
-      "integrity": "sha512-IZUoxEjNjubzrmvzZU4lKP7OnYmX72XRl3sqkfJhBKweKi5rnGi5+IUdlj/H1M+Ip5JQ1WzaDMOBRY90Ajc5jg=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "inline-style-parser": {
       "version": "0.1.1",
@@ -11443,6 +11477,36 @@
         "is-alphabetical": "1.0.4",
         "remark-parse": "8.0.3",
         "unified": "9.2.0"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.12.9",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
+          "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.12.5",
+            "@babel/helper-module-transforms": "^7.12.1",
+            "@babel/helpers": "^7.12.5",
+            "@babel/parser": "^7.12.7",
+            "@babel/template": "^7.12.7",
+            "@babel/traverse": "^7.12.9",
+            "@babel/types": "^7.12.7",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.2",
+            "lodash": "^4.17.19",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "remark-parse": {
@@ -13209,9 +13273,9 @@
       }
     },
     "ua-parser-js": {
-      "version": "0.7.22",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
-      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
+      "version": "0.7.23",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+      "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
     },
     "unherit": {
       "version": "1.1.3",
@@ -14354,9 +14418,9 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
-      "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.3.tgz",
+      "integrity": "sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==",
       "requires": {
         "memory-fs": "^0.4.1",
         "mime": "^2.4.4",
@@ -14366,9 +14430,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+          "version": "2.4.7",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
+          "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA=="
         }
       }
     },

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,9 +12,9 @@
     "clear": "docusaurus clear"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-alpha.69",
-    "@docusaurus/plugin-google-analytics": "2.0.0-alpha.69",
-    "@docusaurus/preset-classic": "2.0.0-alpha.69",
+    "@docusaurus/core": "2.0.0-alpha.70",
+    "@docusaurus/plugin-google-analytics": "2.0.0-alpha.70",
+    "@docusaurus/preset-classic": "2.0.0-alpha.70",
     "@mdx-js/react": "^1.6.21",
     "docusaurus-plugin-sass": "^0.1.11",
     "react": "^16.8.4",


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Keep up-to-date with docusaurus alpha versions.

# Solution and steps

- [x] Upgrade to alpha.70.
- [x] Test that the website is still working properly.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
