### PR TITLE
Add missing documentation and add more e2e tests

### DIFF
--- a/docs/docs/architecture/hooks.md
+++ b/docs/docs/architecture/hooks.md
@@ -457,3 +457,46 @@ class MyController {
   }
 }
 ```
+
+## Forward Data Between Hooks
+
+If you need to transfer data from one hook to another or to the controller method, you can use the `state` property of the `Context` object to do so.
+
+```typescript
+import { Context, Get, Hook, HttpResponseOK, UserRequired } from '@foal/core';
+import { Org } from '../entities';
+
+function AddOrgToContext() {
+  return Hook(async ctx => {
+    if (ctx.user) {
+      ctx.state.org = await Org.findOneOrFail(ctx.user.orgId);
+    }
+  })
+}
+
+export class ApiController {
+
+  @Get('/org-name')
+  @UserRequired()
+  @AddOrgToContext()
+  readOrgName(ctx: Context) {
+    return new HttpResponseOK(ctx.state.org.name);
+  }
+
+}
+```
+
+If needed, you can also define an interface for your state and pass it as type argument to the context.
+
+```typescript
+interface State {
+  org: Org;
+}
+
+export class ApiController {
+  // ...
+  readOrgName(ctx: Context<any, any, State>) {
+    // ...
+  }
+}
+```

--- a/docs/docs/authentication-and-access-control/password-management.md
+++ b/docs/docs/authentication-and-access-control/password-management.md
@@ -7,7 +7,7 @@ sidebar_label: Passwords
 
 Every application must store passwords using a cryptographic technique. FoalTS provides two functions to hash and verify passwords.
 
-## The `hashPassword` function
+## Hash and Salt Passwords
 
 The `hashPassword` utility uses the [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2) algorithm with a SHA256 hash. It takes as parameters the password in plain text and an optional `options` object. It returns a promise which value is a password hash.
 
@@ -17,7 +17,7 @@ The `hashPassword` utility uses the [PBKDF2](https://en.wikipedia.org/wiki/PBKDF
 const passwordHash = await hashPassword(plainTextPassword);
 ```
 
-## The `verifyPassword` function
+## Verify Passwords
 
 The `verifyPassword` takes three arguments:
 - the password to check in plain text,
@@ -25,4 +25,16 @@ The `verifyPassword` takes three arguments:
 
 ```typescript
 const isEqual = await verifyPassword(plainTextPassword, passwordHash);
+```
+
+## Forbid Overly Common Passwords
+
+```
+npm install @foal/password
+```
+
+To prevent users from using very weak passwords such as `123456` or `password`, you can call the `isCommon` function. This utility checks if the given password is part of the 10000 most common passwords listed [here](https://github.com/danielmiessler/SecLists/blob/master/Passwords/Common-Credentials/10-million-password-list-top-10000.txt).
+
+```typescript
+const isPasswordTooCommon = await isCommon(password);
 ```

--- a/docs/docs/cookbook/base64url.md
+++ b/docs/docs/cookbook/base64url.md
@@ -1,0 +1,9 @@
+---
+title: Base 64 URL
+---
+
+If you need to convert a base64-encoded string to base64URL, you can use the `convertBase64ToBase64url` function for this. It will replace the characters `+` and `/` by `-` and `_` respectively and omit the `=` sign.
+
+```typescript
+const foo = convertBase64ToBase64url('bar');
+```

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/architecture/hooks.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/architecture/hooks.md
@@ -457,3 +457,46 @@ class MyController {
   }
 }
 ```
+
+## Forward Data Between Hooks
+
+If you need to transfer data from one hook to another or to the controller method, you can use the `state` property of the `Context` object to do so.
+
+```typescript
+import { Context, Get, Hook, HttpResponseOK, UserRequired } from '@foal/core';
+import { Org } from '../entities';
+
+function AddOrgToContext() {
+  return Hook(async ctx => {
+    if (ctx.user) {
+      ctx.state.org = await Org.findOneOrFail(ctx.user.orgId);
+    }
+  })
+}
+
+export class ApiController {
+
+  @Get('/org-name')
+  @UserRequired()
+  @AddOrgToContext()
+  readOrgName(ctx: Context) {
+    return new HttpResponseOK(ctx.state.org.name);
+  }
+
+}
+```
+
+If needed, you can also define an interface for your state and pass it as type argument to the context.
+
+```typescript
+interface State {
+  org: Org;
+}
+
+export class ApiController {
+  // ...
+  readOrgName(ctx: Context<any, any, State>) {
+    // ...
+  }
+}
+```

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/authentication-and-access-control/password-management.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/authentication-and-access-control/password-management.md
@@ -7,7 +7,7 @@ sidebar_label: Contraseñas
 
 Every application must store passwords using a cryptographic technique. FoalTS provides two functions to hash and verify passwords.
 
-## The `hashPassword` function
+## Hash and Salt Passwords
 
 The `hashPassword` utility uses the [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2) algorithm with a SHA256 hash. It takes as parameters the password in plain text and an optional `options` object. It returns a promise which value is a password hash.
 
@@ -17,7 +17,7 @@ The `hashPassword` utility uses the [PBKDF2](https://en.wikipedia.org/wiki/PBKDF
 const passwordHash = await hashPassword(plainTextPassword);
 ```
 
-## The `verifyPassword` function
+## Verify Passwords
 
 The `verifyPassword` takes three arguments:
 - the password to check in plain text,
@@ -25,4 +25,16 @@ The `verifyPassword` takes three arguments:
 
 ```typescript
 const isEqual = await verifyPassword(plainTextPassword, passwordHash);
+```
+
+## Forbid Overly Common Passwords
+
+```
+npm install @foal/password
+```
+
+To prevent users from using very weak passwords such as `123456` or `password`, you can call the `isCommon` function. This utility checks if the given password is part of the 10000 most common passwords listed [here](https://github.com/danielmiessler/SecLists/blob/master/Passwords/Common-Credentials/10-million-password-list-top-10000.txt).
+
+```typescript
+const isPasswordTooCommon = await isCommon(password);
 ```

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/cookbook/base64url.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/cookbook/base64url.md
@@ -1,0 +1,9 @@
+---
+title: Base 64 URL
+---
+
+If you need to convert a base64-encoded string to base64URL, you can use the `convertBase64ToBase64url` function for this. It will replace the characters `+` and `/` by `-` and `_` respectively and omit the `=` sign.
+
+```typescript
+const foo = convertBase64ToBase64url('bar');
+```

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/architecture/hooks.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/architecture/hooks.md
@@ -457,3 +457,46 @@ class MyController {
   }
 }
 ```
+
+## Forward Data Between Hooks
+
+If you need to transfer data from one hook to another or to the controller method, you can use the `state` property of the `Context` object to do so.
+
+```typescript
+import { Context, Get, Hook, HttpResponseOK, UserRequired } from '@foal/core';
+import { Org } from '../entities';
+
+function AddOrgToContext() {
+  return Hook(async ctx => {
+    if (ctx.user) {
+      ctx.state.org = await Org.findOneOrFail(ctx.user.orgId);
+    }
+  })
+}
+
+export class ApiController {
+
+  @Get('/org-name')
+  @UserRequired()
+  @AddOrgToContext()
+  readOrgName(ctx: Context) {
+    return new HttpResponseOK(ctx.state.org.name);
+  }
+
+}
+```
+
+If needed, you can also define an interface for your state and pass it as type argument to the context.
+
+```typescript
+interface State {
+  org: Org;
+}
+
+export class ApiController {
+  // ...
+  readOrgName(ctx: Context<any, any, State>) {
+    // ...
+  }
+}
+```

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/authentication-and-access-control/password-management.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/authentication-and-access-control/password-management.md
@@ -6,8 +6,7 @@ sidebar_label: Mots de Passe
 > You are reading the documentation for version 2 of FoalTS. Instructions for upgrading to this version are available [here](../upgrade-to-v2/README.md). The old documentation can be found [here](https://foalts.org/docs/1.x/).
 
 Every application must store passwords using a cryptographic technique. FoalTS provides two functions to hash and verify passwords.
-
-## The `hashPassword` function
+## Hash and Salt Passwords
 
 The `hashPassword` utility uses the [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2) algorithm with a SHA256 hash. It takes as parameters the password in plain text and an optional `options` object. It returns a promise which value is a password hash.
 
@@ -17,7 +16,7 @@ The `hashPassword` utility uses the [PBKDF2](https://en.wikipedia.org/wiki/PBKDF
 const passwordHash = await hashPassword(plainTextPassword);
 ```
 
-## The `verifyPassword` function
+## Verify Passwords
 
 The `verifyPassword` takes three arguments:
 - the password to check in plain text,
@@ -25,4 +24,16 @@ The `verifyPassword` takes three arguments:
 
 ```typescript
 const isEqual = await verifyPassword(plainTextPassword, passwordHash);
+```
+
+## Forbid Overly Common Passwords
+
+```
+npm install @foal/password
+```
+
+To prevent users from using very weak passwords such as `123456` or `password`, you can call the `isCommon` function. This utility checks if the given password is part of the 10000 most common passwords listed [here](https://github.com/danielmiessler/SecLists/blob/master/Passwords/Common-Credentials/10-million-password-list-top-10000.txt).
+
+```typescript
+const isPasswordTooCommon = await isCommon(password);
 ```

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/cookbook/base64url.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/cookbook/base64url.md
@@ -1,0 +1,9 @@
+---
+title: Base 64 URL
+---
+
+If you need to convert a base64-encoded string to base64URL, you can use the `convertBase64ToBase64url` function for this. It will replace the characters `+` and `/` by `-` and `_` respectively and omit the `=` sign.
+
+```typescript
+const foo = convertBase64ToBase64url('bar');
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -119,6 +119,7 @@ module.exports = {
         'cookbook/expressjs',
         'cookbook/root-imports',
         'cookbook/limit-repeated-requests',
+        'cookbook/base64url',
       ]),
       category('Deployment & Environments', [
         'deployment-and-environments/configuration',

--- a/packages/acceptance-tests/src/additional/authentication/do-not-save-sessions-on-error.spec.ts
+++ b/packages/acceptance-tests/src/additional/authentication/do-not-save-sessions-on-error.spec.ts
@@ -1,0 +1,127 @@
+// 3p
+import * as request from 'supertest';
+
+// FoalTS
+import { Config, Context, createApp, createSession, dependency, Get, Hook, HttpResponseOK, Store, UseSessions } from '@foal/core';
+import { DatabaseSession } from '@foal/typeorm';
+import { closeTestConnection, createTestConnection, getTypeORMStorePath } from '../../common';
+
+describe('Sessions should not be saved when an error has been thrown', () => {
+
+  beforeEach(() => {
+    Config.set('settings.session.store', getTypeORMStorePath());
+    Config.set('settings.logErrors', false);
+  });
+
+  afterEach(() => {
+    Config.remove('settings.session.store');
+    Config.remove('settings.logErrors');
+    return closeTestConnection();
+  });
+
+  function SetFooContent() {
+    return Hook(ctx => {
+      if (ctx.session) {
+        ctx.session.set('foo', 'bar');
+      }
+    });
+  }
+
+  @UseSessions()
+  class AppController {
+    @dependency
+    store: Store;
+
+    @Get('/new-session')
+    async createNewSession(ctx: Context) {
+      ctx.session = await createSession(this.store);
+      return new HttpResponseOK({ token: ctx.session.getToken() });
+    }
+
+    @Get('/error-in-hook')
+    @SetFooContent()
+    @Hook(() => {
+      throw new Error('Error in hook');
+    })
+    errorInHook() {
+      return new HttpResponseOK();
+    }
+
+    @Get('/error-in-method')
+    @SetFooContent()
+    errorInMethod() {
+      throw new Error('Error in controller method');
+    }
+
+    @Get('/error-in-post-hook')
+    @SetFooContent()
+    @Hook(() => () => {
+      throw new Error('Error in post hook function');
+    })
+    errorInPostHook() {
+      return new HttpResponseOK();
+    }
+
+    @Get('/read-foo-content')
+    readFooContent(ctx: Context) {
+      return new HttpResponseOK(ctx.session?.get('foo') ?? 'null');
+    }
+
+    async init() {
+      await createTestConnection([ DatabaseSession ]);
+    }
+
+  }
+
+  let app: any;
+  let token: string;
+
+  beforeEach(async () => {
+    app = await createApp(AppController);
+
+    await request(app)
+      .get('/new-session')
+      .expect(200)
+      .then(response => token = response.body.token);
+  });
+
+  it('in a hook.', async () => {
+    await request(app)
+      .get('/error-in-hook')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(500);
+
+    await request(app)
+      .get('/read-foo-content')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .expect('null');
+  });
+
+  it('in the controller method.', async () => {
+    await request(app)
+      .get('/error-in-method')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(500);
+
+    await request(app)
+      .get('/read-foo-content')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .expect('null');
+  });
+
+  it('in a hook post function', async () => {
+    await request(app)
+      .get('/error-in-post-hook')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(500);
+
+    await request(app)
+      .get('/read-foo-content')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .expect('null');
+  });
+
+});

--- a/packages/acceptance-tests/src/docs/architecture/hooks/forwarding-data-between-hooks.feature.ts
+++ b/packages/acceptance-tests/src/docs/architecture/hooks/forwarding-data-between-hooks.feature.ts
@@ -1,0 +1,60 @@
+// 3p
+import * as request from 'supertest';
+
+// FoalTS
+import { Context, controller, createApp, Get, Hook, HttpResponseOK, UserRequired } from '@foal/core';
+
+describe('Feature: Forwarding data betweens hooks', () => {
+
+  it('Example: Load and forward the org of the connected user.', async () => {
+
+    class Org {
+
+      static async findOneOrFail(orgId: number) {
+        return new Org('Hello!');
+      }
+
+      constructor(public name: string) {}
+
+    }
+
+    /* ======================= DOCUMENTATION BEGIN ======================= */
+
+    function AddOrgToContext() {
+      return Hook(async ctx => {
+        if (ctx.user) {
+          ctx.state.org = await Org.findOneOrFail(ctx.user.orgId);
+        }
+      });
+    }
+
+    class ApiController {
+
+      @Get('/org-name')
+      @UserRequired()
+      @AddOrgToContext()
+      readOrgName(ctx: Context) {
+        return new HttpResponseOK(ctx.state.org.name);
+      }
+
+    }
+
+    /* ======================= DOCUMENTATION END ========================= */
+
+    @Hook(ctx => { ctx.user = { orgId: 1 }; })
+    class AppController {
+      subControllers = [
+        controller('/api', ApiController),
+      ];
+    }
+
+    const app = await createApp(AppController);
+
+    await request(app)
+      .get('/api/org-name')
+      .expect(200)
+      .expect('Hello!');
+
+  });
+
+});

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/regenerating-the-session-id.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/regenerating-the-session-id.feature.ts
@@ -21,7 +21,7 @@ import {
 import { DatabaseSession } from '@foal/typeorm';
 import { closeTestConnection, createTestConnection, getTypeORMStorePath } from '../../../common';
 
-describe.only('Feature: Regenerating the session ID', () => {
+describe('Feature: Regenerating the session ID', () => {
 
   beforeEach(() => {
     Config.set('settings.session.store', getTypeORMStorePath());

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/regenerating-the-session-id.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/regenerating-the-session-id.feature.ts
@@ -1,0 +1,82 @@
+// std
+import { notStrictEqual } from 'assert';
+
+// 3p
+import * as request from 'supertest';
+
+// FoalTS
+import {
+  Config,
+  Context,
+  createApp,
+  createSession,
+  dependency,
+  Get,
+  HttpResponseOK,
+  IAppController,
+  Session,
+  Store,
+  UseSessions
+} from '@foal/core';
+import { DatabaseSession } from '@foal/typeorm';
+import { closeTestConnection, createTestConnection, getTypeORMStorePath } from '../../../common';
+
+describe.only('Feature: Regenerating the session ID', () => {
+
+  beforeEach(() => {
+    Config.set('settings.session.store', getTypeORMStorePath());
+  });
+
+  afterEach(() => {
+    Config.remove('settings.session.store');
+    return closeTestConnection();
+  });
+
+  it('Example: Simple Example.', async () => {
+
+    @UseSessions()
+    class AppController implements IAppController {
+      @dependency
+      store: Store;
+
+      @Get('/new-session')
+      async createSessionAndReturnToken(ctx: Context) {
+        ctx.session = await createSession(this.store);
+        return new HttpResponseOK({ token: ctx.session.getToken() });
+      }
+
+      @Get('/regenerated-id')
+      async regenerateID(ctx: Context<any, Session>) {
+        /* ======================= DOCUMENTATION BEGIN ======================= */
+
+        await ctx.session.regenerateID();
+
+        /* ======================= DOCUMENTATION END ========================= */
+
+        return new HttpResponseOK({ token: ctx.session.getToken() });
+      }
+
+      async init() {
+        await createTestConnection([ DatabaseSession ]);
+      }
+    }
+
+    const app = await createApp(AppController);
+
+    let token = '';
+
+    await request(app)
+      .get('/new-session')
+      .expect(200)
+      .then(response => token = response.body.token);
+
+    await request(app)
+      .get('/regenerated-id')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .then(response => {
+        notStrictEqual(response.body.token, token);
+      });
+  });
+
+});

--- a/packages/cli/src/generate/generators/rest-api/create-rest-api.spec.ts
+++ b/packages/cli/src/generate/generators/rest-api/create-rest-api.spec.ts
@@ -5,7 +5,7 @@ import { throws } from 'assert';
 import { ClientError, FileSystem } from '../../file-system';
 import { createRestApi } from './create-rest-api';
 
-describe.only('createRestApi', () => {
+describe('createRestApi', () => {
 
   const fs = new FileSystem();
 


### PR DESCRIPTION
This PR add some parts that were missing in the documentation. It also some more tests to the framework.

- [x] Docs on `isCommon`
- [x] Docs on `Context.state`
- [x] Test on `Session.regenerateID`
- [x] Docs on `convertBase64ToBase64Url`
- [x] Test on the saving of a session when an error is thrown.