### PR TITLE
Color js Bug Fix

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "ajv": "~6.12.0",
     "cli-spinner": "~0.2.10",
-    "colors": "~1.4.0",
+    "colors": "1.4.0",
     "commander": "~7.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/Marak/colors.js/issues/285

Lock the version to 1.4.0 to prevent installing the breaking version