### PR TITLE
Prettify server output

### DIFF
--- a/packages/cli/src/generate/specs/app/src/index.ts
+++ b/packages/cli/src/generate/specs/app/src/index.ts
@@ -4,7 +4,7 @@ import 'source-map-support/register';
 import * as http from 'http';
 
 // 3p
-import { Config, createApp } from '@foal/core';
+import { Config, createApp, displayServerURL } from '@foal/core';
 
 // App
 import { AppController } from './app/app.controller';
@@ -14,9 +14,7 @@ async function main() {
 
   const httpServer = http.createServer(app);
   const port = Config.get('port', 'number', 3001);
-  httpServer.listen(port, () => {
-    console.log(`Listening on port ${port}...`);
-  });
+  httpServer.listen(port, () => displayServerURL(port));
 }
 
 main()

--- a/packages/cli/src/generate/templates/app/src/index.ts
+++ b/packages/cli/src/generate/templates/app/src/index.ts
@@ -4,7 +4,7 @@ import 'source-map-support/register';
 import * as http from 'http';
 
 // 3p
-import { Config, createApp } from '@foal/core';
+import { Config, createApp, displayServerURL } from '@foal/core';
 
 // App
 import { AppController } from './app/app.controller';
@@ -14,9 +14,7 @@ async function main() {
 
   const httpServer = http.createServer(app);
   const port = Config.get('port', 'number', 3001);
-  httpServer.listen(port, () => {
-    console.log(`Listening on port ${port}...`);
-  });
+  httpServer.listen(port, () => displayServerURL(port));
 }
 
 main()

--- a/packages/core/src/common/utils/display-server-url.util.spec.ts
+++ b/packages/core/src/common/utils/display-server-url.util.spec.ts
@@ -1,0 +1,35 @@
+// std
+import { strictEqual } from 'assert';
+
+// FoalTS
+import { displayServerURL } from './display-server-url.util';
+
+describe('displayServerURL', () => {
+
+  it('should display the proper output.', () => {
+    let expectedOutput = `
+\x1b[32m -------------------------------------- \x1b[0m
+\x1b[32m|                                      |\x1b[0m
+\x1b[32m|                                      |\x1b[0m
+\x1b[32m|            Server started!           |\x1b[0m
+\x1b[32m|                                      |\x1b[0m
+\x1b[32m|\x1b[0m     Local: http://localhost:8080     \x1b[32m|\x1b[0m
+\x1b[32m|                                      |\x1b[0m
+\x1b[32m|                                      |\x1b[0m
+\x1b[32m -------------------------------------- \x1b[0m
+`;
+
+    let actualOutput = '';
+
+    function log(str: string = '') {
+      actualOutput += str + `\n`;
+    }
+
+    expectedOutput += '\n';
+
+    displayServerURL(8080, log);
+
+    strictEqual(actualOutput, expectedOutput);
+  });
+
+});

--- a/packages/core/src/common/utils/display-server-url.util.ts
+++ b/packages/core/src/common/utils/display-server-url.util.ts
@@ -1,0 +1,13 @@
+export function displayServerURL(port: number, log = console.log) {
+  log();
+  log('\x1b[32m -------------------------------------- \x1b[0m');
+  log('\x1b[32m|                                      |\x1b[0m');
+  log('\x1b[32m|                                      |\x1b[0m');
+  log('\x1b[32m|            Server started!           |\x1b[0m');
+  log('\x1b[32m|                                      |\x1b[0m');
+  log(`\x1b[32m|\x1b[0m     Local: http://localhost:${port}     \x1b[32m|\x1b[0m`);
+  log('\x1b[32m|                                      |\x1b[0m');
+  log('\x1b[32m|                                      |\x1b[0m');
+  log('\x1b[32m -------------------------------------- \x1b[0m');
+  log();
+}

--- a/packages/core/src/common/utils/index.ts
+++ b/packages/core/src/common/utils/index.ts
@@ -1,4 +1,5 @@
 export { controller } from './controller.util';
+export { displayServerURL } from './display-server-url.util';
 export { escapeProp } from './escape-prop';
 export { escape } from './escape';
 export { getAjvInstance } from './get-ajv-instance';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export {
   ValidatePathParam,
   ValidateQueryParam,
   controller,
+  displayServerURL,
   convertBase64ToBase64url,
   escape,
   escapeProp,

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -10,7 +10,7 @@ import 'source-map-support/register';
 import * as http from 'http';
 
 // 3p
-import { Config, createApp } from '@foal/core';
+import { Config, createApp, displayServerURL } from '@foal/core';
 import { createConnection } from '@foal/typeorm/node_modules/typeorm';
 
 // App
@@ -23,9 +23,7 @@ async function main() {
 
   const httpServer = http.createServer(app);
   const port = Config.get('port', 'number', 3001);
-  httpServer.listen(port, () => {
-    console.log(`Listening on port ${port}...`);
-  });
+  httpServer.listen(port, () => displayServerURL(port));
 }
 
 main()


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

This PR makes prettier the output of the server when it starts.

*Before*

![Capture d’écran 2021-02-24 à 15 34 49](https://user-images.githubusercontent.com/13604533/109016628-a340f200-76b6-11eb-8833-c1baa6890405.png)

*Output*

![Capture d’écran 2021-02-24 à 15 34 02](https://user-images.githubusercontent.com/13604533/109016636-a4721f00-76b6-11eb-9df6-2456dcd6c840.png)

# Solution and steps

- [x] Add `displayServerURL` util
- [x] Use `displayServerURL` in new projects.
- [x] Test on Mac OS
- [x] Test on Windows

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
