### PR TITLE
Allow to pass a custom client/connection to redis, MongoDB and TypeORM stores.

### DIFF
--- a/docs/docs/authentication-and-access-control/session-tokens.md
+++ b/docs/docs/authentication-and-access-control/session-tokens.md
@@ -1041,3 +1041,92 @@ The `@UseSessions` hook automatically saves the session state on each request. I
 ```typescript
 await session.commit();
 ```
+
+### Provide Another Client to Use in the Stores
+
+By default, the `MongoDBStore` and `RedisStore` create a new client to connect to their respective databases. The `TypeORMStore` uses the default TypeORM connection.
+
+This behavior can be overridden by providing a custom client to the stores at initialization.
+
+#### `TypeORMStore`
+
+*First example*
+```typescript
+export class AppController {
+  @dependency
+  store: TypeORMStore;
+
+  // ...
+
+  async init() {
+    const connection = await createConnection('connection2');
+    this.store.setConnection(connection);
+  }
+}
+```
+
+*Second example*
+
+```typescript
+async function main() {
+  const connection = await createConnection('connection2');
+
+  const services = new ServiceManager();
+  services.get(TypeORMStore).setConnection(connection);
+
+  const app = await createApp(AppController, { serviceManager });
+
+  // ...
+}
+```
+
+#### `RedisStore`
+
+```
+npm install redis@3
+```
+
+*index.ts*
+```typescript
+import { createApp, ServiceManager } from '@foal/core';
+import { RedisStore } from '@foal/redis';
+import { createClient } from 'redis';
+
+async function main() {
+  const redisClient = createClient('redis://localhost:6379');
+
+  const services = new ServiceManager();
+  services.get(RedisStore).setRedisClient(redisClient);
+
+  const app = await createApp(AppController, { serviceManager });
+
+  // ...
+}
+```
+
+#### `MongoDBStore`
+
+```
+npm install mongodb@3
+```
+
+*index.ts*
+```typescript
+import { createApp, ServiceManager } from '@foal/core';
+import { RedisStore } from '@foal/mongodb';
+import { MongoDBStore } from 'mongodb';
+
+async function main() {
+  const mongoDBClient = await MongoClient.connect('mongodb://localhost:27017/db', {
+    useNewUrlParser: true,
+    useUnifiedTopology: true
+  });
+
+  const services = new ServiceManager();
+  services.get(MongoDBStore).setMongoDBClient(mongoDBClient);
+
+  const app = await createApp(AppController, { serviceManager });
+
+  // ...
+}
+```

--- a/docs/docs/authentication-and-access-control/session-tokens.md
+++ b/docs/docs/authentication-and-access-control/session-tokens.md
@@ -1042,7 +1042,7 @@ The `@UseSessions` hook automatically saves the session state on each request. I
 await session.commit();
 ```
 
-### Provide Another Client to Use in the Stores
+### Provide A Custom Client to Use in the Stores
 
 By default, the `MongoDBStore` and `RedisStore` create a new client to connect to their respective databases. The `TypeORMStore` uses the default TypeORM connection.
 
@@ -1052,6 +1052,10 @@ This behavior can be overridden by providing a custom client to the stores at in
 
 *First example*
 ```typescript
+import { dependency } from '@foal/core';
+import { TypeORMStore } from '@foal/typeorm';
+import { createConnection } from 'typeorm';
+
 export class AppController {
   @dependency
   store: TypeORMStore;
@@ -1068,11 +1072,15 @@ export class AppController {
 *Second example*
 
 ```typescript
+import { createApp, ServiceManager } from '@foal/core';
+import { TypeORMStore } from '@foal/typeorm';
+import { createConnection } from 'typeorm';
+
 async function main() {
   const connection = await createConnection('connection2');
 
-  const services = new ServiceManager();
-  services.get(TypeORMStore).setConnection(connection);
+  const serviceManager = new ServiceManager();
+  serviceManager.get(TypeORMStore).setConnection(connection);
 
   const app = await createApp(AppController, { serviceManager });
 
@@ -1095,8 +1103,8 @@ import { createClient } from 'redis';
 async function main() {
   const redisClient = createClient('redis://localhost:6379');
 
-  const services = new ServiceManager();
-  services.get(RedisStore).setRedisClient(redisClient);
+  const serviceManager = new ServiceManager();
+  serviceManager.get(RedisStore).setRedisClient(redisClient);
 
   const app = await createApp(AppController, { serviceManager });
 
@@ -1113,8 +1121,8 @@ npm install mongodb@3
 *index.ts*
 ```typescript
 import { createApp, ServiceManager } from '@foal/core';
-import { RedisStore } from '@foal/mongodb';
-import { MongoDBStore } from 'mongodb';
+import { MongoDBStore } from '@foal/mongodb';
+import { MongoClient } from 'mongodb';
 
 async function main() {
   const mongoDBClient = await MongoClient.connect('mongodb://localhost:27017/db', {
@@ -1122,8 +1130,8 @@ async function main() {
     useUnifiedTopology: true
   });
 
-  const services = new ServiceManager();
-  services.get(MongoDBStore).setMongoDBClient(mongoDBClient);
+  const serviceManager = new ServiceManager();
+  serviceManager.get(MongoDBStore).setMongoDBClient(mongoDBClient);
 
   const app = await createApp(AppController, { serviceManager });
 

--- a/packages/acceptance-tests/src/common/create-test-connection.ts
+++ b/packages/acceptance-tests/src/common/create-test-connection.ts
@@ -4,12 +4,13 @@ import { Connection, createConnection } from '@foal/typeorm/node_modules/typeorm
 // FoalTS
 import { Class } from '@foal/core';
 
-export function createTestConnection(entities: Class[]): Promise<Connection> {
+export function createTestConnection(entities: Class[], name?: string): Promise<Connection> {
   return createConnection({
     database: 'e2e_db.sqlite',
     dropSchema: true,
     entities,
     synchronize: true,
     type: 'better-sqlite3',
+    name
   });
 }

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/providing-a-custom-client-to-use-in-stores.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/providing-a-custom-client-to-use-in-stores.feature.ts
@@ -1,0 +1,197 @@
+// std
+import { } from 'assert';
+
+// 3p
+import * as request from 'supertest';
+import { createClient } from 'redis';
+import { getConnection } from '@foal/typeorm/node_modules/typeorm';
+import { MongoClient } from 'mongodb';
+
+// FoalTS
+import { createApp, createSession, dependency, Get, HttpResponseInternalServerError, HttpResponseOK, ServiceManager } from '@foal/core';
+import { RedisStore } from '@foal/redis';
+import { DatabaseSession, TypeORMStore } from '@foal/typeorm';
+import { MongoDBStore } from '@foal/mongodb';
+import { createTestConnection } from '../../../common';
+
+describe('Feature: Providing a Custom Client to Use in the Stores', () => {
+
+  const typeOrmConnectionName = 'connection2';
+
+  afterEach(async () => {
+    const connection = getConnection(typeOrmConnectionName);
+    if (connection.isConnected) {
+      await connection.close();
+    }
+  })
+
+  it('Example: TypeORMStore (in the "init" method).', async () => {
+
+    class AppController {
+      @dependency
+      store: TypeORMStore;
+
+      @Get('/')
+      async index() {
+        const session = await createSession(this.store);
+        // Should not throw.
+        await session.commit();
+        return new HttpResponseOK();
+      }
+    }
+
+    /* ======================= DOCUMENTATION BEGIN ======================= */
+
+    async function main() {
+      const connection = await createTestConnection([ DatabaseSession ], typeOrmConnectionName);
+
+      const serviceManager = new ServiceManager();
+      serviceManager.get(TypeORMStore).setConnection(connection);
+
+      const app = await createApp(AppController, { serviceManager });
+
+      return app;
+    }
+
+    /* ======================= DOCUMENTATION END ========================= */
+
+    const app = await main();
+
+    return request(app)
+      .get('/')
+      .expect(200);
+  });
+
+  it('Example: TypeORMStore (in the "main" function).', async () => {
+
+    /* ======================= DOCUMENTATION BEGIN ======================= */
+
+    class AppController {
+      @dependency
+      store: TypeORMStore;
+
+      /* ======================= DOCUMENTATION END ========================= */
+      @Get('/')
+      async index() {
+        const session = await createSession(this.store);
+        // Should not throw.
+        await session.commit();
+        return new HttpResponseOK();
+      }
+      /* ======================= DOCUMENTATION BEGIN ======================= */
+
+      async init() {
+        const connection = await createTestConnection([ DatabaseSession ], 'connection2');
+        this.store.setConnection(connection);
+      }
+    }
+
+    /* ======================= DOCUMENTATION END ========================= */
+
+    const app = await createApp(AppController);
+
+    return request(app)
+      .get('/')
+      .expect(200);
+  });
+
+  it('Example: RedisStore.', async () => {
+
+    let redisClient: ReturnType<typeof createClient>;
+
+    class AppController {
+      @dependency
+      store: RedisStore;
+
+      @Get('/')
+      async index() {
+        const session = await createSession(this.store);
+        try {
+          await session.commit();
+        } catch (error: any) {
+          // Should throw because the connection has already been closed.
+          if (error.name === 'AbortError') {
+            return new HttpResponseOK();
+          }
+          throw error;
+        }
+        return new HttpResponseInternalServerError();
+      }
+    }
+
+    /* ======================= DOCUMENTATION BEGIN ======================= */
+
+    async function main() {
+      redisClient = createClient('redis://localhost:6379');
+
+      const serviceManager = new ServiceManager();
+      serviceManager.get(RedisStore).setRedisClient(redisClient);
+
+      const app = await createApp(AppController, { serviceManager });
+
+      return app;
+    }
+
+    /* ======================= DOCUMENTATION END ========================= */
+
+    const app = await main();
+
+    await new Promise(resolve => redisClient!.quit(resolve));
+
+    return request(app)
+      .get('/')
+      .expect(200);
+  });
+
+  it('Example: MongoDBStore.', async () => {
+
+    let mongoDBClient: MongoClient;
+
+    class AppController {
+      @dependency
+      store: MongoDBStore;
+
+      @Get('/')
+      async index() {
+        const session = await createSession(this.store);
+        try {
+          await session.commit();
+        } catch (error: any) {
+          // Should throw because the connection has already been closed.
+          if (error.name === 'MongoError') {
+            return new HttpResponseOK();
+          }
+          throw error;
+        }
+        return new HttpResponseInternalServerError();
+      }
+    }
+
+    /* ======================= DOCUMENTATION BEGIN ======================= */
+
+    async function main() {
+      mongoDBClient = await MongoClient.connect('mongodb://localhost:27017/db', {
+        useNewUrlParser: true,
+        useUnifiedTopology: true
+      });
+
+      const serviceManager = new ServiceManager();
+      serviceManager.get(MongoDBStore).setMongoDBClient(mongoDBClient);
+
+      const app = await createApp(AppController, { serviceManager });
+
+      return app;
+    }
+
+    /* ======================= DOCUMENTATION END ========================= */
+
+    const app = await main();
+
+    await mongoDBClient!.close();
+
+    return request(app)
+      .get('/')
+      .expect(200);
+  });
+
+});

--- a/packages/mongodb/src/mongodb-store.service.spec.ts
+++ b/packages/mongodb/src/mongodb-store.service.spec.ts
@@ -75,6 +75,11 @@ describe('MongoDBStore', () => {
 
         store.setMongoDBClient(mongoDBClient);
 
+        if ((await mongoDBClient.db().collections()).length === 0) {
+          // This line is required in order to use the method "indexInformation()".
+          await mongoDBClient.db().createCollection('sessions');
+        }
+
         let indexInformation = await mongoDBClient.db().collection(COLLECTION_NAME).indexInformation();
         strictEqual(Object.keys(indexInformation).some(key => indexInformation[key][0][0] === 'sessionID'), false);
 

--- a/packages/mongodb/src/mongodb-store.service.spec.ts
+++ b/packages/mongodb/src/mongodb-store.service.spec.ts
@@ -90,6 +90,10 @@ describe('MongoDBStore', () => {
 
   describe('when the service has been initialized', () => {
 
+    let state: SessionState;
+    let state2: SessionState;
+    let maxInactivity: number;
+
     function createState(): SessionState {
       return {
         content: {
@@ -104,10 +108,6 @@ describe('MongoDBStore', () => {
         userId: null,
       };
     }
-
-    let state: SessionState;
-    let state2: SessionState;
-    let maxInactivity: number;
 
     before(async () => {
       mongoDBClient = await MongoClient.connect(MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true });

--- a/packages/mongodb/src/mongodb-store.service.spec.ts
+++ b/packages/mongodb/src/mongodb-store.service.spec.ts
@@ -31,142 +31,322 @@ describe('MongoDBStore', () => {
   let state2: SessionState;
   let maxInactivity: number;
 
-  function createState(): SessionState {
-    return {
-      content: {
-        foo: 'bar'
-      },
-      createdAt: 0,
-      flash: {
-        hello: 'world'
-      },
-      id: 'xxx',
-      updatedAt: 0,
-      userId: null,
-    };
-  }
+  before(() => Config.set('settings.mongodb.uri', MONGODB_URI));
 
-  before(async () => {
-    Config.set('settings.mongodb.uri', MONGODB_URI);
-
-    mongoDBClient = await MongoClient.connect(MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true });
-    try {
-      await mongoDBClient.db().collection(COLLECTION_NAME).dropIndexes();
-    } catch (error) {
-      if (!(error.message.includes('ns not found'))) {
-        throw error;
-      }
-    }
-    store = createService(MongoDBStore);
-    await store.boot();
-  });
-
-  beforeEach(async () => {
-    state = createState();
-    state2 = {
-      ...createState(),
-      id: `${state.id}2`
-    };
-    maxInactivity = 1000;
-    await mongoDBClient.db().collection(COLLECTION_NAME).deleteMany({});
-  });
-
-  after(() => {
-    Config.remove('settings.mongodb.uri');
-
-    return Promise.all([
-      mongoDBClient.close(),
-      store.close(),
-    ]);
-  });
-
-  async function insertSessionIntoDB(session: DatabaseSession): Promise<DatabaseSession> {
-    await mongoDBClient.db().collection(COLLECTION_NAME).insertOne(session);
-    return session;
-  }
-
-  async function readSessionsFromDB(): Promise<DatabaseSession[]> {
-    return mongoDBClient.db().collection(COLLECTION_NAME).find({}).toArray();
-  }
-
-  async function findByID(sessionID: string): Promise<DatabaseSession> {
-    const session = await mongoDBClient.db().collection(COLLECTION_NAME).findOne({ sessionID });
-    if (!session) {
-      throw new Error('Session not found');
-    }
-    return session;
-  }
-
-  it('should support sessions IDs of length 44.', async () => {
-    const session = await createSession({} as any);
-    const id = session.getToken();
-    await insertSessionIntoDB({
-      sessionID: id,
-      state: {} as any,
-    });
-    return doesNotReject(() => findByID(id));
-  });
+  after(() => Config.remove('settings.mongodb.uri'));
 
   describe('has a "boot" method that', () => {
 
-    it('should throw a ConfigNotFoundError if no MongoDB URI is provided.', () => {
-      Config.remove('settings.mongodb.uri');
+    beforeEach(() => store = createService(MongoDBStore));
 
-      return rejects(
-        () => createService(MongoDBStore).boot(),
-        new ConfigNotFoundError(
-          'settings.mongodb.uri',
-          'You must provide the URI of your database when using MongoDBStore.',
-        )
-      );
-    });
+    afterEach(() => Promise.all([
+      mongoDBClient.close(),
+      store.close(),
+    ]))
+
+    context('when setMongoDBClient has been previously called', () => {
+
+      it('should NOT create a new MongoDB instance but use the one provided.', async () => {
+        mongoDBClient = await MongoClient.connect(MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true });
+        try {
+          await mongoDBClient.db().collection(COLLECTION_NAME).dropIndexes();
+        } catch (error: any) {
+          if (!(error.message.includes('ns not found'))) {
+            throw error;
+          }
+        }
+
+        store.setMongoDBClient(mongoDBClient);
+
+        strictEqual(mongoDBClient.isConnected(), true);
+
+        await store.boot();
+        await store.close();
+
+        strictEqual(mongoDBClient.isConnected(), false);
+      });
+
+      it('should still create an index on the provided MongoDB instance', async () => {
+        mongoDBClient = await MongoClient.connect(MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true });
+        try {
+          await mongoDBClient.db().collection(COLLECTION_NAME).dropIndexes();
+        } catch (error: any) {
+          if (!(error.message.includes('ns not found'))) {
+            throw error;
+          }
+        }
+
+        store.setMongoDBClient(mongoDBClient);
+
+        let indexInformation = await mongoDBClient.db().collection(COLLECTION_NAME).indexInformation();
+        strictEqual(Object.keys(indexInformation).some(key => indexInformation[key][0][0] === 'sessionID'), false);
+
+        await store.boot();
+
+        indexInformation = await mongoDBClient.db().collection(COLLECTION_NAME).indexInformation();
+        strictEqual(Object.keys(indexInformation).some(key => indexInformation[key][0][0] === 'sessionID'), true);
+      })
+
+    })
 
   });
 
-  describe('has a "save" method that', () => {
+  describe('when the service has been initialized', () => {
 
-    context('given no session exists in the database with the given ID', () => {
+    function createState(): SessionState {
+      return {
+        content: {
+          foo: 'bar'
+        },
+        createdAt: 0,
+        flash: {
+          hello: 'world'
+        },
+        id: 'xxx',
+        updatedAt: 0,
+        userId: null,
+      };
+    }
 
-      it('should save the session state in the database.', async () => {
-        await store.save(state, maxInactivity);
-
-        const actual = (await findByID(state.id)).state;
-        deepStrictEqual(actual, state);
-      });
-
+    before(async () => {
+      mongoDBClient = await MongoClient.connect(MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true });
+      try {
+        await mongoDBClient.db().collection(COLLECTION_NAME).dropIndexes();
+      } catch (error: any) {
+        if (!(error.message.includes('ns not found'))) {
+          throw error;
+        }
+      }
+      store = createService(MongoDBStore);
+      await store.boot();
     });
 
-    context('given a session already exists in the database with the given ID', () => {
+    beforeEach(async () => {
+      state = createState();
+      state2 = {
+        ...createState(),
+        id: `${state.id}2`
+      };
+      maxInactivity = 1000;
+      await mongoDBClient.db().collection(COLLECTION_NAME).deleteMany({});
+    });
 
-      beforeEach(async () => {
-        await insertSessionIntoDB({
-          sessionID: state.id,
-          state,
-        });
+    after(() => {
+      return Promise.all([
+        mongoDBClient.close(),
+        store.close(),
+      ]);
+    });
+
+    async function insertSessionIntoDB(session: DatabaseSession): Promise<DatabaseSession> {
+      await mongoDBClient.db().collection(COLLECTION_NAME).insertOne(session);
+      return session;
+    }
+
+    async function readSessionsFromDB(): Promise<DatabaseSession[]> {
+      return mongoDBClient.db().collection(COLLECTION_NAME).find({}).toArray();
+    }
+
+    async function findByID(sessionID: string): Promise<DatabaseSession> {
+      const session = await mongoDBClient.db().collection(COLLECTION_NAME).findOne({ sessionID });
+      if (!session) {
+        throw new Error('Session not found');
+      }
+      return session;
+    }
+
+    it('should support sessions IDs of length 44.', async () => {
+      const session = await createSession({} as any);
+      const id = session.getToken();
+      await insertSessionIntoDB({
+        sessionID: id,
+        state: {} as any,
       });
+      return doesNotReject(() => findByID(id));
+    });
 
-      it('should throw a SessionAlreadyExists error.', async () => {
+    describe('has a "boot" method that', () => {
+
+      it('should throw a ConfigNotFoundError if no MongoDB URI is provided.', () => {
+        Config.remove('settings.mongodb.uri');
+
         return rejects(
-          () => store.save(state, maxInactivity),
-          new SessionAlreadyExists()
+          () => createService(MongoDBStore).boot(),
+          new ConfigNotFoundError(
+            'settings.mongodb.uri',
+            'You must provide the URI of your database when using MongoDBStore.',
+          )
         );
       });
 
     });
 
-  });
+    describe('has a "save" method that', () => {
 
-  describe('has a "read" method that', () => {
+      context('given no session exists in the database with the given ID', () => {
 
-    context('given no session exists in the database with the given ID', () => {
+        it('should save the session state in the database.', async () => {
+          await store.save(state, maxInactivity);
 
-      it('should return null.', async () => {
-        strictEqual(await store.read('c'), null);
+          const actual = (await findByID(state.id)).state;
+          deepStrictEqual(actual, state);
+        });
+
+      });
+
+      context('given a session already exists in the database with the given ID', () => {
+
+        beforeEach(async () => {
+          await insertSessionIntoDB({
+            sessionID: state.id,
+            state,
+          });
+        });
+
+        it('should throw a SessionAlreadyExists error.', async () => {
+          return rejects(
+            () => store.save(state, maxInactivity),
+            new SessionAlreadyExists()
+          );
+        });
+
       });
 
     });
 
-    context('given a session exists in the database with the given ID', () => {
+    describe('has a "read" method that', () => {
+
+      context('given no session exists in the database with the given ID', () => {
+
+        it('should return null.', async () => {
+          strictEqual(await store.read('c'), null);
+        });
+
+      });
+
+      context('given a session exists in the database with the given ID', () => {
+
+        beforeEach(async () => {
+          await insertSessionIntoDB({
+            sessionID: state.id,
+            state,
+          });
+        });
+
+        it('should return the session state.', async () => {
+          const expected = createState();
+          const actual = await store.read(state.id);
+
+          deepStrictEqual(actual, expected);
+        });
+
+      });
+
+    });
+
+    describe('has a "update" method that', () => {
+
+      context('given no session exists in the database with the given ID', () => {
+
+        it('should save the session state in the database.', async () => {
+          await store.update(state, maxInactivity);
+
+          const actual = (await findByID(state.id)).state;
+          deepStrictEqual(actual, state);
+        });
+
+      });
+
+      context('given a session already exists in the database with the given ID', () => {
+
+        let updatedState: SessionState;
+
+        beforeEach(async () => {
+          // The state2 must be saved before the state.
+          await insertSessionIntoDB({
+            sessionID: state2.id,
+            state: state2,
+          });
+          await insertSessionIntoDB({
+            sessionID: state.id,
+            state,
+          });
+
+          updatedState = {
+            content: {
+              ...state.content,
+              foo2: 'bar2',
+            },
+            createdAt: state.createdAt + 1,
+            flash: {
+              ...state.flash,
+              hello2: 'world2',
+            },
+            id: state.id,
+            updatedAt: state.updatedAt + 2,
+            userId: 3,
+          };
+        });
+
+        it('should update the session state in the database.', async () => {
+          await store.update(updatedState, maxInactivity);
+
+          const actual = (await findByID(state.id)).state;
+          deepStrictEqual(actual, updatedState);
+        });
+
+        it('should not update the other session states in the database.', async () => {
+          await store.update(updatedState, maxInactivity);
+
+          const actual = (await findByID(state2.id)).state;
+          deepStrictEqual(actual, state2);
+        });
+
+      });
+
+    });
+
+    describe('has a "destroy" method that', () => {
+
+      context('given no session exists in the database with the given ID', () => {
+
+        it('should not throw an error.', () => {
+          return doesNotReject(() => store.destroy('c'));
+        });
+
+      });
+
+      context('given a session already exists in the database with the given ID', () => {
+
+        beforeEach(async () => {
+          // The state2 must be saved before the state.
+          await insertSessionIntoDB({
+            sessionID: state2.id,
+            state: state2,
+          });
+          await insertSessionIntoDB({
+            sessionID: state.id,
+            state,
+          });
+        });
+
+        it('should delete the session in the database.', async () => {
+          await store.destroy(state.id);
+
+          return rejects(() => findByID(state.id));
+        });
+
+        it('should delete the session in the database.', async () => {
+          await store.destroy(state.id);
+
+          return doesNotReject(() => findByID(state2.id));
+        });
+
+      });
+
+    });
+
+    describe('has a "clear" method that', () => {
 
       beforeEach(async () => {
         await insertSessionIntoDB({
@@ -175,190 +355,70 @@ describe('MongoDBStore', () => {
         });
       });
 
-      it('should return the session state.', async () => {
-        const expected = createState();
-        const actual = await store.read(state.id);
+      it('should remove all sessions.', async () => {
+        await store.clear();
 
-        deepStrictEqual(actual, expected);
+        strictEqual((await readSessionsFromDB()).length, 0);
       });
 
     });
 
-  });
+    describe('has a "cleanUpExpiredSessions" method that', () => {
 
-  describe('has a "update" method that', () => {
-
-    context('given no session exists in the database with the given ID', () => {
-
-      it('should save the session state in the database.', async () => {
-        await store.update(state, maxInactivity);
-
-        const actual = (await findByID(state.id)).state;
-        deepStrictEqual(actual, state);
-      });
-
-    });
-
-    context('given a session already exists in the database with the given ID', () => {
-
-      let updatedState: SessionState;
+      let maxLifeTime: number;
 
       beforeEach(async () => {
-        // The state2 must be saved before the state.
-        await insertSessionIntoDB({
-          sessionID: state2.id,
-          state: state2,
-        });
-        await insertSessionIntoDB({
-          sessionID: state.id,
-          state,
-        });
+        maxInactivity = 10;
+        maxLifeTime = 20;
 
-        updatedState = {
-          content: {
-            ...state.content,
-            foo2: 'bar2',
+        const now = Math.trunc(Date.now() / 1000);
+        const states: SessionState[] = [
+          {
+            ...createState(),
+            createdAt: now - 1,
+            id: 'xxx',
+            updatedAt: now - 1,
           },
-          createdAt: state.createdAt + 1,
-          flash: {
-            ...state.flash,
-            hello2: 'world2',
+          {
+            ...createState(),
+            createdAt: now,
+            id: 'yyy',
+            updatedAt: now - maxInactivity - 1,
           },
-          id: state.id,
-          updatedAt: state.updatedAt + 2,
-          userId: 3,
-        };
+          {
+            ...createState(),
+            createdAt: now - maxLifeTime - 1,
+            id: 'zzz',
+            updatedAt: now,
+          },
+        ];
+
+        for (const state of states) {
+          await insertSessionIntoDB({
+            sessionID: state.id,
+            state,
+          });
+        }
       });
 
-      it('should update the session state in the database.', async () => {
-        await store.update(updatedState, maxInactivity);
+      it('should not remove unexpired sessions.', async () => {
+        await store.cleanUpExpiredSessions(maxInactivity, maxLifeTime);
 
-        const actual = (await findByID(state.id)).state;
-        deepStrictEqual(actual, updatedState);
+        return doesNotReject(() => findByID('xxx'));
       });
 
-      it('should not update the other session states in the database.', async () => {
-        await store.update(updatedState, maxInactivity);
+      it('should remove sessions expired due to inactivity.', async () => {
+        await store.cleanUpExpiredSessions(maxInactivity, maxLifeTime);
 
-        const actual = (await findByID(state2.id)).state;
-        deepStrictEqual(actual, state2);
+        return rejects(() => findByID('yyy'));
       });
 
-    });
+      it('should remove sessions expired due to absolute end of life.', async () => {
+        await store.cleanUpExpiredSessions(maxInactivity, maxLifeTime);
 
-  });
-
-  describe('has a "destroy" method that', () => {
-
-    context('given no session exists in the database with the given ID', () => {
-
-      it('should not throw an error.', () => {
-        return doesNotReject(() => store.destroy('c'));
+        return rejects(() => findByID('zzz'));
       });
 
-    });
-
-    context('given a session already exists in the database with the given ID', () => {
-
-      beforeEach(async () => {
-        // The state2 must be saved before the state.
-        await insertSessionIntoDB({
-          sessionID: state2.id,
-          state: state2,
-        });
-        await insertSessionIntoDB({
-          sessionID: state.id,
-          state,
-        });
-      });
-
-      it('should delete the session in the database.', async () => {
-        await store.destroy(state.id);
-
-        return rejects(() => findByID(state.id));
-      });
-
-      it('should delete the session in the database.', async () => {
-        await store.destroy(state.id);
-
-        return doesNotReject(() => findByID(state2.id));
-      });
-
-    });
-
-  });
-
-  describe('has a "clear" method that', () => {
-
-    beforeEach(async () => {
-      await insertSessionIntoDB({
-        sessionID: state.id,
-        state,
-      });
-    });
-
-    it('should remove all sessions.', async () => {
-      await store.clear();
-
-      strictEqual((await readSessionsFromDB()).length, 0);
-    });
-
-  });
-
-  describe('has a "cleanUpExpiredSessions" method that', () => {
-
-    let maxLifeTime: number;
-
-    beforeEach(async () => {
-      maxInactivity = 10;
-      maxLifeTime = 20;
-
-      const now = Math.trunc(Date.now() / 1000);
-      const states: SessionState[] = [
-        {
-          ...createState(),
-          createdAt: now - 1,
-          id: 'xxx',
-          updatedAt: now - 1,
-        },
-        {
-          ...createState(),
-          createdAt: now,
-          id: 'yyy',
-          updatedAt: now - maxInactivity - 1,
-        },
-        {
-          ...createState(),
-          createdAt: now - maxLifeTime - 1,
-          id: 'zzz',
-          updatedAt: now,
-        },
-      ];
-
-      for (const state of states) {
-        await insertSessionIntoDB({
-          sessionID: state.id,
-          state,
-        });
-      }
-    });
-
-    it('should not remove unexpired sessions.', async () => {
-      await store.cleanUpExpiredSessions(maxInactivity, maxLifeTime);
-
-      return doesNotReject(() => findByID('xxx'));
-    });
-
-    it('should remove sessions expired due to inactivity.', async () => {
-      await store.cleanUpExpiredSessions(maxInactivity, maxLifeTime);
-
-      return rejects(() => findByID('yyy'));
-    });
-
-    it('should remove sessions expired due to absolute end of life.', async () => {
-      await store.cleanUpExpiredSessions(maxInactivity, maxLifeTime);
-
-      return rejects(() => findByID('zzz'));
     });
 
   });

--- a/packages/mongodb/src/mongodb-store.service.spec.ts
+++ b/packages/mongodb/src/mongodb-store.service.spec.ts
@@ -27,9 +27,6 @@ describe('MongoDBStore', () => {
 
   let store: MongoDBStore;
   let mongoDBClient: any;
-  let state: SessionState;
-  let state2: SessionState;
-  let maxInactivity: number;
 
   before(() => Config.set('settings.mongodb.uri', MONGODB_URI));
 
@@ -107,6 +104,10 @@ describe('MongoDBStore', () => {
         userId: null,
       };
     }
+
+    let state: SessionState;
+    let state2: SessionState;
+    let maxInactivity: number;
 
     before(async () => {
       mongoDBClient = await MongoClient.connect(MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true });

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -18,13 +18,19 @@ export class MongoDBStore extends SessionStore {
   private mongoDBClient: any;
   private collection: any;
 
+  setMongoDBClient(mongoDBClient: any) {
+    this.mongoDBClient = mongoDBClient;
+  }
+
   async boot() {
-    const mongoDBURI = Config.getOrThrow(
-      'settings.mongodb.uri',
-      'string',
-      'You must provide the URI of your database when using MongoDBStore.'
-    );
-    this.mongoDBClient = await MongoClient.connect(mongoDBURI, { useNewUrlParser: true, useUnifiedTopology: true });
+    if (!this.mongoDBClient) {
+      const mongoDBURI = Config.getOrThrow(
+        'settings.mongodb.uri',
+        'string',
+        'You must provide the URI of your database when using MongoDBStore.'
+      );
+      this.mongoDBClient = await MongoClient.connect(mongoDBURI, { useNewUrlParser: true, useUnifiedTopology: true });
+    }
     this.collection = this.mongoDBClient.db().collection('sessions');
     this.collection.createIndex({ sessionID: 1 }, { unique: true });
   }

--- a/packages/redis/src/redis-store.service.spec.ts
+++ b/packages/redis/src/redis-store.service.spec.ts
@@ -13,8 +13,6 @@ describe('RedisStore', () => {
 
   let store: RedisStore;
   let redisClient: any;
-  let state: SessionState;
-  let maxInactivity: number;
 
   before(() => Config.set('settings.redis.uri', REDIS_URI));
 
@@ -67,6 +65,9 @@ describe('RedisStore', () => {
     function getKey(id: string): string {
       return `${COLLECTION_NAME}:${id}`;
     }
+
+    let state: SessionState;
+    let maxInactivity: number;
 
     before(async () => {
       redisClient = createClient(REDIS_URI);

--- a/packages/redis/src/redis-store.service.spec.ts
+++ b/packages/redis/src/redis-store.service.spec.ts
@@ -47,6 +47,9 @@ describe('RedisStore', () => {
 
   describe('when the service has been initialized', () => {
 
+    let state: SessionState;
+    let maxInactivity: number;
+
     function createState(): SessionState {
       return {
         content: {
@@ -65,9 +68,6 @@ describe('RedisStore', () => {
     function getKey(id: string): string {
       return `${COLLECTION_NAME}:${id}`;
     }
-
-    let state: SessionState;
-    let maxInactivity: number;
 
     before(async () => {
       redisClient = createClient(REDIS_URI);

--- a/packages/redis/src/redis-store.service.spec.ts
+++ b/packages/redis/src/redis-store.service.spec.ts
@@ -16,257 +16,288 @@ describe('RedisStore', () => {
   let state: SessionState;
   let maxInactivity: number;
 
-  function createState(): SessionState {
-    return {
-      content: {
-        foo: 'bar'
-      },
-      createdAt: 0,
-      flash: {
-        hello: 'world'
-      },
-      id: 'xxx',
-      updatedAt: 0,
-      userId: null,
-    };
-  }
+  before(() => Config.set('settings.redis.uri', REDIS_URI));
 
-  function getKey(id: string): string {
-    return `${COLLECTION_NAME}:${id}`;
-  }
+  after(() => Config.remove('settings.redis.uri'));
 
-  before(async () => {
-    Config.set('settings.redis.uri', REDIS_URI);
+  describe('has a "boot" method that', () => {
 
-    redisClient = createClient(REDIS_URI);
-    store = createService(RedisStore);
-    await store.boot();
-  });
+    beforeEach(() => store = createService(RedisStore));
 
-  beforeEach(done => {
-    state = createState();
-    maxInactivity = 1000;
-    redisClient.flushdb(done);
-  });
-
-  after(() => {
-    Config.remove('settings.redis.uri');
-
-    return Promise.all([
-      redisClient.end(true),
+    afterEach(() => Promise.all([
       store.close(),
-    ]);
+      redisClient.quit()
+    ]))
+
+    context('when setRedisClient has been previously called', () => {
+
+      it('should NOT create a new redis instance but use the one provided.', () => {
+        return new Promise<void>(async resolve => {
+          redisClient = createClient(REDIS_URI)
+          redisClient.on('end', resolve);
+
+          store.setRedisClient(redisClient);
+
+          await store.boot();
+          await store.close();
+        });
+      })
+
+    })
+
   });
 
-  function asyncSet(key: string, value: string) {
-    return new Promise((resolve, reject) => {
-      redisClient.set(key, value, (err: any, success: any) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve(success);
-      });
-    });
-  }
+  describe('when the service has been initialized', () => {
 
-  function asyncGet(key: string): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
-      redisClient.get(key, (err: any, val: string) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve(val);
-      });
-    });
-  }
+    function createState(): SessionState {
+      return {
+        content: {
+          foo: 'bar'
+        },
+        createdAt: 0,
+        flash: {
+          hello: 'world'
+        },
+        id: 'xxx',
+        updatedAt: 0,
+        userId: null,
+      };
+    }
 
-  function asyncTTL(key: string): Promise<number> {
-    return new Promise<number>((resolve, reject) => {
-      redisClient.ttl(key, (err: any, val: number) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve(val);
-      });
-    });
-  }
+    function getKey(id: string): string {
+      return `${COLLECTION_NAME}:${id}`;
+    }
 
-  function asyncExists(key: string): Promise<number> {
-    return new Promise<number>((resolve, reject) => {
-      redisClient.exists(key, (err: any, val: number) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve(val);
-      });
-    });
-  }
-
-  it('should support sessions IDs of length 44.', async () => {
-    const session = await createSession({} as any);
-    const key = getKey(session.getToken());
-    await asyncSet(key, 'bar');
-    strictEqual(await asyncExists(key), 1);
-  });
-
-  describe('has a "save" method that', () => {
-
-    context('given no session exists in the database with the given ID', () => {
-
-      it('should save the session state in the database.', async () => {
-        await store.save(state, maxInactivity);
-
-        const actual = JSON.parse(await asyncGet(getKey(state.id)));
-        deepStrictEqual(actual, state);
-      });
-
-      it('should set the proper key lifetime in the database.', async () => {
-        await store.save(state, maxInactivity);
-
-        const actual = await asyncTTL(getKey(state.id));
-        deepStrictEqual(actual, maxInactivity);
-      });
-
+    before(async () => {
+      redisClient = createClient(REDIS_URI);
+      store = createService(RedisStore);
+      await store.boot();
     });
 
-    context('given a session already exists in the database with the given ID', () => {
+    beforeEach(done => {
+      state = createState();
+      maxInactivity = 1000;
+      redisClient.flushdb(done);
+    });
+
+    after(() => {
+      return Promise.all([
+        redisClient.quit(),
+        store.close(),
+      ]);
+    });
+
+    function asyncSet(key: string, value: string) {
+      return new Promise((resolve, reject) => {
+        redisClient.set(key, value, (err: any, success: any) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(success);
+        });
+      });
+    }
+
+    function asyncGet(key: string): Promise<string> {
+      return new Promise<string>((resolve, reject) => {
+        redisClient.get(key, (err: any, val: string) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(val);
+        });
+      });
+    }
+
+    function asyncTTL(key: string): Promise<number> {
+      return new Promise<number>((resolve, reject) => {
+        redisClient.ttl(key, (err: any, val: number) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(val);
+        });
+      });
+    }
+
+    function asyncExists(key: string): Promise<number> {
+      return new Promise<number>((resolve, reject) => {
+        redisClient.exists(key, (err: any, val: number) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(val);
+        });
+      });
+    }
+
+    it('should support sessions IDs of length 44.', async () => {
+      const session = await createSession({} as any);
+      const key = getKey(session.getToken());
+      await asyncSet(key, 'bar');
+      strictEqual(await asyncExists(key), 1);
+    });
+
+    describe('has a "save" method that', () => {
+
+      context('given no session exists in the database with the given ID', () => {
+
+        it('should save the session state in the database.', async () => {
+          await store.save(state, maxInactivity);
+
+          const actual = JSON.parse(await asyncGet(getKey(state.id)));
+          deepStrictEqual(actual, state);
+        });
+
+        it('should set the proper key lifetime in the database.', async () => {
+          await store.save(state, maxInactivity);
+
+          const actual = await asyncTTL(getKey(state.id));
+          deepStrictEqual(actual, maxInactivity);
+        });
+
+      });
+
+      context('given a session already exists in the database with the given ID', () => {
+
+        beforeEach(async () => {
+          await asyncSet(getKey(state.id), JSON.stringify(state));
+        });
+
+        it('should throw a SessionAlreadyExists error.', async () => {
+          return rejects(
+            () => store.save(state, maxInactivity),
+            new SessionAlreadyExists()
+          );
+        });
+
+      });
+
+    });
+
+    describe('has a "read" method that', () => {
+
+      context('given no session exists in the database with the given ID', () => {
+
+        it('should return null.', async () => {
+          strictEqual(await store.read('c'), null);
+        });
+
+      });
+
+      context('given a session exists in the database with the given ID', () => {
+
+        beforeEach(async () => {
+          await asyncSet(getKey(state.id), JSON.stringify(state));
+        });
+
+        it('should return the session state.', async () => {
+          const expected = createState();
+          const actual = await store.read(state.id);
+
+          deepStrictEqual(actual, expected);
+        });
+
+      });
+
+    });
+
+    describe('has a "update" method that', () => {
+
+      context('given no session exists in the database with the given ID', () => {
+
+        it('should save the session state in the database.', async () => {
+          await store.update(state, maxInactivity);
+
+          const actual = JSON.parse(await asyncGet(getKey(state.id)));
+          deepStrictEqual(actual, state);
+        });
+
+        it('should set the proper key lifetime in the database.', async () => {
+          await store.update(state, maxInactivity);
+
+          const actual = await asyncTTL(getKey(state.id));
+          deepStrictEqual(actual, maxInactivity);
+        });
+
+      });
+
+      context('given a session already exists in the database with the given ID', () => {
+
+        beforeEach(async () => {
+          await asyncSet(getKey(state.id), JSON.stringify(state));
+        });
+
+        it('should update the session state in the database.', async () => {
+          const updatedState = {
+            ...state,
+            updatedAt: state.updatedAt + 1,
+          };
+          await store.update(updatedState, maxInactivity);
+
+          const actual = JSON.parse(await asyncGet(getKey(state.id)));
+          deepStrictEqual(actual, updatedState);
+        });
+
+        it('should set the proper key lifetime in the database.', async () => {
+          strictEqual(await asyncTTL(getKey(state.id)), -1);
+
+          await store.update(state, maxInactivity);
+
+          const actual = await asyncTTL(getKey(state.id));
+          deepStrictEqual(actual, maxInactivity);
+        });
+
+      });
+
+    });
+
+    describe('has a "destroy" method that', () => {
+
+      context('given no session exists in the database with the given ID', () => {
+
+        it('should not throw an error.', () => {
+          return doesNotReject(() => store.destroy('c'));
+        });
+
+      });
+
+      context('given a session already exists in the database with the given ID', () => {
+
+        beforeEach(async () => {
+          await asyncSet(getKey(state.id), JSON.stringify(state));
+        });
+
+        it('should delete the session in the database.', async () => {
+          await store.destroy(state.id);
+
+          strictEqual(await asyncGet(getKey(state.id)), null);
+        });
+
+      });
+
+    });
+
+    describe('has a "clear" method that', () => {
 
       beforeEach(async () => {
         await asyncSet(getKey(state.id), JSON.stringify(state));
       });
 
-      it('should throw a SessionAlreadyExists error.', async () => {
-        return rejects(
-          () => store.save(state, maxInactivity),
-          new SessionAlreadyExists()
-        );
-      });
-
-    });
-
-  });
-
-  describe('has a "read" method that', () => {
-
-    context('given no session exists in the database with the given ID', () => {
-
-      it('should return null.', async () => {
-        strictEqual(await store.read('c'), null);
-      });
-
-    });
-
-    context('given a session exists in the database with the given ID', () => {
-
-      beforeEach(async () => {
-        await asyncSet(getKey(state.id), JSON.stringify(state));
-      });
-
-      it('should return the session state.', async () => {
-        const expected = createState();
-        const actual = await store.read(state.id);
-
-        deepStrictEqual(actual, expected);
-      });
-
-    });
-
-  });
-
-  describe('has a "update" method that', () => {
-
-    context('given no session exists in the database with the given ID', () => {
-
-      it('should save the session state in the database.', async () => {
-        await store.update(state, maxInactivity);
-
-        const actual = JSON.parse(await asyncGet(getKey(state.id)));
-        deepStrictEqual(actual, state);
-      });
-
-      it('should set the proper key lifetime in the database.', async () => {
-        await store.update(state, maxInactivity);
-
-        const actual = await asyncTTL(getKey(state.id));
-        deepStrictEqual(actual, maxInactivity);
-      });
-
-    });
-
-    context('given a session already exists in the database with the given ID', () => {
-
-      beforeEach(async () => {
-        await asyncSet(getKey(state.id), JSON.stringify(state));
-      });
-
-      it('should update the session state in the database.', async () => {
-        const updatedState = {
-          ...state,
-          updatedAt: state.updatedAt + 1,
-        };
-        await store.update(updatedState, maxInactivity);
-
-        const actual = JSON.parse(await asyncGet(getKey(state.id)));
-        deepStrictEqual(actual, updatedState);
-      });
-
-      it('should set the proper key lifetime in the database.', async () => {
-        strictEqual(await asyncTTL(getKey(state.id)), -1);
-
-        await store.update(state, maxInactivity);
-
-        const actual = await asyncTTL(getKey(state.id));
-        deepStrictEqual(actual, maxInactivity);
-      });
-
-    });
-
-  });
-
-  describe('has a "destroy" method that', () => {
-
-    context('given no session exists in the database with the given ID', () => {
-
-      it('should not throw an error.', () => {
-        return doesNotReject(() => store.destroy('c'));
-      });
-
-    });
-
-    context('given a session already exists in the database with the given ID', () => {
-
-      beforeEach(async () => {
-        await asyncSet(getKey(state.id), JSON.stringify(state));
-      });
-
-      it('should delete the session in the database.', async () => {
-        await store.destroy(state.id);
+      it('should remove all sessions.', async () => {
+        await store.clear();
 
         strictEqual(await asyncGet(getKey(state.id)), null);
       });
 
     });
 
-  });
+    describe('has a "cleanUpExpiredSessions" method that', () => {
 
-  describe('has a "clear" method that', () => {
+      it('should not throw.', () => {
+        return doesNotReject(() => store.cleanUpExpiredSessions());
+      });
 
-    beforeEach(async () => {
-      await asyncSet(getKey(state.id), JSON.stringify(state));
-    });
-
-    it('should remove all sessions.', async () => {
-      await store.clear();
-
-      strictEqual(await asyncGet(getKey(state.id)), null);
-    });
-
-  });
-
-  describe('has a "cleanUpExpiredSessions" method that', () => {
-
-    it('should not throw.', () => {
-      return doesNotReject(() => store.cleanUpExpiredSessions());
     });
 
   });

--- a/packages/redis/src/redis-store.service.ts
+++ b/packages/redis/src/redis-store.service.ts
@@ -12,7 +12,14 @@ export class RedisStore extends SessionStore {
 
   private redisClient: any;
 
+  setRedisClient(redisClient: any) {
+    this.redisClient = redisClient;
+  }
+
   boot() {
+    if (this.redisClient) {
+      return;
+    }
     const redisURI = Config.get('settings.redis.uri', 'string');
     this.redisClient = createClient(redisURI);
   }
@@ -94,6 +101,6 @@ export class RedisStore extends SessionStore {
    * @memberof RedisStore
    */
   async close(): Promise<void> {
-    await this.redisClient.end(true);
+    await this.redisClient.quit();
   }
 }

--- a/packages/typeorm/src/typeorm-store.service.spec.ts
+++ b/packages/typeorm/src/typeorm-store.service.spec.ts
@@ -682,7 +682,7 @@ function storeTestSuite(type: DBType) {
 
 }
 
-describe.only('TypeORMStore', () => {
+describe('TypeORMStore', () => {
 
   storeTestSuite('mysql');
   storeTestSuite('mariadb');

--- a/packages/typeorm/src/typeorm-store.service.spec.ts
+++ b/packages/typeorm/src/typeorm-store.service.spec.ts
@@ -2,7 +2,7 @@
 import { deepStrictEqual, doesNotReject, rejects, strictEqual } from 'assert';
 
 // 3p
-import { createConnection, getConnection, getRepository } from 'typeorm';
+import { Connection, createConnection, getConnection, getRepository } from 'typeorm';
 
 // FoalTS
 import { createService, createSession, SessionAlreadyExists, SessionState } from '@foal/core';
@@ -10,11 +10,11 @@ import { DatabaseSession, TypeORMStore } from './typeorm-store.service';
 
 type DBType = 'mysql'|'mariadb'|'postgres'|'sqlite'|'better-sqlite3';
 
-async function createTestConnection(type: DBType) {
+async function createTestConnection(type: DBType, name?: string): Promise<Connection> {
   switch (type) {
     case 'mysql':
     case 'mariadb':
-      await createConnection({
+      return createConnection({
         database: 'test',
         dropSchema: true,
         entities: [ DatabaseSession ],
@@ -23,10 +23,10 @@ async function createTestConnection(type: DBType) {
         synchronize: true,
         type,
         username: 'test',
+        name,
       });
-      break;
     case 'postgres':
-      await createConnection({
+      return createConnection({
         database: 'test',
         dropSchema: true,
         entities: [ DatabaseSession ],
@@ -34,20 +34,20 @@ async function createTestConnection(type: DBType) {
         synchronize: true,
         type,
         username: 'test',
+        name,
       });
-      break;
     case 'sqlite':
     case 'better-sqlite3':
-      await createConnection({
+      return createConnection({
         database: 'test_db.sqlite',
         dropSchema: true,
         entities: [ DatabaseSession ],
         synchronize: true,
         type,
+        name,
       });
-      break;
     default:
-      break;
+      throw new Error('Invalid database type.');
   }
 }
 
@@ -187,475 +187,514 @@ function storeTestSuite(type: DBType) {
   describe(`with ${type}`, () => {
 
     let store: TypeORMStore;
-    let state: SessionState;
-    let state2: SessionState;
-    let maxInactivity: number;
 
-    function createState(): SessionState {
-      return {
-        content: {
-          foo: 'bar'
-        },
-        createdAt: 0,
-        flash: {
-          hello: 'world'
-        },
-        id: 'xxx',
-        updatedAt: 0,
-        // The null value is important in this test suite.
-        userId: null,
-      };
-    }
+    describe('has a "boot" method that', () => {
 
-    before(async () => {
-      store = createService(TypeORMStore);
-      await createTestConnection(type);
+      let connection2: Connection;
+
+      beforeEach(async () => {
+        store = createService(TypeORMStore);
+        await createTestConnection(type);
+      });
+
+      afterEach(() => Promise.all([
+        getConnection().isConnected ? getConnection().close() : undefined,
+        connection2.isConnected ? connection2.close() : undefined,
+      ]))
+
+      context('when setConnection has been previously called', () => {
+
+        it('should NOT create a new TypeORM connection but use the one provided.', async () => {
+          connection2 = await createTestConnection(type, 'connection2');
+
+          store.setConnection(connection2);
+
+          strictEqual(connection2.isConnected, true);
+
+          await store.boot();
+          await store.close();
+
+          strictEqual(connection2.isConnected, false);
+        });
+
+      });
+
     });
 
-    beforeEach(async () => {
-      state = createState();
-      state2 = {
-        ...createState(),
-        id: `${state.id}2`
-      };
-      maxInactivity = 1000;
-      await getRepository(DatabaseSession).clear();
-    });
+    describe('when the service has been initialized', () => {
 
-    after(() => getConnection().close());
+      let state: SessionState;
+      let state2: SessionState;
+      let maxInactivity: number;
 
-    function convertDbSessionToState(dbSession: DatabaseSession): SessionState {
-      return {
-        content: JSON.parse(dbSession.content),
-        createdAt: dbSession.created_at,
-        flash: JSON.parse(dbSession.flash),
-        id: dbSession.id,
-        updatedAt: dbSession.updated_at,
-        // tslint:disable-next-line
-        userId: dbSession.user_id ?? null,
-      };
-    }
-
-    function convertStateToDbSession(state: SessionState): DatabaseSession {
-      if (typeof state.userId === 'string') {
-        throw new Error('user ID cannot be a string.');
+      function createState(): SessionState {
+        return {
+          content: {
+            foo: 'bar'
+          },
+          createdAt: 0,
+          flash: {
+            hello: 'world'
+          },
+          id: 'xxx',
+          updatedAt: 0,
+          // The null value is important in this test suite.
+          userId: null,
+        };
       }
-      return getRepository(DatabaseSession).create({
-        content: JSON.stringify(state.content),
-        created_at: state.createdAt,
-        flash: JSON.stringify(state.flash),
-        id: state.id,
-        updated_at: state.updatedAt,
-        // tslint:disable-next-line
-        user_id: state.userId ?? undefined,
+
+      before(async () => {
+        store = createService(TypeORMStore);
+        await createTestConnection(type);
+        store.boot();
       });
-    }
 
-    describe('has a "save" method that', () => {
+      beforeEach(async () => {
+        state = createState();
+        state2 = {
+          ...createState(),
+          id: `${state.id}2`
+        };
+        maxInactivity = 1000;
+        await getRepository(DatabaseSession).clear();
+      });
 
-      it('should throw if the user ID is defined and is not a number.', async () => {
-        await rejects(
-          () => store.save(
+      after(() => getConnection().close());
+
+      function convertDbSessionToState(dbSession: DatabaseSession): SessionState {
+        return {
+          content: JSON.parse(dbSession.content),
+          createdAt: dbSession.created_at,
+          flash: JSON.parse(dbSession.flash),
+          id: dbSession.id,
+          updatedAt: dbSession.updated_at,
+          // tslint:disable-next-line
+          userId: dbSession.user_id ?? null,
+        };
+      }
+
+      function convertStateToDbSession(state: SessionState): DatabaseSession {
+        if (typeof state.userId === 'string') {
+          throw new Error('user ID cannot be a string.');
+        }
+        return getRepository(DatabaseSession).create({
+          content: JSON.stringify(state.content),
+          created_at: state.createdAt,
+          flash: JSON.stringify(state.flash),
+          id: state.id,
+          updated_at: state.updatedAt,
+          // tslint:disable-next-line
+          user_id: state.userId ?? undefined,
+        });
+      }
+
+      describe('has a "save" method that', () => {
+
+        it('should throw if the user ID is defined and is not a number.', async () => {
+          await rejects(
+            () => store.save(
+              {
+                ...createState(),
+                userId: 'xxx',
+              },
+              maxInactivity
+            ),
             {
-              ...createState(),
-              userId: 'xxx',
-            },
-            maxInactivity
-          ),
-          {
-            message: '[TypeORMStore] Impossible to save the session. The user ID must be a number.'
-          }
-        );
-      });
-
-      context('given no session exists in the database with the given ID', () => {
-
-        it('should save the session state in the database.', async () => {
-          await store.save(state, maxInactivity);
-
-          const dbSession = await getRepository(DatabaseSession).findOneOrFail({ id: state.id });
-          deepStrictEqual(convertDbSessionToState(dbSession), state);
-        });
-
-      });
-
-      context('given a session already exists in the database with the given ID', () => {
-
-        beforeEach(async () => {
-          const session = convertStateToDbSession(state);
-          await getRepository(DatabaseSession).save(session);
-        });
-
-        it('should throw a SessionAlreadyExists error.', async () => {
-          return rejects(
-            () => store.save(state, maxInactivity),
-            new SessionAlreadyExists()
+              message: '[TypeORMStore] Impossible to save the session. The user ID must be a number.'
+            }
           );
         });
 
-      });
+        context('given no session exists in the database with the given ID', () => {
 
-    });
+          it('should save the session state in the database.', async () => {
+            await store.save(state, maxInactivity);
 
-    describe('has a "read" method that', () => {
+            const dbSession = await getRepository(DatabaseSession).findOneOrFail({ id: state.id });
+            deepStrictEqual(convertDbSessionToState(dbSession), state);
+          });
 
-      context('given no session exists in the database with the given ID', () => {
+        });
 
-        it('should return null.', async () => {
-          strictEqual(await store.read('c'), null);
+        context('given a session already exists in the database with the given ID', () => {
+
+          beforeEach(async () => {
+            const session = convertStateToDbSession(state);
+            await getRepository(DatabaseSession).save(session);
+          });
+
+          it('should throw a SessionAlreadyExists error.', async () => {
+            return rejects(
+              () => store.save(state, maxInactivity),
+              new SessionAlreadyExists()
+            );
+          });
+
         });
 
       });
 
-      context('given a session exists in the database with the given ID', () => {
+      describe('has a "read" method that', () => {
+
+        context('given no session exists in the database with the given ID', () => {
+
+          it('should return null.', async () => {
+            strictEqual(await store.read('c'), null);
+          });
+
+        });
+
+        context('given a session exists in the database with the given ID', () => {
+
+          beforeEach(async () => {
+            const session = convertStateToDbSession(state);
+            await getRepository(DatabaseSession).save(session);
+          });
+
+          it('should return the session state.', async () => {
+            const expected = createState();
+            const actual = await store.read(state.id);
+
+            deepStrictEqual(actual, expected);
+          });
+
+        });
+
+      });
+
+      describe('has a "update" method that', () => {
+
+        it('should throw if the user ID is defined and is not a number.', async () => {
+          await rejects(
+            () => store.update(
+              {
+                ...createState(),
+                userId: 'xxx',
+              },
+              maxInactivity
+            ),
+            {
+              message: '[TypeORMStore] Impossible to save the session. The user ID must be a number.'
+            }
+          );
+        });
+
+        context('given no session exists in the database with the given ID', () => {
+
+          it('should save the session state in the database.', async () => {
+            await store.update(state, maxInactivity);
+
+            const dbSession = await getRepository(DatabaseSession).findOneOrFail({ id: state.id });
+            deepStrictEqual(convertDbSessionToState(dbSession), state);
+          });
+
+        });
+
+        context('given a session already exists in the database with the given ID', () => {
+
+          let updatedState: SessionState;
+
+          beforeEach(async () => {
+            const session = convertStateToDbSession(state);
+            const session2 = convertStateToDbSession(state2);
+            // The state2 must be saved before the state.
+            await getRepository(DatabaseSession).save([ session2, session ]);
+
+            updatedState = {
+              content: {
+                ...state.content,
+                foo2: 'bar2',
+              },
+              createdAt: state.createdAt + 1,
+              flash: {
+                ...state.flash,
+                hello2: 'world2',
+              },
+              id: state.id,
+              updatedAt: state.updatedAt + 2,
+              userId: 3,
+            };
+          });
+
+          it('should update the session state in the database.', async () => {
+            await store.update(updatedState, maxInactivity);
+
+            const dbSession = await getRepository(DatabaseSession).findOneOrFail({ id: state.id });
+            deepStrictEqual(convertDbSessionToState(dbSession), updatedState);
+          });
+
+          it('should not update the other session states in the database.', async () => {
+            await store.update(updatedState, maxInactivity);
+
+            const dbSession = await getRepository(DatabaseSession).findOneOrFail({ id: state2.id });
+            deepStrictEqual(convertDbSessionToState(dbSession), state2);
+          });
+
+        });
+
+      });
+
+      describe('has a "destroy" method that', () => {
+
+        context('given no session exists in the database with the given ID', () => {
+
+          it('should not throw an error.', () => {
+            return doesNotReject(() => store.destroy('c'));
+          });
+
+        });
+
+        context('given a session already exists in the database with the given ID', () => {
+
+          beforeEach(async () => {
+            const session = convertStateToDbSession(state);
+            const session2 = convertStateToDbSession(state2);
+            // The state2 must be saved before the state.
+            await getRepository(DatabaseSession).save([ session2, session ]);
+          });
+
+          it('should delete the session in the database.', async () => {
+            await store.destroy(state.id);
+
+            strictEqual((await getRepository(DatabaseSession).findOne({ id: state.id })), undefined);
+          });
+
+          it('should not delete the other sessions in the database.', async () => {
+            await store.destroy(state.id);
+
+            return doesNotReject(() => getRepository(DatabaseSession).findOneOrFail({ id: state2.id }));
+          });
+
+        });
+
+      });
+
+      describe('has a "clear" method that', () => {
 
         beforeEach(async () => {
           const session = convertStateToDbSession(state);
           await getRepository(DatabaseSession).save(session);
         });
 
-        it('should return the session state.', async () => {
-          const expected = createState();
-          const actual = await store.read(state.id);
+        it('should remove all sessions.', async () => {
+          await store.clear();
 
-          deepStrictEqual(actual, expected);
+          strictEqual((await getRepository(DatabaseSession).find()).length, 0);
         });
 
       });
 
-    });
+      describe('has a "cleanUpExpiredSessions" method that', () => {
 
-    describe('has a "update" method that', () => {
+        let maxLifeTime: number;
 
-      it('should throw if the user ID is defined and is not a number.', async () => {
-        await rejects(
-          () => store.update(
+        beforeEach(async () => {
+          maxInactivity = 10;
+          maxLifeTime = 20;
+
+          const now = Math.trunc(Date.now() / 1000);
+          const states: SessionState[] = [
             {
               ...createState(),
-              userId: 'xxx',
+              createdAt: now - 1,
+              id: 'xxx',
+              updatedAt: now - 1,
             },
-            maxInactivity
-          ),
-          {
-            message: '[TypeORMStore] Impossible to save the session. The user ID must be a number.'
+            {
+              ...createState(),
+              createdAt: now,
+              id: 'yyy',
+              updatedAt: now - maxInactivity - 1,
+            },
+            {
+              ...createState(),
+              createdAt: now - maxLifeTime - 1,
+              id: 'zzz',
+              updatedAt: now,
+            },
+          ];
+
+          for (const state of states) {
+            const session = convertStateToDbSession(state);
+            await getRepository(DatabaseSession).save(session);
           }
-        );
-      });
+        });
 
-      context('given no session exists in the database with the given ID', () => {
+        it('should not remove unexpired sessions.', async () => {
+          await store.cleanUpExpiredSessions(maxInactivity, maxLifeTime);
 
-        it('should save the session state in the database.', async () => {
-          await store.update(state, maxInactivity);
+          return doesNotReject(() => getRepository(DatabaseSession).findOneOrFail({ id: 'xxx' }));
+        });
 
-          const dbSession = await getRepository(DatabaseSession).findOneOrFail({ id: state.id });
-          deepStrictEqual(convertDbSessionToState(dbSession), state);
+        it('should remove sessions expired due to inactivity.', async () => {
+          await store.cleanUpExpiredSessions(maxInactivity, maxLifeTime);
+
+          return rejects(() => getRepository(DatabaseSession).findOneOrFail({ id: 'yyy' }));
+        });
+
+        it('should remove sessions expired due to absolute end of life.', async () => {
+          await store.cleanUpExpiredSessions(maxInactivity, maxLifeTime);
+
+          return rejects(() => getRepository(DatabaseSession).findOneOrFail({ id: 'zzz' }));
         });
 
       });
 
-      context('given a session already exists in the database with the given ID', () => {
-
-        let updatedState: SessionState;
+      describe('has a "getAuthenticatedUsers" method that', () => {
 
         beforeEach(async () => {
-          const session = convertStateToDbSession(state);
-          const session2 = convertStateToDbSession(state2);
-          // The state2 must be saved before the state.
-          await getRepository(DatabaseSession).save([ session2, session ]);
+          const sessions = getRepository(DatabaseSession).create([
+            {
+              content: '{}',
+              created_at: 1,
+              flash: JSON.stringify({}),
+              id: 'a',
+              updated_at: 2,
+            },
+            {
+              content: '{}',
+              created_at: 3,
+              flash: JSON.stringify({}),
+              id: 'b',
+              updated_at: 4,
+              user_id: 1,
+            },
+            {
+              content: '{}',
+              created_at: 5,
+              flash: JSON.stringify({}),
+              id: 'c',
+              updated_at: 6,
+              user_id: 2,
+            },
+            {
+              content: '{}',
+              created_at: 7,
+              flash: JSON.stringify({}),
+              id: 'd',
+              updated_at: 8,
+              user_id: 2
+            }
+          ]);
 
-          updatedState = {
-            content: {
-              ...state.content,
-              foo2: 'bar2',
-            },
-            createdAt: state.createdAt + 1,
-            flash: {
-              ...state.flash,
-              hello2: 'world2',
-            },
-            id: state.id,
-            updatedAt: state.updatedAt + 2,
-            userId: 3,
-          };
+          await getRepository(DatabaseSession).save(sessions);
         });
 
-        it('should update the session state in the database.', async () => {
-          await store.update(updatedState, maxInactivity);
-
-          const dbSession = await getRepository(DatabaseSession).findOneOrFail({ id: state.id });
-          deepStrictEqual(convertDbSessionToState(dbSession), updatedState);
-        });
-
-        it('should not update the other session states in the database.', async () => {
-          await store.update(updatedState, maxInactivity);
-
-          const dbSession = await getRepository(DatabaseSession).findOneOrFail({ id: state2.id });
-          deepStrictEqual(convertDbSessionToState(dbSession), state2);
+        it('should return the IDs of the authenticated users (distinct).', async () => {
+          const sessions = await store.getAuthenticatedUserIds();
+          // No null or dupplicated values.
+          deepStrictEqual(sessions, [ 1, 2 ]);
         });
 
       });
 
-    });
-
-    describe('has a "destroy" method that', () => {
-
-      context('given no session exists in the database with the given ID', () => {
-
-        it('should not throw an error.', () => {
-          return doesNotReject(() => store.destroy('c'));
-        });
-
-      });
-
-      context('given a session already exists in the database with the given ID', () => {
+      describe('has a "destroyAllSessionsOf" method that', () => {
 
         beforeEach(async () => {
-          const session = convertStateToDbSession(state);
-          const session2 = convertStateToDbSession(state2);
-          // The state2 must be saved before the state.
-          await getRepository(DatabaseSession).save([ session2, session ]);
+          const sessions = getRepository(DatabaseSession).create([
+            {
+              content: '{}',
+              created_at: 1,
+              flash: JSON.stringify({}),
+              id: 'a',
+              updated_at: 2,
+            },
+            {
+              content: '{}',
+              created_at: 3,
+              flash: JSON.stringify({}),
+              id: 'b',
+              updated_at: 4,
+              user_id: 1,
+            },
+            {
+              content: '{}',
+              created_at: 5,
+              flash: JSON.stringify({}),
+              id: 'c',
+              updated_at: 6,
+              user_id: 2,
+            },
+            {
+              content: '{}',
+              created_at: 7,
+              flash: JSON.stringify({}),
+              id: 'd',
+              updated_at: 8,
+              user_id: 2
+            }
+          ]);
+
+          await getRepository(DatabaseSession).save(sessions);
         });
 
-        it('should delete the session in the database.', async () => {
-          await store.destroy(state.id);
+        it('destroy all the sessions of the given user.', async () => {
+          const user = { id: 2 };
+          await store.destroyAllSessionsOf(user);
 
-          strictEqual((await getRepository(DatabaseSession).findOne({ id: state.id })), undefined);
+          const sessions = await getRepository(DatabaseSession).find();
+          strictEqual(sessions.length, 2);
+          strictEqual(sessions[0].id, 'a');
+          strictEqual(sessions[1].id, 'b');
         });
 
-        it('should not delete the other sessions in the database.', async () => {
-          await store.destroy(state.id);
+      });
 
-          return doesNotReject(() => getRepository(DatabaseSession).findOneOrFail({ id: state2.id }));
+      describe('has a "getSessionIDsOf" method that', () => {
+
+        beforeEach(async () => {
+          const sessions = getRepository(DatabaseSession).create([
+            {
+              content: '{}',
+              created_at: 1,
+              flash: JSON.stringify({}),
+              id: 'a',
+              updated_at: 2,
+            },
+            {
+              content: '{}',
+              created_at: 3,
+              flash: JSON.stringify({}),
+              id: 'b',
+              updated_at: 4,
+              user_id: 1,
+            },
+            {
+              content: '{ "foo": "bar" }',
+              created_at: 5,
+              flash: JSON.stringify({ hello: 'world' }),
+              id: 'c',
+              updated_at: 6,
+              user_id: 2,
+            },
+            {
+              content: '{ "bar": "foo" }',
+              created_at: 7,
+              flash: JSON.stringify({}),
+              id: 'd',
+              updated_at: 8,
+              user_id: 2
+            }
+          ]);
+
+          await getRepository(DatabaseSession).save(sessions);
         });
 
-      });
+        it('should return an empty array if the user ID does not match any users.', async () => {
+          const user = { id: 0 };
+          const sessions = await store.getSessionIDsOf(user);
+          strictEqual(sessions.length, 0);
+        });
 
-    });
+        it('should return the IDs of the sessions associated with the given user.', async () => {
+          const user = { id: 2 };
+          const sessions = await store.getSessionIDsOf(user);
+          strictEqual(sessions.length, 2);
 
-    describe('has a "clear" method that', () => {
+          strictEqual(sessions[0], 'c');
+          strictEqual(sessions[1], 'd');
+        });
 
-      beforeEach(async () => {
-        const session = convertStateToDbSession(state);
-        await getRepository(DatabaseSession).save(session);
-      });
-
-      it('should remove all sessions.', async () => {
-        await store.clear();
-
-        strictEqual((await getRepository(DatabaseSession).find()).length, 0);
-      });
-
-    });
-
-    describe('has a "cleanUpExpiredSessions" method that', () => {
-
-      let maxLifeTime: number;
-
-      beforeEach(async () => {
-        maxInactivity = 10;
-        maxLifeTime = 20;
-
-        const now = Math.trunc(Date.now() / 1000);
-        const states: SessionState[] = [
-          {
-            ...createState(),
-            createdAt: now - 1,
-            id: 'xxx',
-            updatedAt: now - 1,
-          },
-          {
-            ...createState(),
-            createdAt: now,
-            id: 'yyy',
-            updatedAt: now - maxInactivity - 1,
-          },
-          {
-            ...createState(),
-            createdAt: now - maxLifeTime - 1,
-            id: 'zzz',
-            updatedAt: now,
-          },
-        ];
-
-        for (const state of states) {
-          const session = convertStateToDbSession(state);
-          await getRepository(DatabaseSession).save(session);
-        }
-      });
-
-      it('should not remove unexpired sessions.', async () => {
-        await store.cleanUpExpiredSessions(maxInactivity, maxLifeTime);
-
-        return doesNotReject(() => getRepository(DatabaseSession).findOneOrFail({ id: 'xxx' }));
-      });
-
-      it('should remove sessions expired due to inactivity.', async () => {
-        await store.cleanUpExpiredSessions(maxInactivity, maxLifeTime);
-
-        return rejects(() => getRepository(DatabaseSession).findOneOrFail({ id: 'yyy' }));
-      });
-
-      it('should remove sessions expired due to absolute end of life.', async () => {
-        await store.cleanUpExpiredSessions(maxInactivity, maxLifeTime);
-
-        return rejects(() => getRepository(DatabaseSession).findOneOrFail({ id: 'zzz' }));
-      });
-
-    });
-
-    describe('has a "getAuthenticatedUsers" method that', () => {
-
-      beforeEach(async () => {
-        const sessions = getRepository(DatabaseSession).create([
-          {
-            content: '{}',
-            created_at: 1,
-            flash: JSON.stringify({}),
-            id: 'a',
-            updated_at: 2,
-          },
-          {
-            content: '{}',
-            created_at: 3,
-            flash: JSON.stringify({}),
-            id: 'b',
-            updated_at: 4,
-            user_id: 1,
-          },
-          {
-            content: '{}',
-            created_at: 5,
-            flash: JSON.stringify({}),
-            id: 'c',
-            updated_at: 6,
-            user_id: 2,
-          },
-          {
-            content: '{}',
-            created_at: 7,
-            flash: JSON.stringify({}),
-            id: 'd',
-            updated_at: 8,
-            user_id: 2
-          }
-        ]);
-
-        await getRepository(DatabaseSession).save(sessions);
-      });
-
-      it('should return the IDs of the authenticated users (distinct).', async () => {
-        const sessions = await store.getAuthenticatedUserIds();
-        // No null or dupplicated values.
-        deepStrictEqual(sessions, [ 1, 2 ]);
-      });
-
-    });
-
-    describe('has a "destroyAllSessionsOf" method that', () => {
-
-      beforeEach(async () => {
-        const sessions = getRepository(DatabaseSession).create([
-          {
-            content: '{}',
-            created_at: 1,
-            flash: JSON.stringify({}),
-            id: 'a',
-            updated_at: 2,
-          },
-          {
-            content: '{}',
-            created_at: 3,
-            flash: JSON.stringify({}),
-            id: 'b',
-            updated_at: 4,
-            user_id: 1,
-          },
-          {
-            content: '{}',
-            created_at: 5,
-            flash: JSON.stringify({}),
-            id: 'c',
-            updated_at: 6,
-            user_id: 2,
-          },
-          {
-            content: '{}',
-            created_at: 7,
-            flash: JSON.stringify({}),
-            id: 'd',
-            updated_at: 8,
-            user_id: 2
-          }
-        ]);
-
-        await getRepository(DatabaseSession).save(sessions);
-      });
-
-      it('destroy all the sessions of the given user.', async () => {
-        const user = { id: 2 };
-        await store.destroyAllSessionsOf(user);
-
-        const sessions = await getRepository(DatabaseSession).find();
-        strictEqual(sessions.length, 2);
-        strictEqual(sessions[0].id, 'a');
-        strictEqual(sessions[1].id, 'b');
-      });
-
-    });
-
-    describe('has a "getSessionIDsOf" method that', () => {
-
-      beforeEach(async () => {
-        const sessions = getRepository(DatabaseSession).create([
-          {
-            content: '{}',
-            created_at: 1,
-            flash: JSON.stringify({}),
-            id: 'a',
-            updated_at: 2,
-          },
-          {
-            content: '{}',
-            created_at: 3,
-            flash: JSON.stringify({}),
-            id: 'b',
-            updated_at: 4,
-            user_id: 1,
-          },
-          {
-            content: '{ "foo": "bar" }',
-            created_at: 5,
-            flash: JSON.stringify({ hello: 'world' }),
-            id: 'c',
-            updated_at: 6,
-            user_id: 2,
-          },
-          {
-            content: '{ "bar": "foo" }',
-            created_at: 7,
-            flash: JSON.stringify({}),
-            id: 'd',
-            updated_at: 8,
-            user_id: 2
-          }
-        ]);
-
-        await getRepository(DatabaseSession).save(sessions);
-      });
-
-      it('should return an empty array if the user ID does not match any users.', async () => {
-        const user = { id: 0 };
-        const sessions = await store.getSessionIDsOf(user);
-        strictEqual(sessions.length, 0);
-      });
-
-      it('should return the IDs of the sessions associated with the given user.', async () => {
-        const user = { id: 2 };
-        const sessions = await store.getSessionIDsOf(user);
-        strictEqual(sessions.length, 2);
-
-        strictEqual(sessions[0], 'c');
-        strictEqual(sessions[1], 'd');
       });
 
     });

--- a/packages/typeorm/src/typeorm-store.service.ts
+++ b/packages/typeorm/src/typeorm-store.service.ts
@@ -39,17 +39,17 @@ export class DatabaseSession {
  */
 export class TypeORMStore extends SessionStore {
 
-  private connection: Connection;
+  private _connection: Connection;
 
   setConnection(connection: Connection) {
-    this.connection = connection;
+    this._connection = connection;
   }
 
-  boot() {
-    if (this.connection) {
-      return;
+  get connection(): Connection {
+    if (this._connection) {
+      return this._connection;
     }
-    this.connection = getConnection();
+    return getConnection();
   }
 
   async save(state: SessionState, maxInactivity: number): Promise<void> {


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Resolves issue described in #1017

It also avoids to have multiple connections to redis in the app if redis is used somewhere else.

# Solution and steps

- [x] Add a new `setRedisClient` method
- [x] Add a new `setMongoDBClient` method
- [x] Add a new `setConnection` method
- [x] Update the doc with its acceptance tests (specify redis version)

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
