### PR TITLE
Hide unhelpful sqlite3 warnings when using createapp with npm

### DIFF
--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -156,7 +156,7 @@ export async function createApp({ name, autoInstall, initRepo, mongodb = false, 
     log('');
     log('  📦 Installing the dependencies...');
     const packageManager = isYarnInstalled() ? 'yarn' : 'npm';
-    const args = [ 'install' ];
+    const args = isYarnInstalled() ? [ 'install' ] : [ '--loglevel=error', 'install' ];
     const options: SpawnOptions = {
       cwd: names.kebabName,
       shell: true,


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Fixes #667 

# Solution and steps

- [x] Only show errors when installing the dependencies.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
