### PR TITLE
AJV $data support #920

### DIFF
--- a/docs/docs/common/validation-and-sanitization.md
+++ b/docs/docs/common/validation-and-sanitization.md
@@ -24,7 +24,7 @@ Here is the list of AJV options that can be overridden with FoalTS configuration
 
 | Ajv option | Configuration key | FoalTS default |
 | --- | --- | --- |
-| $data | `settings.ajv.$data` | true |
+| $data | `settings.ajv.$data` | - |
 | allErrors | `settings.ajv.allErrors` | - |
 | coerceTypes | `settings.ajv.coerceType` | true |
 | nullable | `settings.ajv.nullable` | - |

--- a/docs/docs/common/validation-and-sanitization.md
+++ b/docs/docs/common/validation-and-sanitization.md
@@ -24,11 +24,12 @@ Here is the list of AJV options that can be overridden with FoalTS configuration
 
 | Ajv option | Configuration key | FoalTS default |
 | --- | --- | --- |
+| $data | `settings.ajv.$data` | true |
+| allErrors | `settings.ajv.allErrors` | - |
 | coerceTypes | `settings.ajv.coerceType` | true |
+| nullable | `settings.ajv.nullable` | - |
 | removeAdditional | `settings.ajv.removeAdditional` | true |
 | useDefaults | `settings.ajv.useDefaults` | true |
-| nullable | `settings.ajv.nullable` | - |
-| allErrors | `settings.ajv.allErrors` | - |
 
 *Example*
 <Tabs

--- a/packages/core/src/common/utils/get-ajv-instance.spec.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.spec.ts
@@ -192,8 +192,6 @@ describe('getAjvInstance', () => {
           schemaPath: '#/properties/confirmPassword/const',
         }
       ], 'AJV should should have errors explaining "confirmPassword" didn\'t match the expected value in "password"');
-
-     
     });
 
     it('should throw a ConfigTypeError when the value of `settings.ajv.coerceTypes` has an invalid type.', () => {

--- a/packages/core/src/common/utils/get-ajv-instance.spec.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.spec.ts
@@ -172,10 +172,10 @@ describe('getAjvInstance', () => {
       const data6 = {
         password: 'superSecretPassword',
         confirmPassword: 'superSecretPassword',
-      };      
+      };
       strictEqual(ajv.validate(schema6, data6), true, 'If $data is true in the configuration, and property "confirmPassword" matches "password", AJV should validate the data as valid.');
       strictEqual(ajv.errors, null);
-  
+
       const data7 = {
         password: 'superSecretPassword',
         confirmPassword: 'notEvenCloseToTheSamePassword',

--- a/packages/core/src/common/utils/get-ajv-instance.spec.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.spec.ts
@@ -41,7 +41,7 @@ describe('getAjvInstance', () => {
     strictEqual(data.foo, 3);
   });
 
-  it('should support not $data references.', () => {
+  it('should not support $data references.', () => {
     const schema6 = {
       properties: {
         password: {
@@ -74,7 +74,7 @@ describe('getAjvInstance', () => {
         },
         message:'should be equal to constant',
       }
-    ], 'AJV should should have error data explaining "confirmPassword" didn\'t match the expected value in "password"');
+    ], 'AJV should have error data explaining "confirmPassword" didn\'t match the expected value in "password"');
   });
 
   describe('', () => {
@@ -191,7 +191,7 @@ describe('getAjvInstance', () => {
           },
           schemaPath: '#/properties/confirmPassword/const',
         }
-      ], 'AJV should should have errors explaining "confirmPassword" didn\'t match the expected value in "password"');
+      ], 'AJV should have errors explaining "confirmPassword" didn\'t match the expected value in "password"');
     });
 
     it('should throw a ConfigTypeError when the value of `settings.ajv.coerceTypes` has an invalid type.', () => {

--- a/packages/core/src/common/utils/get-ajv-instance.spec.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.spec.ts
@@ -171,14 +171,14 @@ describe('getAjvInstance', () => {
       };
       const data6 = {
         password: 'superSecretPassword',
-        confirmPassword: 'superSecretPassword'
+        confirmPassword: 'superSecretPassword',
       };      
       strictEqual(ajv.validate(schema6, data6), true, 'If $data is true in the configuration, and property "confirmPassword" matches "password", AJV should validate the data as valid.');
       strictEqual(ajv.errors, null);
   
       const data7 = {
         password: 'superSecretPassword',
-        confirmPassword: 'notEvenCloseToTheSamePassword'
+        confirmPassword: 'notEvenCloseToTheSamePassword',
       };
       strictEqual(ajv.validate(schema6, data7), false, 'If $data is true in the configuration, and property "confirmPassword" does not match "password", AJV should validate the data as invalid.');
       deepStrictEqual(ajv.errors, [
@@ -187,7 +187,7 @@ describe('getAjvInstance', () => {
           keyword: 'const',
           message: 'should be equal to constant',
           params: {
-            allowedValue: 'superSecretPassword'
+            allowedValue: 'superSecretPassword',
           },
           schemaPath: '#/properties/confirmPassword/const'
         }

--- a/packages/core/src/common/utils/get-ajv-instance.spec.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.spec.ts
@@ -61,7 +61,7 @@ describe('getAjvInstance', () => {
       confirmPassword: 'superSecretPassword'
     };
     const ajv = getAjvInstance();
-    strictEqual(ajv.validate(schema, data), true, 'If property 'confirmPassword' matches 'password', AJV should validate the data as valid.');
+    strictEqual(ajv.validate(schema, data), true, 'If property "confirmPassword" matches "password", AJV should validate the data as valid.');
     strictEqual(ajv.errors, null);
 
     const data2 = {
@@ -133,7 +133,7 @@ describe('getAjvInstance', () => {
       const data4 = {
         foo: null
       };
-      strictEqual(ajv.validate(schema, data4), true, 'Property 'foo' should be nullable.');
+      strictEqual(ajv.validate(schema, data4), true, 'Property "foo" should be nullable.');
 
       // allErrors
       const schema5 = {
@@ -197,7 +197,7 @@ describe('getAjvInstance', () => {
           message:'should be equal to constant'
         }
       ],
-      'AJV should should have error data explaining 'confirmPassword' didn\'t match the expected value in 'password''
+      'AJV should should have error data explaining "confirmPassword" didn\'t match the expected value in "password"'
       );
     });
 

--- a/packages/core/src/common/utils/get-ajv-instance.spec.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.spec.ts
@@ -45,13 +45,13 @@ describe('getAjvInstance', () => {
     const schema = {
       properties: {
         password: {
-          type: "string",
+          type: 'string',
         },
         confirmPassword: {
           const: {
-            $data: "1/password",
+            $data: '1/password',
           },
-          type: "string",
+          type: 'string',
         },
       },
       type: 'object',
@@ -61,9 +61,9 @@ describe('getAjvInstance', () => {
       confirmPassword: 'superSecretPassword'
     };
     const ajv = getAjvInstance();
-    strictEqual(ajv.validate(schema, data), true, 'If property "confirmPassword" matches "password", AJV should validate the data as valid.');
+    strictEqual(ajv.validate(schema, data), true, 'If property 'confirmPassword' matches 'password', AJV should validate the data as valid.');
     strictEqual(ajv.errors, null);
-    
+
     const data2 = {
       password: 'superSecretPassword',
       confirmPassword: 'notEvenCloseToTheSamePassword'
@@ -71,22 +71,22 @@ describe('getAjvInstance', () => {
     strictEqual(ajv.validate(schema, data2), false, 'If property "confirmPassword" does not match "password", AJV should validate the data as invalid.');
     deepStrictEqual(ajv.errors, [
       {
-        dataPath: ".confirmPassword",
-        keyword: "const",
-        message: "should be equal to constant",
+        dataPath: '.confirmPassword',
+        keyword: 'const',
+        message: 'should be equal to constant',
         params: {
-          allowedValue: "superSecretPassword"
+          allowedValue: 'superSecretPassword'
         },
-        schemaPath: "#/properties/confirmPassword/const"
+        schemaPath: '#/properties/confirmPassword/const'
       }
     ], 'AJV should should have errors explaining "confirmPassword" didn\'t match the expected value in "password"');
   });
 
 
 
-       
-       
-      
+
+
+
 
   describe('', () => {
 
@@ -133,7 +133,7 @@ describe('getAjvInstance', () => {
       const data4 = {
         foo: null
       };
-      strictEqual(ajv.validate(schema, data4), true, 'Property "foo" should be nullable.');
+      strictEqual(ajv.validate(schema, data4), true, 'Property 'foo' should be nullable.');
 
       // allErrors
       const schema5 = {
@@ -164,17 +164,17 @@ describe('getAjvInstance', () => {
           schemaPath: '#/properties/b/type',
         },
       ]);
-      
+
       const schema6 = {
         properties: {
           password: {
-            type: "string",
+            type: 'string',
           },
           confirmPassword: {
             const: {
-              $data: "1/password",
+              $data: '1/password',
             },
-            type: "string",
+            type: 'string',
           },
         },
         type: 'object',
@@ -182,24 +182,24 @@ describe('getAjvInstance', () => {
       const data6 = {
         password: 'superSecretPassword',
         confirmPassword: 'superSecretPassword'
-      };      
+      };
       strictEqual(ajv.validate(schema6, data6), false, 'If $data is false in the configuration, AJV should not be able to validate using $data references.');
       strictEqual(ajv.errors, [
         {
-          keyword: "const",
-          dataPath: ".confirmPassword",
-          schemaPath: "#/properties/confirmPassword/const",
+          keyword: 'const',
+          dataPath: '.confirmPassword',
+          schemaPath: '#/properties/confirmPassword/const',
           params: {
             allowedValue: {
-              data: "1/password"
+              data: '1/password'
             },
           },
-          message:"should be equal to constant"
+          message:'should be equal to constant'
         }
       ],
-      'AJV should should have error data explaining "confirmPassword" didn\'t match the expected value in "password"'
-      );   
-    });    
+      'AJV should should have error data explaining 'confirmPassword' didn\'t match the expected value in 'password''
+      );
+    });
 
     it('should throw a ConfigTypeError when the value of `settings.ajv.coerceTypes` has an invalid type.', () => {
       Config.set('settings.ajv.coerceTypes', 'hello');

--- a/packages/core/src/common/utils/get-ajv-instance.spec.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.spec.ts
@@ -189,7 +189,7 @@ describe('getAjvInstance', () => {
           params: {
             allowedValue: 'superSecretPassword',
           },
-          schemaPath: '#/properties/confirmPassword/const'
+          schemaPath: '#/properties/confirmPassword/const',
         }
       ], 'AJV should should have errors explaining "confirmPassword" didn\'t match the expected value in "password"');
 

--- a/packages/core/src/common/utils/get-ajv-instance.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.ts
@@ -23,7 +23,7 @@ export const _instanceWrapper: { instance: null|Ajv.Ajv } = {
 export function getAjvInstance(): Ajv.Ajv {
   if (!_instanceWrapper.instance) {
     _instanceWrapper.instance = new Ajv({
-      $data: Config.get('settings.ajv.$data', 'boolean', true),
+      $data: Config.get('settings.ajv.$data', 'boolean'),
       allErrors: Config.get('settings.ajv.allErrors', 'boolean'),
       coerceTypes: Config.get('settings.ajv.coerceTypes', 'boolean', true),
       nullable: Config.get('settings.ajv.nullable', 'boolean'),

--- a/packages/core/src/common/utils/get-ajv-instance.ts
+++ b/packages/core/src/common/utils/get-ajv-instance.ts
@@ -23,6 +23,7 @@ export const _instanceWrapper: { instance: null|Ajv.Ajv } = {
 export function getAjvInstance(): Ajv.Ajv {
   if (!_instanceWrapper.instance) {
     _instanceWrapper.instance = new Ajv({
+      $data: Config.get('settings.ajv.$data', 'boolean', true),
       allErrors: Config.get('settings.ajv.allErrors', 'boolean'),
       coerceTypes: Config.get('settings.ajv.coerceTypes', 'boolean', true),
       nullable: Config.get('settings.ajv.nullable', 'boolean'),


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue
Add support for the AJV $data option to Foal configuration. Resolves #920 

# Solution and steps
- [X] Add `$data` attribute to options passed to AJV initialization in `getAjvInstance`, defaulted to `undefined`
- [X] Updated documentation in "Validation and Sanitization" to list the new configuration property. 
- [X] Added test to `should accept custom configuration from the Config` to test the case where `$data` is `true`. Tested both validation success and failure. 
- [X] Added test to `getAjvInstance` to test the default case where `$data` is `undefined`. 
- [X] Added test to check throwing a `ConfigTypeError` when `settings.ajv.$data` has an invalid type.


# Checklist

- [X] ~~update~~/~~check~~ docs (code comments and docs/ folder).
- [ ] ~~update~~/check tests.
- [ ] Update/check the cli generators.
