### PR TITLE
fix: connect database before Initializing controllers

### DIFF
--- a/packages/cli/src/generate/templates/app/src/app/app.controller.ts
+++ b/packages/cli/src/generate/templates/app/src/app/app.controller.ts
@@ -1,5 +1,4 @@
 import { controller, IAppController } from '@foal/core';
-import { createConnection } from 'typeorm';
 
 import { ApiController } from './controllers';
 
@@ -7,8 +6,4 @@ export class AppController implements IAppController {
   subControllers = [
     controller('/api', ApiController),
   ];
-
-  async init() {
-    await createConnection();
-  }
 }

--- a/packages/cli/src/generate/templates/app/src/index.ts
+++ b/packages/cli/src/generate/templates/app/src/index.ts
@@ -5,11 +5,13 @@ import * as http from 'http';
 
 // 3p
 import { Config, createApp, displayServerURL } from '@foal/core';
+import { createConnection } from 'typeorm';
 
 // App
 import { AppController } from './app/app.controller';
 
 async function main() {
+  await createConnection();
   const app = await createApp(AppController);
 
   const httpServer = http.createServer(app);


### PR DESCRIPTION
Problem description:
* When using MongoDB (maybe on other databases too), if you try to instance a `Repository` using `getMongoRepository(<Entity>)` in [`boot` or `init` methods](https://foalts.org/docs/architecture/initialization), you'll get a fatal error because the connection is not yet initialized and `boot`/`init` is called too early.

Proposed solution:
* Moving `createConnection()` to `index.ts` file, before creating app in default templates.

Thank you 👍 