### PR TITLE
Allow to use FOAL_ENV to define the environment name

### DIFF
--- a/docs/blog/version-2.7-release-notes.md
+++ b/docs/blog/version-2.7-release-notes.md
@@ -53,3 +53,9 @@ src/
    |- log.hook.ts
    '- index.ts
 ```
+
+## Environment name can be provided via `NODE_ENV` or `FOAL_ENV`
+
+Version 2.7 allows to you to specify the environment name (production, development, etc) with the `FOAL_ENV` environment variable.
+
+This can be useful if you have third party libraries whose behavior also depends on the value of `NODE_ENV` (see [Github issue here](https://github.com/FoalTS/foal/issues/1004)).

--- a/docs/docs/architecture/configuration.md
+++ b/docs/docs/architecture/configuration.md
@@ -96,6 +96,8 @@ The *default* configuration files are used regardless of the environment, i.e. r
 
 Configuration values can also be set or overridden for a specific environment using the filename syntax: `config/<environment-name>.{json|yml|js}`. If no value is assigned to `NODE_ENV`, the environment considered is *development*.
 
+> The environment name can be supplied in two ways in Foal: via the `NODE_ENV` environment variable or via `FOAL_ENV`. If both of these variables are set, then the value of `FOAL_ENV` is used by the configuration system.
+
 ### Reserved Parameters
 
 All parameters under the keyword `settings` are reserved for the operation of the framework. You can assign values to those given in the documentation, but you cannot create new ones.

--- a/docs/docs/architecture/configuration.md
+++ b/docs/docs/architecture/configuration.md
@@ -96,7 +96,7 @@ The *default* configuration files are used regardless of the environment, i.e. r
 
 Configuration values can also be set or overridden for a specific environment using the filename syntax: `config/<environment-name>.{json|yml|js}`. If no value is assigned to `NODE_ENV`, the environment considered is *development*.
 
-> The environment name can be supplied in two ways in Foal: via the `NODE_ENV` environment variable or via `FOAL_ENV`. If both of these variables are set, then the value of `FOAL_ENV` is used by the configuration system.
+> The environment name can be provided in two ways in Foal: via the `NODE_ENV` environment variable or via `FOAL_ENV`. If both of these variables are set, then the value of `FOAL_ENV` is used by the configuration system.
 
 ### Reserved Parameters
 

--- a/docs/docs/deployment-and-environments/checklist.md
+++ b/docs/docs/deployment-and-environments/checklist.md
@@ -6,7 +6,7 @@ sidebar_label: Checklist
 
 ## Set the Node.JS environment to `production`
 
-Set the `NODE_ENV` environment variable to `production`.
+Set the `NODE_ENV` (or `FOAL_ENV`) environment variable to `production`.
 
 ```bash
 NODE_ENV=production npm run start

--- a/packages/core/src/core/config/config.spec.ts
+++ b/packages/core/src/core/config/config.spec.ts
@@ -61,6 +61,7 @@ describe('Config', () => {
   });
 
   afterEach(() => {
+    delete process.env.FOAL_ENV;
     delete process.env.NODE_ENV;
     delete process.env.FOO_BAR;
 
@@ -107,11 +108,11 @@ describe('Config', () => {
 
     });
 
-    function testConfigFile(path: string, fileContent: string, nodeEnv?: string): void {
+    function testConfigFile(path: string, fileContent: string, nodeEnv?: string, nodeEnvName = 'NODE_ENV'): void {
       beforeEach(() => {
         writeFileSync(path, fileContent, 'utf8');
         if (nodeEnv) {
-          process.env.NODE_ENV = nodeEnv;
+          process.env[nodeEnvName] = nodeEnv;
         }
       });
 
@@ -129,27 +130,39 @@ describe('Config', () => {
       });
     }
 
+    context('given FOAL_ENV is defined and config/${FOAL_ENV}.json exists', () => {
+      testConfigFile('config/test.json', json, 'test', 'FOAL_ENV');
+    });
+
     context('given NODE_ENV is defined and config/${NODE_ENV}.json exists', () => {
       testConfigFile('config/test.json', json, 'test');
     });
 
-    context('given NODE_ENV is not defined and config/development.json exists', () => {
+    context('given NODE_ENV and FOAL_ENV are not defined and config/development.json exists', () => {
       testConfigFile('config/development.json', json);
+    });
+
+    context('given FOAL_ENV is defined and config/${FOAL_ENV}.yml exists', () => {
+      testConfigFile('config/test.yml', yaml, 'test', 'FOAL_ENV');
     });
 
     context('given NODE_ENV is defined and config/${NODE_ENV}.yml exists', () => {
       testConfigFile('config/test.yml', yaml, 'test');
     });
 
-    context('given NODE_ENV is not defined and config/development.yml exists', () => {
+    context('given NODE_ENV and FOAL_ENV not defined and config/development.yml exists', () => {
       testConfigFile('config/development.yml', yaml);
+    });
+
+    context('given FOAL_ENV is defined and config/${FOAL_ENV}.js exists', () => {
+      testConfigFile('config/test.js', js, 'test', 'FOAL_ENV');
     });
 
     context('given NODE_ENV is defined and config/${NODE_ENV}.js exists', () => {
       testConfigFile('config/test.js', js, 'test');
     });
 
-    context('given NODE_ENV is not defined and config/development.js exists', () => {
+    context('given NODE_ENV and FOAL_ENV not defined and config/development.js exists', () => {
       testConfigFile('config/development.js', js);
     });
 

--- a/packages/core/src/core/config/config.ts
+++ b/packages/core/src/core/config/config.ts
@@ -184,9 +184,9 @@ export class Config {
         this.readJS('config/default.js'),
         this.readYAML('config/default.yml'),
         this.readJSON('config/default.json'),
-        this.readJS(`config/${process.env.NODE_ENV || 'development'}.js`),
-        this.readYAML(`config/${process.env.NODE_ENV || 'development'}.yml`),
-        this.readJSON(`config/${process.env.NODE_ENV || 'development'}.json`),
+        this.readJS(`config/${Env.getEnvironmentName()}.js`),
+        this.readYAML(`config/${Env.getEnvironmentName()}.yml`),
+        this.readJSON(`config/${Env.getEnvironmentName()}.json`),
       ].reduce((config1, config2) => this.mergeDeep(config1, config2));
     }
 

--- a/packages/core/src/core/config/env.spec.ts
+++ b/packages/core/src/core/config/env.spec.ts
@@ -33,6 +33,34 @@ const dotEnvContent4 = `FOO_BAR_FOUR=four`;
 
 describe('Env', () => {
 
+  describe('has a static "getEnvironmentName" that', () => {
+
+    afterEach(() => {
+      delete process.env.FOAL_ENV;
+      delete process.env.NODE_ENV;
+    });
+
+    it('should return the value of process.env.FOAL_ENV if it exists.', () => {
+      process.env.FOAL_ENV = 'foobar';
+      strictEqual(Env.getEnvironmentName(), 'foobar');
+    });
+
+    it('should return the value of process.env.NODE_ENV if it exists.', () => {
+      process.env.NODE_ENV = 'barfoo';
+      strictEqual(Env.getEnvironmentName(), 'barfoo');
+    });
+
+    it('should return the value "development" if process.env.FOAL_ENV and process.env.NODE_ENV are not defined.', () => {
+      strictEqual(Env.getEnvironmentName(), 'development');
+    });
+
+    it('should return the value of process.env.FOAL_ENV if both FOAL_ENV and NODE_ENV are defined.', () => {
+      process.env.FOAL_ENV = 'foobar';
+      process.env.NODE_ENV = 'barfoo';
+      strictEqual(Env.getEnvironmentName(), 'foobar');
+    });
+  })
+
   describe('has a static "get" method that', () => {
 
     beforeEach(() => Env.clearCache());

--- a/packages/core/src/core/config/env.spec.ts
+++ b/packages/core/src/core/config/env.spec.ts
@@ -79,17 +79,17 @@ describe('Env', () => {
 
     });
 
-    function testConfigFile(filename: string, nodeEnv?: string): void {
+    function testConfigFile(filename: string, nodeEnv?: string, nodeEnvName = 'NODE_ENV'): void {
       beforeEach(() => {
         writeFileSync(filename, dotEnvContent, 'utf8');
         if (nodeEnv) {
-          process.env.NODE_ENV = nodeEnv;
+          process.env[nodeEnvName] = nodeEnv;
         }
       });
 
       afterEach(() => {
         removeFile(filename);
-        delete process.env.NODE_ENV;
+        delete process.env[nodeEnvName];
       });
 
       context('and given a variable exists with the given name', () => {
@@ -137,11 +137,19 @@ describe('Env', () => {
       testConfigFile('.env.test.local', 'test');
     });
 
-    context('given NODE_ENV is not defined and .env.development exists', () => {
+    context('given FOAL_ENV is defined and .env.${FOAL_ENV} exists', () => {
+      testConfigFile('.env.test', 'test', 'FOAL_ENV');
+    });
+
+    context('given FOAL_ENV is defined and .env.${FOAL_ENV}.local exists', () => {
+      testConfigFile('.env.test.local', 'test', 'FOAL_ENV');
+    });
+
+    context('given NODE_ENV and FOAL_ENV are not defined and .env.development exists', () => {
       testConfigFile('.env.development');
     });
 
-    context('given NODE_ENV is not defined and .env.development.local exists', () => {
+    context('given NODE_ENV and FOAL_ENV are not defined and .env.development.local exists', () => {
       testConfigFile('.env.development.local');
     });
 

--- a/packages/core/src/core/config/env.ts
+++ b/packages/core/src/core/config/env.ts
@@ -11,6 +11,10 @@ export class Env {
     this.dotEnv = null;
   }
 
+  static getEnvironmentName(): string {
+    return process.env.FOAL_ENV || process.env.NODE_ENV || 'development';
+  }
+
   static get(key: string): string|undefined {
     if (this.dotEnv === null) {
       this.dotEnv = {};

--- a/packages/core/src/core/config/env.ts
+++ b/packages/core/src/core/config/env.ts
@@ -20,8 +20,8 @@ export class Env {
       this.dotEnv = {};
       this.loadEnv('.env');
       this.loadEnv('.env.local');
-      this.loadEnv(`.env.${process.env.NODE_ENV || 'development'}`);
-      this.loadEnv(`.env.${process.env.NODE_ENV || 'development'}.local`);
+      this.loadEnv(`.env.${this.getEnvironmentName()}`);
+      this.loadEnv(`.env.${this.getEnvironmentName()}.local`);
     }
 
     if (this.dotEnv[key] !== undefined) {


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Resolves #1004 

# Solution and steps

- [x] Add utility to "compute" the environment name based on precedence (`FOAL_ENV` has higher precedence over `NODE_ENV`).
- [x] Use this utility in `Env`.
- [x] Use this utility in `Config`.
- [x] Update docs.
- [x] Add the feature in the release notes.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
