### PR TITLE
Make body generic on HttpResponse

### DIFF
--- a/docs/docs/architecture/controllers.md
+++ b/docs/docs/architecture/controllers.md
@@ -280,6 +280,21 @@ new HttpResponseOK(myStream, { stream: true })
 > new HttpResponseServerError({}, { error, ctx });
 > ```
 
+The type of the `body` may be constrained. This is useful if you wish to guarantee your endpoints return a certain data shape.
+
+*Example with a constrained body type*
+```typescript
+interface Item {
+  title: string
+}
+
+// OK
+new HttpResponseOK<Item>({ title: 'foobar' })
+
+// Error
+new HttpResponseOK<Item>('foobar')
+```
+
 ### Adding Headers
 
 *Example*

--- a/packages/core/src/core/http/http-responses.spec.ts
+++ b/packages/core/src/core/http/http-responses.spec.ts
@@ -115,6 +115,13 @@ describe('HttpResponse', () => {
     notStrictEqual(actual1.my_cookie2.options, actual2.my_cookie2.options);
   });
 
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponse<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number | undefined ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
+  });
+
 });
 
 describe('isHttpResponse', () => {
@@ -159,6 +166,13 @@ describe('isHttpResponseSuccess', () => {
     strictEqual(isHttpResponseSuccess(null), false);
   });
 
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponse<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number | undefined ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
+  });
+
 });
 
 describe('HttpResponseOK', () => {
@@ -190,6 +204,13 @@ describe('HttpResponseOK', () => {
 
     httpResponse = new HttpResponseOK({}, { stream: true });
     strictEqual(httpResponse.stream, true);
+  });
+
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponseOK<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number | undefined ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
   });
 
 });
@@ -245,6 +266,13 @@ describe('HttpResponseCreated', () => {
 
     httpResponse = new HttpResponseCreated({}, { stream: true });
     strictEqual(httpResponse.stream, true);
+  });
+
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponseCreated<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number | undefined ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
   });
 
 });
@@ -407,6 +435,13 @@ describe('HttpResponseRedirect', () => {
     strictEqual(httpResponse.stream, true);
   });
 
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponseRedirect<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number | undefined ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
+  });
+
 });
 
 describe('isHttpResponseRedirect', () => {
@@ -484,6 +519,13 @@ describe('HttpResponseBadRequest', () => {
     strictEqual(httpResponse.stream, true);
   });
 
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponseBadRequest<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number | undefined ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
+  });
+
 });
 
 describe('isHttpResponseBadRequest', () => {
@@ -537,6 +579,13 @@ describe('HttpResponseUnauthorized', () => {
 
     httpResponse = new HttpResponseUnauthorized({}, { stream: true });
     strictEqual(httpResponse.stream, true);
+  });
+
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponseUnauthorized<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number | undefined ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
   });
 
 });
@@ -594,6 +643,13 @@ describe('HttpResponseForbidden', () => {
     strictEqual(httpResponse.stream, true);
   });
 
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponseForbidden<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number | undefined ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
+  });
+
 });
 
 describe('isHttpResponseForbidden', () => {
@@ -647,6 +703,13 @@ describe('HttpResponseNotFound', () => {
 
     httpResponse = new HttpResponseNotFound({}, { stream: true });
     strictEqual(httpResponse.stream, true);
+  });
+
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponseNotFound<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number | undefined ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
   });
 
 });
@@ -704,6 +767,13 @@ describe('HttpResponseMethodNotAllowed', () => {
     strictEqual(httpResponse.stream, true);
   });
 
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponseMethodNotAllowed<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number | undefined ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
+  });
+
 });
 
 describe('isHttpResponseMethodNotAllowed', () => {
@@ -759,6 +829,13 @@ describe('HttpResponseConflict', () => {
     strictEqual(httpResponse.stream, true);
   });
 
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponseConflict<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number | undefined ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
+  });
+
 });
 
 describe('isHttpResponseConflict', () => {
@@ -812,6 +889,13 @@ describe('HttpResponseTooManyRequests', () => {
 
     httpResponse = new HttpResponseTooManyRequests({}, { stream: true });
     strictEqual(httpResponse.stream, true);
+  });
+
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponseTooManyRequests<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number | undefined ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
   });
 
 });
@@ -909,6 +993,13 @@ describe('HttpResponseInternalServerError', () => {
     strictEqual(httpResponse.ctx, ctx);
   });
 
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponseInternalServerError<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number | undefined ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
+  });
+
 });
 
 describe('isHttpResponseInternalServerError', () => {
@@ -962,6 +1053,13 @@ describe('HttpResponseNotImplemented', () => {
 
     httpResponse = new HttpResponseNotImplemented({}, { stream: true });
     strictEqual(httpResponse.stream, true);
+  });
+
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponseNotImplemented<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number | undefined ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
   });
 
 });

--- a/packages/core/src/core/http/http-responses.ts
+++ b/packages/core/src/core/http/http-responses.ts
@@ -27,7 +27,7 @@ export interface CookieOptions {
  * @abstract
  * @class HttpResponse
  */
-export abstract class HttpResponse {
+export abstract class HttpResponse<T = any> {
   /**
    * Property used internally by isHttpResponse.
    *
@@ -68,7 +68,7 @@ export abstract class HttpResponse {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponse
    */
-  constructor(public body?: any, options: { stream?: boolean } = {}) {
+  constructor(public body?: T, options: { stream?: boolean } = {}) {
     this.stream = options.stream || false;
   }
 
@@ -182,7 +182,7 @@ export function isHttpResponse(obj: any): obj is HttpResponse {
  * @class HttpResponseSuccess
  * @extends {HttpResponse}
  */
-export abstract class HttpResponseSuccess extends HttpResponse {
+export abstract class HttpResponseSuccess<T = any> extends HttpResponse<T> {
   /**
    * Property used internally by isHttpResponseSuccess.
    *
@@ -195,7 +195,7 @@ export abstract class HttpResponseSuccess extends HttpResponse {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseSuccess
    */
-  constructor(body?: any, options: { stream?: boolean } = {}) {
+  constructor(body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
   }
 }
@@ -225,7 +225,7 @@ export function isHttpResponseSuccess(obj: any): obj is HttpResponseSuccess {
  * @class HttpResponseOK
  * @extends {HttpResponseSuccess}
  */
-export class HttpResponseOK extends HttpResponseSuccess {
+export class HttpResponseOK<T = any> extends HttpResponseSuccess<T> {
   /**
    * Property used internally by isHttpResponseOK.
    *
@@ -240,7 +240,7 @@ export class HttpResponseOK extends HttpResponseSuccess {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseOK
    */
-  constructor(body?: any, options: { stream?: boolean } = {}) {
+  constructor(body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
   }
 }
@@ -270,7 +270,7 @@ export function isHttpResponseOK(obj: any): obj is HttpResponseOK {
  * @class HttpResponseCreated
  * @extends {HttpResponseSuccess}
  */
-export class HttpResponseCreated extends HttpResponseSuccess {
+export class HttpResponseCreated<T = any> extends HttpResponseSuccess<T> {
   /**
    * Property used internally by isHttpResponseCreated.
    *
@@ -285,7 +285,7 @@ export class HttpResponseCreated extends HttpResponseSuccess {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseCreated
    */
-  constructor(body?: any, options: { stream?: boolean } = {}) {
+  constructor(body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
   }
 }
@@ -362,7 +362,7 @@ export function isHttpResponseNoContent(obj: any): obj is HttpResponseNoContent 
  * @class HttpResponseRedirection
  * @extends {HttpResponse}
  */
-export abstract class HttpResponseRedirection extends HttpResponse {
+export abstract class HttpResponseRedirection<T = any> extends HttpResponse<T> {
   /**
    * Property used internally by isHttpResponseRedirection.
    *
@@ -375,7 +375,7 @@ export abstract class HttpResponseRedirection extends HttpResponse {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseRedirection
    */
-  constructor(body?: any, options: { stream?: boolean } = {}) {
+  constructor(body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
   }
 }
@@ -452,7 +452,7 @@ export function isHttpResponseMovedPermanently(obj: any): obj is HttpResponseMov
  * @class HttpResponseRedirect
  * @extends {HttpResponseRedirection}
  */
-export class HttpResponseRedirect extends HttpResponseRedirection {
+export class HttpResponseRedirect<T = any> extends HttpResponseRedirection<T> {
   /**
    * Property used internally by isHttpResponseRedirect.
    *
@@ -468,7 +468,7 @@ export class HttpResponseRedirect extends HttpResponseRedirection {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseRedirect
    */
-  constructor(public path: string, body?: any, options: { stream?: boolean } = {}) {
+  constructor(public path: string, body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
   }
 }
@@ -501,7 +501,7 @@ export function isHttpResponseRedirect(obj: any): obj is HttpResponseRedirect {
  * @class HttpResponseClientError
  * @extends {HttpResponse}
  */
-export abstract class HttpResponseClientError extends HttpResponse {
+export abstract class HttpResponseClientError<T = any> extends HttpResponse<T> {
   /**
    * Property used internally by isHttpResponseClientError.
    *
@@ -514,7 +514,7 @@ export abstract class HttpResponseClientError extends HttpResponse {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseClientError
    */
-  constructor(body?: any, options: { stream?: boolean } = {}) {
+  constructor(body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
   }
 }
@@ -545,7 +545,7 @@ export function isHttpResponseClientError(obj: any): obj is HttpResponseClientEr
  * @class HttpResponseBadRequest
  * @extends {HttpResponseClientError}
  */
-export class HttpResponseBadRequest extends HttpResponseClientError {
+export class HttpResponseBadRequest<T = any> extends HttpResponseClientError<T> {
   /**
    * Property used internally by isHttpResponseBadRequest.
    *
@@ -560,7 +560,7 @@ export class HttpResponseBadRequest extends HttpResponseClientError {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseBadRequest
    */
-  constructor(body?: any, options: { stream?: boolean } = {}) {
+  constructor(body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
   }
 }
@@ -591,7 +591,7 @@ export function isHttpResponseBadRequest(obj: any): obj is HttpResponseBadReques
  * @class HttpResponseUnauthorized
  * @extends {HttpResponseClientError}
  */
-export class HttpResponseUnauthorized extends HttpResponseClientError {
+export class HttpResponseUnauthorized<T = any> extends HttpResponseClientError<T> {
   /**
    * Property used internally by isHttpResponseUnauthorized.
    *
@@ -606,7 +606,7 @@ export class HttpResponseUnauthorized extends HttpResponseClientError {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseUnauthorized
    */
-  constructor(body?: any, options: { stream?: boolean } = {}) {
+  constructor(body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
     this.setHeader('WWW-Authenticate', '');
   }
@@ -638,7 +638,7 @@ export function isHttpResponseUnauthorized(obj: any): obj is HttpResponseUnautho
  * @class HttpResponseForbidden
  * @extends {HttpResponseClientError}
  */
-export class HttpResponseForbidden extends HttpResponseClientError {
+export class HttpResponseForbidden<T = any> extends HttpResponseClientError<T> {
   /**
    * Property used internally by isHttpResponseForbidden.
    *
@@ -653,7 +653,7 @@ export class HttpResponseForbidden extends HttpResponseClientError {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseForbidden
    */
-  constructor(body?: any, options: { stream?: boolean } = {}) {
+  constructor(body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
   }
 }
@@ -683,7 +683,7 @@ export function isHttpResponseForbidden(obj: any): obj is HttpResponseForbidden 
  * @class HttpResponseNotFound
  * @extends {HttpResponseClientError}
  */
-export class HttpResponseNotFound extends HttpResponseClientError {
+export class HttpResponseNotFound<T = any> extends HttpResponseClientError<T> {
   /**
    * Property used internally by isHttpResponseNotFound.
    *
@@ -698,7 +698,7 @@ export class HttpResponseNotFound extends HttpResponseClientError {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseNotFound
    */
-  constructor(body?: any, options: { stream?: boolean } = {}) {
+  constructor(body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
   }
 }
@@ -728,7 +728,7 @@ export function isHttpResponseNotFound(obj: any): obj is HttpResponseNotFound {
  * @class HttpResponseMethodNotAllowed
  * @extends {HttpResponseClientError}
  */
-export class HttpResponseMethodNotAllowed extends HttpResponseClientError {
+export class HttpResponseMethodNotAllowed<T = any> extends HttpResponseClientError<T> {
   /**
    * Property used internally by isHttpResponseMethodNotAllowed.
    *
@@ -743,7 +743,7 @@ export class HttpResponseMethodNotAllowed extends HttpResponseClientError {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseMethodNotAllowed
    */
-  constructor(body?: any, options: { stream?: boolean } = {}) {
+  constructor(body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
   }
 }
@@ -774,7 +774,7 @@ export function isHttpResponseMethodNotAllowed(obj: any): obj is HttpResponseMet
  * @class HttpResponseConflict
  * @extends {HttpResponseClientError}
  */
-export class HttpResponseConflict extends HttpResponseClientError {
+export class HttpResponseConflict<T = any> extends HttpResponseClientError<T> {
   /**
    * Property used internally by isHttpResponseConflict.
    *
@@ -789,7 +789,7 @@ export class HttpResponseConflict extends HttpResponseClientError {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseConflict
    */
-  constructor(body?: any, options: { stream?: boolean } = {}) {
+  constructor(body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
   }
 }
@@ -819,7 +819,7 @@ export function isHttpResponseConflict(obj: any): obj is HttpResponseConflict {
  * @class HttpResponseTooManyRequests
  * @extends {HttpResponseClientError}
  */
-export class HttpResponseTooManyRequests extends HttpResponseClientError {
+export class HttpResponseTooManyRequests<T = any> extends HttpResponseClientError<T> {
   /**
    * Property used internally by isHttpResponseTooManyRequests.
    *
@@ -834,7 +834,7 @@ export class HttpResponseTooManyRequests extends HttpResponseClientError {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseTooManyRequests
    */
-  constructor(body?: any, options: { stream?: boolean } = {}) {
+  constructor(body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
   }
 }
@@ -868,14 +868,14 @@ export function isHttpResponseTooManyRequests(obj: any): obj is HttpResponseTooM
  * @class HttpResponseServerError
  * @extends {HttpResponse}
  */
-export abstract class HttpResponseServerError extends HttpResponse {
+export abstract class HttpResponseServerError<T = any> extends HttpResponse<T> {
   /**
    * Property used internally by isHttpResponseServerError.
    *
    * @memberof HttpResponseServerError
    */
   readonly isHttpResponseServerError = true;
-  constructor(body?: any, options: { stream?: boolean } = {}) {
+  constructor(body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
   }
 }
@@ -906,7 +906,7 @@ export function isHttpResponseServerError(obj: any): obj is HttpResponseServerEr
  * @class HttpResponseInternalServerError
  * @extends {HttpResponseServerError}
  */
-export class HttpResponseInternalServerError extends HttpResponseServerError {
+export class HttpResponseInternalServerError<T = any> extends HttpResponseServerError<T> {
   /**
    * Property used internally by isHttpResponseInternalServerError.
    *
@@ -923,7 +923,7 @@ export class HttpResponseInternalServerError extends HttpResponseServerError {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseInternalServerError
    */
-  constructor(body?: any, options: { stream?: boolean, error?: Error, ctx?: Context } = {}) {
+  constructor(body?: T, options: { stream?: boolean, error?: Error, ctx?: Context } = {}) {
     super(body, options);
     this.error = options.error;
     this.ctx = options.ctx;
@@ -956,7 +956,7 @@ export function isHttpResponseInternalServerError(obj: any): obj is HttpResponse
  * @class HttpResponseNotImplemented
  * @extends {HttpResponseServerError}
  */
-export class HttpResponseNotImplemented extends HttpResponseServerError {
+export class HttpResponseNotImplemented<T = any> extends HttpResponseServerError<T> {
   /**
    * Property used internally by isHttpResponseNotImplemented.
    *
@@ -971,7 +971,7 @@ export class HttpResponseNotImplemented extends HttpResponseServerError {
    * @param {*} [body] - Optional body of the response.
    * @memberof HttpResponseNotImplemented
    */
-  constructor(body?: any, options: { stream?: boolean } = {}) {
+  constructor(body?: T, options: { stream?: boolean } = {}) {
     super(body, options);
   }
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

I have a monorepo where I am using Foal for the backend and have a different project for the frontend. Since the type of `body` is `any`, I can't make any guarantees around what that data should look like.

```typescript
export class TodosController {
  @Get('/')
  getTodos() {
    return new HttpResponseOK(this.todoService.getTodos())
  }
}
```

and the frontend would have to read it like this:

```typescript
const response = await fetch('/todos')
if (response.ok) {
  // Here I'm just assuming that the backend is returning an array of todos
  const todos: Todo[] = await response.json()
  /*
  Alternatively, an additional validation step would be necessary to be safe:
  const maybeTodos = await response.json()
  if (isTodos(maybeTodos)) {
    return maybeTodos
  }
  */
  return todos
}
```

# Solution and steps

By making the `body` generic, I can have a stronger guarantee about the shape of my data:

```typescript
// Shared
export type TodoResponse = Todo[]

// Backend
export class TodoController {
  @Get('/')
  getTodos(): HttpResponseOK<TodoResponse> {
    return new HttpResponseOK(this.todoService.getTodos())
  }
}

// Frontend
const response = await fetch('/todos')
const todos: TodoResponse = await response.json()
```

This doesn't provide a full guarantee since it's possible to mistype the URL or not bind the return type to the correct response type but it helps.

An additional bonus is it removes the need to creates tests for controllers that verify they return the right kind of data.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
