### PR TITLE
Update redis-store.service.ts

### DIFF
--- a/packages/redis/src/redis-store.service.ts
+++ b/packages/redis/src/redis-store.service.ts
@@ -17,10 +17,14 @@ export class RedisStore extends SessionStore {
     this.redisClient = createClient(redisURI);
   }
 
+  getRedisClient() {
+    return this.redisClient;
+  }
+
   save(state: SessionState, maxInactivity: number): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       const payload = JSON.stringify(state);
-      this.redisClient.set(`sessions:${state.id}`, payload, 'NX', 'EX', maxInactivity, (err: any, val: string|null) => {
+      this.redisClient.set(`sessions:${state.id}`, payload, 'NX', 'EX', maxInactivity, (err: any, val: string | null) => {
         // TODO: test this line.
         if (err) {
           return reject(err);
@@ -35,7 +39,7 @@ export class RedisStore extends SessionStore {
 
   read(id: string): Promise<SessionState | null> {
     return new Promise<SessionState | null>((resolve, reject) => {
-      this.redisClient.get(`sessions:${id}`, async (err: any, val: string|null) => {
+      this.redisClient.get(`sessions:${id}`, async (err: any, val: string | null) => {
         // TODO: test this line.
         if (err) {
           return reject(err);
@@ -86,7 +90,7 @@ export class RedisStore extends SessionStore {
     });
   }
 
-  async cleanUpExpiredSessions(): Promise<void> {}
+  async cleanUpExpiredSessions(): Promise<void> { }
 
   /**
    * Closes the connection to the database.


### PR DESCRIPTION
# Issue
I'm having an issue with the Redis Store. I was exploring the source code of Foal.

The thing is: the Redis Client is a private field of RedisStore (wich it's ok). But... I'm using Azure Cache for Redis (Basic version), and sometimes (very often) the connection is interrupted.

The known solution for the interruptions, is to catch the redisClient errors, allowing the client to do the reconnection (instead of closing the app).

In order to do that, I need the possibility to access to the redisClient field.

Is there any chance to add a public getter for the redis client, in RedisStore?

In order to access to that getter, the people should cast the SessionStore to RedisStore.

# Solution and steps

# Checklist

I think that my small change doesn't apply to the checklist.

- [ ] Add/update/check docs (code comments and docs/ folder). 
- [ ] Add/update/check tests.
- [ ] Update/check the cli generators.
