### PR TITLE
fix typo in controllers docs

### DIFF
--- a/docs/docs/architecture/controllers.md
+++ b/docs/docs/architecture/controllers.md
@@ -102,8 +102,8 @@ It has four properties:
 | --- | --- | --- |
 | `request` | `Request` | Gives information about the HTTP request. |
 | `state` | object | Object which can be used to forward data accross several hooks (see [Hooks](./hooks.md)). |
-| `user` | `any|undefined` | The current user (see [Authentication](../authentication-and-access-control/quick-start.md)). | 
-| `session`| `Session|undefined` | The session object if you use sessions. |
+| `user` | `any\|undefined` | The current user (see [Authentication](../authentication-and-access-control/quick-start.md)). | 
+| `session`| `Session\|undefined` | The session object if you use sessions. |
 
 
 ### HTTP Requests

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/architecture/controllers.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/architecture/controllers.md
@@ -102,8 +102,8 @@ It has four properties:
 | --- | --- | --- |
 | `request` | `Request` | Gives information about the HTTP request. |
 | `state` | object | Object which can be used to forward data accross several hooks (see [Hooks](./hooks.md)). |
-| `user` | `any|undefined` | The current user (see [Authentication](../authentication-and-access-control/quick-start.md)). | 
-| `session`| `Session|undefined` | The session object if you use sessions. |
+| `user` | `any\|undefined` | The current user (see [Authentication](../authentication-and-access-control/quick-start.md)). | 
+| `session`| `Session\|undefined` | The session object if you use sessions. |
 
 
 ### HTTP Requests

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/architecture/controllers.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/architecture/controllers.md
@@ -102,8 +102,8 @@ It has four properties:
 | --- | --- | --- |
 | `request` | `Request` | Gives information about the HTTP request. |
 | `state` | object | Object which can be used to forward data accross several hooks (see [Hooks](./hooks.md)). |
-| `user` | `any|undefined` | The current user (see [Authentication](../authentication-and-access-control/quick-start.md)). | 
-| `session`| `Session|undefined` | The session object if you use sessions. |
+| `user` | `any\|undefined` | The current user (see [Authentication](../authentication-and-access-control/quick-start.md)). | 
+| `session`| `Session\|undefined` | The session object if you use sessions. |
 
 
 ### HTTP Requests


### PR DESCRIPTION
I was reading the docs when i found this little typo


# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).