### PR TITLE
[CLI] Simplify default create-user script

### DIFF
--- a/docs/docs/authentication-and-access-control/groups-and-permissions.md
+++ b/docs/docs/authentication-and-access-control/groups-and-permissions.md
@@ -216,9 +216,70 @@ The `hasPerm(permissionCodeName: string)` method of the `UserWithPermissions` cl
 
 ### Creating Users with Groups and Permissions with a Shell Script (CLI)
 
-Uncomment the code in the file `src/scripts/create-user.ts`.
+Replace the content of the new created file `src/scripts/create-user.ts` with the following:
+
+```typescript
+// 3p
+import { hashPassword } from '@foal/core';
+import { Group, Permission } from '@foal/typeorm';
+import { createConnection, getConnection, getManager } from 'typeorm';
+
+// App
+import { User } from '../app/entities';
+
+export const schema = {
+  additionalProperties: false,
+  properties: {
+    email: { type: 'string', format: 'email' },
+    groups: { type: 'array', items: { type: 'string' }, uniqueItems: true, default: [] },
+    password: { type: 'string' },
+    userPermissions: { type: 'array', items: { type: 'string' }, uniqueItems: true, default: [] },
+  },
+  required: [ 'email', 'password' ],
+  type: 'object',
+};
+
+export async function main(args) {
+  const user = new User();
+  user.userPermissions = [];
+  user.groups = [];
+  user.email = args.email;
+  user.password = await hashPassword(args.password);
+
+  await createConnection();
+
+  for (const codeName of args.userPermissions as string[]) {
+    const permission = await Permission.findOne({ codeName });
+    if (!permission) {
+      console.log(`No permission with the code name "${codeName}" was found.`);
+      return;
+    }
+    user.userPermissions.push(permission);
+  }
+
+  for (const codeName of args.groups as string[]) {
+    const group = await Group.findOne({ codeName });
+    if (!group) {
+      console.log(`No group with the code name "${codeName}" was found.`);
+      return;
+    }
+    user.groups.push(group);
+  }
+
+  try {
+    console.log(
+      await getManager().save(user)
+    );
+  } catch (error) {
+    console.log(error.message);
+  } finally {
+    await getConnection().close();
+  }
+}
+```
 
 Then you can create a user with their permissions and groups through the command line.
+
 ```sh
 npm run build
 foal run create-user userPermissions="[ \"my-first-perm\" ]" groups="[ \"my-group\" ]"

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/authentication-and-access-control/groups-and-permissions.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/authentication-and-access-control/groups-and-permissions.md
@@ -215,9 +215,70 @@ The `hasPerm(permissionCodeName: string)` method of the `UserWithPermissions` cl
 
 ### Creating Users with Groups and Permissions with a Shell Script (CLI)
 
-Uncomment the code in the file `src/scripts/create-user.ts`.
+Replace the content of the new created file `src/scripts/create-user.ts` with the following:
+
+```typescript
+// 3p
+import { hashPassword } from '@foal/core';
+import { Group, Permission } from '@foal/typeorm';
+import { createConnection, getConnection, getManager } from 'typeorm';
+
+// App
+import { User } from '../app/entities';
+
+export const schema = {
+  additionalProperties: false,
+  properties: {
+    email: { type: 'string', format: 'email' },
+    groups: { type: 'array', items: { type: 'string' }, uniqueItems: true, default: [] },
+    password: { type: 'string' },
+    userPermissions: { type: 'array', items: { type: 'string' }, uniqueItems: true, default: [] },
+  },
+  required: [ 'email', 'password' ],
+  type: 'object',
+};
+
+export async function main(args) {
+  const user = new User();
+  user.userPermissions = [];
+  user.groups = [];
+  user.email = args.email;
+  user.password = await hashPassword(args.password);
+
+  await createConnection();
+
+  for (const codeName of args.userPermissions as string[]) {
+    const permission = await Permission.findOne({ codeName });
+    if (!permission) {
+      console.log(`No permission with the code name "${codeName}" was found.`);
+      return;
+    }
+    user.userPermissions.push(permission);
+  }
+
+  for (const codeName of args.groups as string[]) {
+    const group = await Group.findOne({ codeName });
+    if (!group) {
+      console.log(`No group with the code name "${codeName}" was found.`);
+      return;
+    }
+    user.groups.push(group);
+  }
+
+  try {
+    console.log(
+      await getManager().save(user)
+    );
+  } catch (error) {
+    console.log(error.message);
+  } finally {
+    await getConnection().close();
+  }
+}
+```
 
 Then you can create a user with their permissions and groups through the command line.
+
 ```sh
 npm run build
 foal run create-user userPermissions="[ \"my-first-perm\" ]" groups="[ \"my-group\" ]"

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/authentication-and-access-control/groups-and-permissions.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/authentication-and-access-control/groups-and-permissions.md
@@ -216,9 +216,70 @@ The `hasPerm(permissionCodeName: string)` method of the `UserWithPermissions` cl
 
 ### Creating Users with Groups and Permissions with a Shell Script (CLI)
 
-Uncomment the code in the file `src/scripts/create-user.ts`.
+Replace the content of the new created file `src/scripts/create-user.ts` with the following:
+
+```typescript
+// 3p
+import { hashPassword } from '@foal/core';
+import { Group, Permission } from '@foal/typeorm';
+import { createConnection, getConnection, getManager } from 'typeorm';
+
+// App
+import { User } from '../app/entities';
+
+export const schema = {
+  additionalProperties: false,
+  properties: {
+    email: { type: 'string', format: 'email' },
+    groups: { type: 'array', items: { type: 'string' }, uniqueItems: true, default: [] },
+    password: { type: 'string' },
+    userPermissions: { type: 'array', items: { type: 'string' }, uniqueItems: true, default: [] },
+  },
+  required: [ 'email', 'password' ],
+  type: 'object',
+};
+
+export async function main(args) {
+  const user = new User();
+  user.userPermissions = [];
+  user.groups = [];
+  user.email = args.email;
+  user.password = await hashPassword(args.password);
+
+  await createConnection();
+
+  for (const codeName of args.userPermissions as string[]) {
+    const permission = await Permission.findOne({ codeName });
+    if (!permission) {
+      console.log(`No permission with the code name "${codeName}" was found.`);
+      return;
+    }
+    user.userPermissions.push(permission);
+  }
+
+  for (const codeName of args.groups as string[]) {
+    const group = await Group.findOne({ codeName });
+    if (!group) {
+      console.log(`No group with the code name "${codeName}" was found.`);
+      return;
+    }
+    user.groups.push(group);
+  }
+
+  try {
+    console.log(
+      await getManager().save(user)
+    );
+  } catch (error) {
+    console.log(error.message);
+  } finally {
+    await getConnection().close();
+  }
+}
+```
 
 Then you can create a user with their permissions and groups through the command line.
+
 ```sh
 npm run build
 foal run create-user userPermissions="[ \"my-first-perm\" ]" groups="[ \"my-group\" ]"

--- a/docs/i18n/id/docusaurus-plugin-content-docs/current/authentication-and-access-control/groups-and-permissions.md
+++ b/docs/i18n/id/docusaurus-plugin-content-docs/current/authentication-and-access-control/groups-and-permissions.md
@@ -216,9 +216,70 @@ The `hasPerm(permissionCodeName: string)` method of the `UserWithPermissions` cl
 
 ### Creating Users with Groups and Permissions with a Shell Script (CLI)
 
-Uncomment the code in the file `src/scripts/create-user.ts`.
+Replace the content of the new created file `src/scripts/create-user.ts` with the following:
+
+```typescript
+// 3p
+import { hashPassword } from '@foal/core';
+import { Group, Permission } from '@foal/typeorm';
+import { createConnection, getConnection, getManager } from 'typeorm';
+
+// App
+import { User } from '../app/entities';
+
+export const schema = {
+  additionalProperties: false,
+  properties: {
+    email: { type: 'string', format: 'email' },
+    groups: { type: 'array', items: { type: 'string' }, uniqueItems: true, default: [] },
+    password: { type: 'string' },
+    userPermissions: { type: 'array', items: { type: 'string' }, uniqueItems: true, default: [] },
+  },
+  required: [ 'email', 'password' ],
+  type: 'object',
+};
+
+export async function main(args) {
+  const user = new User();
+  user.userPermissions = [];
+  user.groups = [];
+  user.email = args.email;
+  user.password = await hashPassword(args.password);
+
+  await createConnection();
+
+  for (const codeName of args.userPermissions as string[]) {
+    const permission = await Permission.findOne({ codeName });
+    if (!permission) {
+      console.log(`No permission with the code name "${codeName}" was found.`);
+      return;
+    }
+    user.userPermissions.push(permission);
+  }
+
+  for (const codeName of args.groups as string[]) {
+    const group = await Group.findOne({ codeName });
+    if (!group) {
+      console.log(`No group with the code name "${codeName}" was found.`);
+      return;
+    }
+    user.groups.push(group);
+  }
+
+  try {
+    console.log(
+      await getManager().save(user)
+    );
+  } catch (error) {
+    console.log(error.message);
+  } finally {
+    await getConnection().close();
+  }
+}
+```
 
 Then you can create a user with their permissions and groups through the command line.
+
 ```sh
 npm run build
 foal run create-user userPermissions="[ \"my-first-perm\" ]" groups="[ \"my-group\" ]"

--- a/packages/cli/src/generate/specs/app/src/scripts/create-user.ts
+++ b/packages/cli/src/generate/specs/app/src/scripts/create-user.ts
@@ -1,7 +1,6 @@
 // 3p
-// import { Group, Permission } from '@foal/typeorm';
-// import { isCommon } from '@foal/password';
-import { createConnection, getConnection, getManager } from 'typeorm';
+// import { hashPassword } from '@foal/core';
+import { createConnection } from 'typeorm';
 
 // App
 import { User } from '../app/entities';
@@ -10,52 +9,24 @@ export const schema = {
   additionalProperties: false,
   properties: {
     // email: { type: 'string', format: 'email' },
-    // groups: { type: 'array', items: { type: 'string' }, uniqueItems: true, default: [] },
     // password: { type: 'string' },
-    // userPermissions: { type: 'array', items: { type: 'string' }, uniqueItems: true, default: [] },
   },
   required: [ /* 'email', 'password' */ ],
   type: 'object',
 };
 
 export async function main(/*args*/) {
-  const user = new User();
-  // user.userPermissions = [];
-  // user.groups = [];
-  // user.email = args.email;
-  // if (await isCommon(args.password)) {
-  //   console.log('This password is too common. Please choose another one.');
-  //   return;
-  // }
-  // await user.setPassword(args.password);
-
-  await createConnection();
-
-  // for (const codeName of args.userPermissions as string[]) {
-  //   const permission = await Permission.findOne({ codeName });
-  //   if (!permission) {
-  //     console.log(`No permission with the code name "${codeName}" was found.`);
-  //     return;
-  //   }
-  //   user.userPermissions.push(permission);
-  // }
-
-  // for (const codeName of args.groups as string[]) {
-  //   const group = await Group.findOne({ codeName });
-  //   if (!group) {
-  //     console.log(`No group with the code name "${codeName}" was found.`);
-  //     return;
-  //   }
-  //   user.groups.push(group);
-  // }
+  const connection = await createConnection();
 
   try {
-    console.log(
-      await getManager().save(user)
-    );
+    const user = new User();
+    // user.email = args.email;
+    // user.password = await hashPassword(args.password);
+
+    console.log(await user.save());
   } catch (error) {
     console.log(error.message);
   } finally {
-    await getConnection().close();
+    await connection.close();
   }
 }

--- a/packages/cli/src/generate/templates/app/src/scripts/create-user.ts
+++ b/packages/cli/src/generate/templates/app/src/scripts/create-user.ts
@@ -1,7 +1,6 @@
 // 3p
-// import { Group, Permission } from '@foal/typeorm';
-// import { isCommon } from '@foal/password';
-import { createConnection, getConnection, getManager } from 'typeorm';
+// import { hashPassword } from '@foal/core';
+import { createConnection } from 'typeorm';
 
 // App
 import { User } from '../app/entities';
@@ -10,52 +9,24 @@ export const schema = {
   additionalProperties: false,
   properties: {
     // email: { type: 'string', format: 'email' },
-    // groups: { type: 'array', items: { type: 'string' }, uniqueItems: true, default: [] },
     // password: { type: 'string' },
-    // userPermissions: { type: 'array', items: { type: 'string' }, uniqueItems: true, default: [] },
   },
   required: [ /* 'email', 'password' */ ],
   type: 'object',
 };
 
 export async function main(/*args*/) {
-  const user = new User();
-  // user.userPermissions = [];
-  // user.groups = [];
-  // user.email = args.email;
-  // if (await isCommon(args.password)) {
-  //   console.log('This password is too common. Please choose another one.');
-  //   return;
-  // }
-  // await user.setPassword(args.password);
-
-  await createConnection();
-
-  // for (const codeName of args.userPermissions as string[]) {
-  //   const permission = await Permission.findOne({ codeName });
-  //   if (!permission) {
-  //     console.log(`No permission with the code name "${codeName}" was found.`);
-  //     return;
-  //   }
-  //   user.userPermissions.push(permission);
-  // }
-
-  // for (const codeName of args.groups as string[]) {
-  //   const group = await Group.findOne({ codeName });
-  //   if (!group) {
-  //     console.log(`No group with the code name "${codeName}" was found.`);
-  //     return;
-  //   }
-  //   user.groups.push(group);
-  // }
+  const connection = await createConnection();
 
   try {
-    console.log(
-      await getManager().save(user)
-    );
+    const user = new User();
+    // user.email = args.email;
+    // user.password = await hashPassword(args.password);
+
+    console.log(await user.save());
   } catch (error) {
     console.log(error.message);
   } finally {
-    await getConnection().close();
+    await connection.close();
   }
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

The default `create-user` script generated by `createapp` has a lot of commented code that can be "intimidating" and is eventually not very useful. This PR removes the commented lines about groups and permissions and moves them to the documentation.

# Solution and steps

- [x] Update the template
- [x] Update the *groups & permissions* page.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
