### PR TITLE
Add "streamToBuffer" and "convertBase64urlToBase64" functions

### DIFF
--- a/docs/blog/version-2.3-release-notes.md
+++ b/docs/blog/version-2.3-release-notes.md
@@ -68,3 +68,24 @@ This can be useful in case you want to have two `.env` files, one to define the 
 If a variable is defined in both files, the value in the `.env.local` file will take precedence.
 
 Similarly, you can also define environment-specific local files (`.env.development.local`, `.env.production.local`, etc).
+
+## Base 64 and base 64 URL utilities
+
+Two functions are provided to convert base64 encoded strings to base64url encoded strings and vice versa.
+
+```typescript
+import { convertBase64ToBase64url, convertBase64urlToBase64 } from '@foal/core';
+
+const str = convertBase64ToBase64url(base64Str);
+const str2 = convertBase64urlToBase64(base64urlStr);
+```
+
+## Converting Streams to Buffers
+
+In case you need to convert a readable stream to a concatenated buffer during testing, you can now use the `streamToBuffer` function for this.
+
+```typescript
+import { streamToBuffer } from '@foal/core';
+
+const buffer = await streamToBuffer(stream);
+```

--- a/docs/docs/common/conversions.md
+++ b/docs/docs/common/conversions.md
@@ -1,0 +1,45 @@
+---
+title: Conversions
+---
+
+This page lists common functions to convert one type or format to another.
+
+## Base64 to Base64URL
+
+This function converts a base64-encoded string into a base64URL-encoded string. 
+
+It replaces the characters `+` and `/` with `-` and `_` and omits the `=` sign.
+
+```typescript
+import { convertBase64ToBase64url } from '@foal/core';
+
+const foo = convertBase64ToBase64url('bar');
+```
+
+## Base64URL to Base64
+
+> *This feature is available from version 2.3 onwards.*
+
+This function converts a base64URL-encoded string into a base64-encoded string. 
+
+It replaces the characters `-` and `_` with `+` and `/` and adds the `=` padding character(s) if any.
+
+```typescript
+import { convertBase64urlToBase64 } from '@foal/core';
+
+const foo = convertBase64urlToBase64('bar');
+```
+
+## Stream to Buffer
+
+> *This feature is available from version 2.3 onwards.*
+
+This function converts a stream of buffers into a concatenated buffer. It returns a promise.
+
+If the stream emits an error, the promise is rejected with the emitted error.
+
+```typescript
+import { streamToBuffer } from '@foal/core';
+
+const buffer = await streamToBuffer(stream);
+```

--- a/docs/docs/cookbook/base64url.md
+++ b/docs/docs/cookbook/base64url.md
@@ -1,9 +1,0 @@
----
-title: Base 64 URL
----
-
-If you need to convert a base64-encoded string to base64URL, you can use the `convertBase64ToBase64url` function for this. It will replace the characters `+` and `/` by `-` and `_` respectively and omit the `=` sign.
-
-```typescript
-const foo = convertBase64ToBase64url('bar');
-```

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/common/conversions.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/common/conversions.md
@@ -1,0 +1,45 @@
+---
+title: Conversiones
+---
+
+This page lists common functions to convert one type or format to another.
+
+## Base64 to Base64URL
+
+This function converts a base64-encoded string into a base64URL-encoded string. 
+
+It replaces the characters `+` and `/` with `-` and `_` and omits the `=` sign.
+
+```typescript
+import { convertBase64ToBase64url } from '@foal/core';
+
+const foo = convertBase64ToBase64url('bar');
+```
+
+## Base64URL to Base64
+
+> *This feature is available from version 2.3 onwards.*
+
+This function converts a base64URL-encoded string into a base64-encoded string. 
+
+It replaces the characters `-` and `_` with `+` and `/` and adds the `=` padding character(s) if any.
+
+```typescript
+import { convertBase64urlToBase64 } from '@foal/core';
+
+const foo = convertBase64urlToBase64('bar');
+```
+
+## Stream to Buffer
+
+> *This feature is available from version 2.3 onwards.*
+
+This function converts a stream of buffers into a concatenated buffer. It returns a promise.
+
+If the stream emits an error, the promise is rejected with the emitted error.
+
+```typescript
+import { streamToBuffer } from '@foal/core';
+
+const buffer = await streamToBuffer(stream);
+```

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/cookbook/base64url.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/cookbook/base64url.md
@@ -1,9 +1,0 @@
----
-title: Base 64 URL
----
-
-If you need to convert a base64-encoded string to base64URL, you can use the `convertBase64ToBase64url` function for this. It will replace the characters `+` and `/` by `-` and `_` respectively and omit the `=` sign.
-
-```typescript
-const foo = convertBase64ToBase64url('bar');
-```

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/common/conversions.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/common/conversions.md
@@ -1,0 +1,45 @@
+---
+title: Conversions
+---
+
+This page lists common functions to convert one type or format to another.
+
+## Base64 to Base64URL
+
+This function converts a base64-encoded string into a base64URL-encoded string. 
+
+It replaces the characters `+` and `/` with `-` and `_` and omits the `=` sign.
+
+```typescript
+import { convertBase64ToBase64url } from '@foal/core';
+
+const foo = convertBase64ToBase64url('bar');
+```
+
+## Base64URL to Base64
+
+> *This feature is available from version 2.3 onwards.*
+
+This function converts a base64URL-encoded string into a base64-encoded string. 
+
+It replaces the characters `-` and `_` with `+` and `/` and adds the `=` padding character(s) if any.
+
+```typescript
+import { convertBase64urlToBase64 } from '@foal/core';
+
+const foo = convertBase64urlToBase64('bar');
+```
+
+## Stream to Buffer
+
+> *This feature is available from version 2.3 onwards.*
+
+This function converts a stream of buffers into a concatenated buffer. It returns a promise.
+
+If the stream emits an error, the promise is rejected with the emitted error.
+
+```typescript
+import { streamToBuffer } from '@foal/core';
+
+const buffer = await streamToBuffer(stream);
+```

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/cookbook/base64url.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/cookbook/base64url.md
@@ -1,9 +1,0 @@
----
-title: Base 64 URL
----
-
-If you need to convert a base64-encoded string to base64URL, you can use the `convertBase64ToBase64url` function for this. It will replace the characters `+` and `/` by `-` and `_` respectively and omit the `=` sign.
-
-```typescript
-const foo = convertBase64ToBase64url('bar');
-```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -62,6 +62,7 @@ module.exports = {
         'common/templating',
         'common/logging-and-debugging',
         'common/generate-tokens',
+        'common/conversions',
       ]),
       category('Databases', [
         'databases/typeorm',
@@ -121,7 +122,6 @@ module.exports = {
         'cookbook/expressjs',
         'cookbook/root-imports',
         'cookbook/limit-repeated-requests',
-        'cookbook/base64url',
       ]),
       category('Deployment', [
         'deployment-and-environments/checklist',

--- a/packages/aws-s3/src/s3-disk.service.spec.ts
+++ b/packages/aws-s3/src/s3-disk.service.spec.ts
@@ -3,7 +3,7 @@ import { strictEqual } from 'assert';
 import { Readable } from 'stream';
 
 // 3p
-import { Config, ConfigNotFoundError, createService } from '@foal/core';
+import { Config, ConfigNotFoundError, createService, streamToBuffer } from '@foal/core';
 import { FileDoesNotExist } from '@foal/storage';
 import * as S3 from 'aws-sdk/clients/s3';
 
@@ -12,15 +12,6 @@ import { S3Disk } from './s3-disk.service';
 
 // Isolate each job with a different S3 bucket.
 const bucketName = `foal-test-${process.env.NODE_VERSION || 10}`;
-
-function streamToBuffer(stream: Readable): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  return new Promise<Buffer>((resolve, reject) => {
-    stream.on('data', chunk => chunks.push(chunk));
-    stream.on('error', reject);
-    stream.on('end', () => resolve(Buffer.concat(chunks)));
-  });
-}
 
 async function rmObjectsIfExist(s3: S3) {
   const response = await s3.listObjects({

--- a/packages/core/src/common/encoding/convert-base64-to-base64-url.spec.ts
+++ b/packages/core/src/common/encoding/convert-base64-to-base64-url.spec.ts
@@ -6,7 +6,21 @@ import { convertBase64ToBase64url } from './convert-base64-to-base64-url';
 
 describe('convertBase64ToBase64url', () => {
 
-  it('should convert base64-encoded strings to base64url-encoded strings.', () => {
+  it('should convert base64-encoded strings to base64url-encoded strings (no padding character).', () => {
+    const expected = 'hello-hi-_how_arfAbc';
+    const actual = convertBase64ToBase64url('hello+hi+/how/arfAbc');
+
+    strictEqual(actual, expected);
+  });
+
+  it('should convert base64-encoded strings to base64url-encoded strings (one padding character).', () => {
+    const expected = 'hello-hi-_how_arfAb';
+    const actual = convertBase64ToBase64url('hello+hi+/how/arfAb=');
+
+    strictEqual(actual, expected);
+  });
+
+  it('should convert base64-encoded strings to base64url-encoded strings (two padding characters).', () => {
     const expected = 'hello-hi-_how_arfA';
     const actual = convertBase64ToBase64url('hello+hi+/how/arfA==');
 

--- a/packages/core/src/common/encoding/convert-base64-to-base64-url.spec.ts
+++ b/packages/core/src/common/encoding/convert-base64-to-base64-url.spec.ts
@@ -2,12 +2,15 @@
 import { strictEqual } from 'assert';
 
 // FoalTS
-import { convertBase64ToBase64url } from './convert-base64-to-base64-url.util';
+import { convertBase64ToBase64url } from './convert-base64-to-base64-url';
 
 describe('convertBase64ToBase64url', () => {
-  it('should convert base64-encoded strings to base64url-encoded ones.', () => {
+
+  it('should convert base64-encoded strings to base64url-encoded strings.', () => {
     const expected = 'hello-hi-_how_arfA';
     const actual = convertBase64ToBase64url('hello+hi+/how/arfA==');
+
     strictEqual(actual, expected);
   });
+
 });

--- a/packages/core/src/common/encoding/convert-base64-to-base64-url.ts
+++ b/packages/core/src/common/encoding/convert-base64-to-base64-url.ts
@@ -1,9 +1,9 @@
 /**
- * Convert a base64-encode string into a base64url-encode string with no equals.
+ * Converts a base64-encoded string into a base64url-encoded string with no equals.
  *
  * @export
  * @param {string} str The base64-encoded string.
- * @returns {string} The base64url-encode string.
+ * @returns {string} The base64url-encoded string.
  */
 export function convertBase64ToBase64url(str: string): string {
   return str

--- a/packages/core/src/common/encoding/convert-base64-url-to-base64.spec.ts
+++ b/packages/core/src/common/encoding/convert-base64-url-to-base64.spec.ts
@@ -1,0 +1,37 @@
+// std
+import { strictEqual, throws } from 'assert';
+
+// FoalTS
+import { convertBase64urlToBase64 } from './convert-base64-url-to-base64';
+
+describe('convertBase64urlToBase64', () => {
+
+  it('should convert base64url-encoded strings to base64-encoded strings (no padding character).', () => {
+    const expected = 'hello+hi+/how/arfAbc';
+    const actual = convertBase64urlToBase64('hello-hi-_how_arfAbc');
+
+    strictEqual(actual, expected);
+  });
+
+  it('should convert base64url-encoded strings to base64-encoded strings (one padding character).', () => {
+    const expected = 'hello+hi+/how/arfAb=';
+    const actual = convertBase64urlToBase64('hello-hi-_how_arfAb');
+
+    strictEqual(actual, expected);
+  });
+
+  it('should convert base64url-encoded strings to base64-encoded strings (two padding characters).', () => {
+    const expected = 'hello+hi+/how/arfA==';
+    const actual = convertBase64urlToBase64('hello-hi-_how_arfA');
+
+    strictEqual(actual, expected);
+  });
+
+  it('should throw an error if the provided base64url-encoded string has an incorrect length.', () => {
+    throws(
+      () => convertBase64urlToBase64('hello-hi-_how_arf'),
+      new TypeError('The provided base64url-encoded string has an incorrect length.')
+    )
+  })
+
+});

--- a/packages/core/src/common/encoding/convert-base64-url-to-base64.ts
+++ b/packages/core/src/common/encoding/convert-base64-url-to-base64.ts
@@ -1,0 +1,26 @@
+function addPaddingToBase64url(str: string): string {
+  if (str.length % 4 === 1) {
+    throw new TypeError('The provided base64url-encoded string has an incorrect length.');
+  }
+
+  if (str.length % 4 === 2) {
+    return str + '==';
+  }
+  if (str.length % 4 === 3) {
+    return str + '=';
+  }
+  return str;
+}
+
+/**
+ * Converts a base64url-encoded string into a base64-encoded string.
+ *
+ * @export
+ * @param {string} str The base64url-encoded string.
+ * @returns {string} The base64-encoded string.
+ */
+export function convertBase64urlToBase64(str: string): string {
+  return addPaddingToBase64url(str)
+    .replace(/\-/g, '+')
+    .replace(/_/g, '/');
+}

--- a/packages/core/src/common/encoding/index.ts
+++ b/packages/core/src/common/encoding/index.ts
@@ -1,0 +1,1 @@
+export { convertBase64ToBase64url } from './convert-base64-to-base64-url';

--- a/packages/core/src/common/encoding/index.ts
+++ b/packages/core/src/common/encoding/index.ts
@@ -1,1 +1,2 @@
 export { convertBase64ToBase64url } from './convert-base64-to-base64-url';
+export { convertBase64urlToBase64 } from './convert-base64-url-to-base64';

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -1,3 +1,4 @@
+export * from './encoding';
 export * from './hooks';
 export * from './tokens';
 export * from './utils';

--- a/packages/core/src/common/tokens/generate-token.util.ts
+++ b/packages/core/src/common/tokens/generate-token.util.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'crypto';
 import { promisify } from 'util';
 
 // FoalTS
-import { convertBase64ToBase64url } from './convert-base64-to-base64-url.util';
+import { convertBase64ToBase64url } from '../encoding';
 
 /**
  * Generate a 256-bit base64url-encoded token.

--- a/packages/core/src/common/tokens/index.ts
+++ b/packages/core/src/common/tokens/index.ts
@@ -1,4 +1,3 @@
-export { convertBase64ToBase64url } from './convert-base64-to-base64-url.util';
 export { generateSignedToken } from './generate-signed-token.util';
 export { generateToken } from './generate-token.util';
 export { signToken } from './sign-token.util';

--- a/packages/core/src/common/tokens/sign-token.util.ts
+++ b/packages/core/src/common/tokens/sign-token.util.ts
@@ -2,7 +2,7 @@
 import { createHmac } from 'crypto';
 
 // FoalTS
-import { convertBase64ToBase64url } from './convert-base64-to-base64-url.util';
+import { convertBase64ToBase64url } from '../encoding';
 
 export function sign(base64Value: string, base64Secret: string): Buffer {
   return createHmac('sha256', Buffer.from(base64Secret, 'base64'))

--- a/packages/core/src/common/utils/index.ts
+++ b/packages/core/src/common/utils/index.ts
@@ -7,4 +7,5 @@ export { hashPassword } from './hash-password.util';
 export { isInFile } from './is-in-file.util';
 export { renderError } from './render-error.util';
 export { render, renderToString } from './render.util';
+export { streamToBuffer } from './stream-to-buffer';
 export { verifyPassword } from './verify-password.util';

--- a/packages/core/src/common/utils/stream-to-buffer.spec.ts
+++ b/packages/core/src/common/utils/stream-to-buffer.spec.ts
@@ -1,0 +1,36 @@
+// std
+import { deepStrictEqual, rejects } from 'assert';
+import { Readable } from 'stream';
+
+// FoalTS
+import { streamToBuffer } from './stream-to-buffer';
+
+describe('streamToBuffer', () => {
+
+  it('should convert a stream of buffers into a buffer and returns it.', async () => {
+    const stream = new Readable();
+
+    const promise = streamToBuffer(stream);
+
+    stream.push(Buffer.from('hello', 'utf8'));
+    stream.push(Buffer.from(' ', 'utf8'));
+    stream.push(Buffer.from('world', 'utf8'));
+    stream.push(null);
+
+    const expected = Buffer.from('hello world', 'utf8');
+    const actual = await promise;
+
+    deepStrictEqual(actual, expected);
+  });
+
+  it('should rejects an error if the stream emits an error.', async () => {
+    const stream = new Readable();
+
+    const promise = streamToBuffer(stream);
+
+    stream.emit('error', new Error('foobar'));
+
+    await rejects(promise, new Error('foobar'));
+  });
+
+});

--- a/packages/core/src/common/utils/stream-to-buffer.spec.ts
+++ b/packages/core/src/common/utils/stream-to-buffer.spec.ts
@@ -26,6 +26,8 @@ describe('streamToBuffer', () => {
   it('should rejects an error if the stream emits an error.', async () => {
     const stream = new Readable();
 
+    stream.push(null);
+
     const promise = streamToBuffer(stream);
 
     stream.emit('error', new Error('foobar'));

--- a/packages/core/src/common/utils/stream-to-buffer.ts
+++ b/packages/core/src/common/utils/stream-to-buffer.ts
@@ -1,0 +1,15 @@
+/**
+ * Converts a stream of buffers into a buffer.
+ *
+ * @export
+ * @param {NodeJS.ReadableStream} stream - A readable stream.
+ * @returns {Promise<Buffer>} The concatenated buffer
+ */
+export async function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  return await new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+    stream.on('error', reject);
+    stream.on('end', () => resolve(Buffer.concat(chunks)));
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export {
   controller,
   displayServerURL,
   convertBase64ToBase64url,
+  convertBase64urlToBase64,
   escape,
   escapeProp,
   generateSignedToken,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export {
   renderToString,
   renderError,
   signToken,
+  streamToBuffer,
   verifyPassword,
   verifySignedToken,
 } from './common';

--- a/packages/graphiql/src/graphiql.controller.spec.ts
+++ b/packages/graphiql/src/graphiql.controller.spec.ts
@@ -2,23 +2,13 @@
 import { ok, strictEqual } from 'assert';
 import { stat, readFileSync } from 'fs';
 import { promisify } from 'util';
-import { Readable } from 'stream';
 import { join } from 'path';
 
 // 3p
-import { Context, getHttpMethod, getPath, isHttpResponseMovedPermanently, isHttpResponseOK } from '@foal/core';
+import { Context, getHttpMethod, getPath, isHttpResponseMovedPermanently, isHttpResponseOK, streamToBuffer } from '@foal/core';
 
 // FoalTS
 import { GraphiQLController } from './graphiql.controller';
-
-function streamToBuffer(stream: Readable): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  return new Promise<Buffer>((resolve, reject) => {
-    stream.on('data', chunk => chunks.push(chunk));
-    stream.on('error', reject);
-    stream.on('end', () => resolve(Buffer.concat(chunks)));
-  });
-}
 
 describe('GraphiQLController', () => {
 

--- a/packages/jwt/src/jwt.hook.spec.ts
+++ b/packages/jwt/src/jwt.hook.spec.ts
@@ -5,6 +5,8 @@ import { deepStrictEqual, notStrictEqual, rejects, strictEqual } from 'assert';
 import {
   Config,
   Context,
+  convertBase64ToBase64url,
+  convertBase64urlToBase64,
   FetchUser,
   getApiComponents,
   getApiParameters,
@@ -66,13 +68,13 @@ b5VoYLNsdvZhqjVFTrYNEuhTJFYCF7jAiZLYvYm0C99BqcJnJPl7JjWynoNHNKw3
 9f6PIOE1rAmPE8Cfz/GFF5115ZKVlq+2BY8EKNxbCIy2d/vMEvisnXI=
 -----END RSA PRIVATE KEY-----`;
 
-function toBase64(headerOrPayload: string): string {
-  return Buffer.from(headerOrPayload, 'binary').toString('base64').replace(/=/g, '');
+function toBase64Url(headerOrPayload: string): string {
+  return convertBase64ToBase64url(Buffer.from(headerOrPayload, 'binary').toString('base64'));
 }
 
 /* tslint:disable-next-line:no-unused-variable */
-function fromBase64(str: string): string {
-  return Buffer.from(str, 'base64').toString('binary');
+function fromBase64Url(str: string): string {
+  return Buffer.from(convertBase64urlToBase64(str), 'base64').toString('binary');
 }
 
 const payload1 = {
@@ -249,7 +251,7 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
     it('should return an HttpResponseUnauthorized object if the header is invalid'
         + ' (not a base64-encoded string).', async () => {
       const token = '$$$'
-        + '.' + toBase64(JSON.stringify(payload1))
+        + '.' + toBase64Url(JSON.stringify(payload1))
         + '.HMwf4pIs-aI8UG5Rv2dKplZP4XKvwVT5moZGA08mogA';
       ctx = createContext({ Authorization: `Bearer ${token}` });
 
@@ -269,8 +271,8 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
     it('should return an HttpResponseUnauthorized object if the header is invalid'
         + ' (not a representation of a valid JSON object).', async () => {
-      const token = toBase64('{')
-        + '.' + toBase64(JSON.stringify(payload1))
+      const token = toBase64Url('{')
+        + '.' + toBase64Url(JSON.stringify(payload1))
         + '.HMwf4pIs-aI8UG5Rv2dKplZP4XKvwVT5moZGA08mogA';
       ctx = createContext({ Authorization: `Bearer ${token}` });
 
@@ -289,7 +291,7 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
     });
 
     it('should return an HttpResponseUnauthorized object if the payload is invalid.', async () => {
-      const token = toBase64(JSON.stringify(header1))
+      const token = toBase64Url(JSON.stringify(header1))
         + '.eyJz32IiOiIxMjM0NTY3ODkwIiwibmFtZSI6UkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ'
         + '.HMwf4pIs-aI8UG5Rv2dKplZP4XKvwVT5moZGA08mogA';
       ctx = createContext({ Authorization: `Bearer ${token}` });
@@ -350,7 +352,7 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
     it('should return an HttpResponseUnauthorized object if the signature is invalid.', async () => {
       const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
-        + '.' + toBase64(JSON.stringify(payload1))
+        + '.' + toBase64Url(JSON.stringify(payload1))
         + '.HMwf4pIs-aI8UG5Rv2dKplZP4XKvwVT5moeGA08mogA';
       ctx = createContext({ Authorization: `Bearer ${token}` });
 
@@ -387,7 +389,7 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
     it('should return an HttpResponseUnauthorized object if the signature is wrong (different secret).', async () => {
       const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'
-        + '.' + toBase64(JSON.stringify(payload1))
+        + '.' + toBase64Url(JSON.stringify(payload1))
         + '.-I5sDyvGWSA8Qwk6OwM7VLV9Nz3pkINNHakp3S8kOn0';
       ctx = createContext({ Authorization: `Bearer ${token}` });
 

--- a/packages/storage/src/local-disk.service.spec.ts
+++ b/packages/storage/src/local-disk.service.spec.ts
@@ -5,20 +5,11 @@ import { join } from 'path';
 import { Readable } from 'stream';
 
 // 3p
-import { Config, ConfigNotFoundError, createService } from '@foal/core';
+import { Config, ConfigNotFoundError, createService, streamToBuffer } from '@foal/core';
 
 // FoalTS
 import { FileDoesNotExist } from './disk.service';
 import { LocalDisk } from './local-disk.service';
-
-function streamToBuffer(stream: Readable): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  return new Promise<Buffer>((resolve, reject) => {
-    stream.on('data', chunk => chunks.push(chunk));
-    stream.on('error', reject);
-    stream.on('end', () => resolve(Buffer.concat(chunks)));
-  });
-}
 
 function rmDirAndFilesIfExist(path: string) {
   if (!existsSync(path)) {

--- a/packages/storage/src/validate-multipart-form-data-body.hook.ts
+++ b/packages/storage/src/validate-multipart-form-data-body.hook.ts
@@ -12,7 +12,8 @@ import {
   HttpResponseBadRequest,
   IApiRequestBody,
   IApiSchema,
-  ServiceManager
+  ServiceManager,
+  streamToBuffer
 } from '@foal/core';
 import * as Busboy from 'busboy';
 
@@ -27,16 +28,6 @@ export interface MultipartFormDataSchema {
   files: {
     [key: string]: { required: boolean, multiple?: boolean, saveTo?: string }
   };
-}
-
-function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  return new Promise<Buffer>((resolve, reject) => {
-    stream.on('data', chunk => chunks.push(chunk));
-    // TODO: test this line.
-    stream.on('error', reject);
-    stream.on('end', () => resolve(Buffer.concat(chunks)));
-  });
 }
 
 async function convertRejectedPromise(fn: () => Promise<void>, errCallback: () => void): Promise<{ error?: any }> {

--- a/packages/swagger/src/swagger-controller.spec.ts
+++ b/packages/swagger/src/swagger-controller.spec.ts
@@ -2,7 +2,6 @@
 import { deepStrictEqual, ok, strictEqual } from 'assert';
 import { readFileSync, stat } from 'fs';
 import { join } from 'path';
-import { Readable } from 'stream';
 import { promisify } from 'util';
 
 // 3p
@@ -17,20 +16,12 @@ import {
   isHttpResponseOK,
   OpenApi,
   OPENAPI_SERVICE_ID,
-  ServiceManager
+  ServiceManager,
+  streamToBuffer
 } from '@foal/core';
 
 // FoalTS
 import { SwaggerController } from './swagger-controller';
-
-function streamToBuffer(stream: Readable): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  return new Promise<Buffer>((resolve, reject) => {
-    stream.on('data', chunk => chunks.push(chunk));
-    stream.on('error', reject);
-    stream.on('end', () => resolve(Buffer.concat(chunks)));
-  });
-}
 
 describe('SwaggerController', () => {
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

- The conversion utility `convertBase64ToBase64url` has no "reverse equivalent".
- In many parts of the framework (especially in tests), readable streams are converted to buffers. Duplicate code could be avoided here. 

# Solution and steps

- [x] Add `convertBase64urlToBase64`.
- [x] Add `streamToBuffer`.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
