### PR TITLE
Add cache option to Disk.createHttpResponse 

### DIFF
--- a/docs/docs/file-system/upload-and-download-files.md
+++ b/docs/docs/file-system/upload-and-download-files.md
@@ -278,6 +278,7 @@ class ApiController {
 | --- | --- | --- |
 | forceDownload | boolean | It indicates whether the response should include the `Content-Disposition: attachment` header. If this is the case, browsers will not attempt to display the returned file (e.g. with the browser's PDF viewer) and will download the file directly. |
 | filename | string | Default name proposed by the browser when saving the file. If it is not specified, FoalTS extracts the name from the path (`foo.jpg` in the example). |
+| cache | string | Value of the `Cache-Control` header (if necessary). |
 
 ## Usage with a Database
 

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/file-system/upload-and-download-files.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/file-system/upload-and-download-files.md
@@ -277,6 +277,7 @@ class ApiController {
 | --- | --- | --- |
 | forceDownload | boolean | It indicates whether the response should include the `Content-Disposition: attachment` header. If this is the case, browsers will not attempt to display the returned file (e.g. with the browser's PDF viewer) and will download the file directly. |
 | filename | string | Default name proposed by the browser when saving the file. If it is not specified, FoalTS extracts the name from the path (`foo.jpg` in the example). |
+| cache | string | Value of the `Cache-Control` header (if necessary). |
 
 ## Usage with a Database
 

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/file-system/upload-and-download-files.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/file-system/upload-and-download-files.md
@@ -278,6 +278,7 @@ class ApiController {
 | --- | --- | --- |
 | forceDownload | boolean | It indicates whether the response should include the `Content-Disposition: attachment` header. If this is the case, browsers will not attempt to display the returned file (e.g. with the browser's PDF viewer) and will download the file directly. |
 | filename | string | Default name proposed by the browser when saving the file. If it is not specified, FoalTS extracts the name from the path (`foo.jpg` in the example). |
+| cache | string | Value of the `Cache-Control` header (if necessary). |
 
 ## Usage with a Database
 

--- a/docs/i18n/id/docusaurus-plugin-content-docs/current/file-system/upload-and-download-files.md
+++ b/docs/i18n/id/docusaurus-plugin-content-docs/current/file-system/upload-and-download-files.md
@@ -278,6 +278,7 @@ class ApiController {
 | --- | --- | --- |
 | forceDownload | boolean | It indicates whether the response should include the `Content-Disposition: attachment` header. If this is the case, browsers will not attempt to display the returned file (e.g. with the browser's PDF viewer) and will download the file directly. |
 | filename | string | Default name proposed by the browser when saving the file. If it is not specified, FoalTS extracts the name from the path (`foo.jpg` in the example). |
+| cache | string | Value of the `Cache-Control` header (if necessary). |
 
 ## Usage with a Database
 

--- a/packages/storage/src/disk.service.spec.ts
+++ b/packages/storage/src/disk.service.spec.ts
@@ -155,6 +155,16 @@ describe('AbstractDisk', () => {
         strictEqual(response.getHeader('Content-Disposition'), 'attachment; filename="download.png"');
       });
 
+      it('should have a correct Cache-Control header based on the "cache" option.', async () => {
+        let response = await disk.createHttpResponse(path);
+        strictEqual(response.getHeader('Cache-Control'), undefined);
+
+        response = await disk.createHttpResponse(path, {
+          cache: 'no-cache'
+        });
+        strictEqual(response.getHeader('Cache-Control'), 'no-cache');
+      });
+
     });
 
   });

--- a/packages/storage/src/disk.service.ts
+++ b/packages/storage/src/disk.service.ts
@@ -135,7 +135,7 @@ export abstract class Disk {
    */
   async createHttpResponse(
     path: string,
-    options: { forceDownload?: boolean, filename?: string } = {}
+    options: { forceDownload?: boolean, filename?: string, cache?: string } = {}
   ): Promise<HttpResponse> {
     const { file, size } = await this.read(path, 'stream');
     const response = new HttpResponseOK(file, { stream: true });
@@ -143,6 +143,10 @@ export abstract class Disk {
     const mimeType = getType(path);
     if (mimeType) {
       response.setHeader('Content-Type', mimeType);
+    }
+
+    if (options.cache) {
+      response.setHeader('Cache-Control', options.cache);
     }
 
     return response


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Resolves #401.

# Solution and steps

- [x] Add cache option to `Disk.createHttpResponse` to manage the `Cache-Control` header.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
