### PR TITLE
Upgrade from `aws-sdk@2` to `@aws-sdk/client-s3@3`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       SETTINGS_AWS_ACCESS_KEY_ID: ${{ secrets.SETTINGS_AWS_ACCESS_KEY_ID }}
       SETTINGS_AWS_SECRET_ACCESS_KEY: ${{ secrets.SETTINGS_AWS_SECRET_ACCESS_KEY }}
+      SETTINGS_AWS_REGION: ${{ secrets.SETTINGS_AWS_REGION }}
       NODE_VERSION: ${{ matrix.node-version }}
 
     services:

--- a/docs/docs/file-system/local-and-cloud-storage.md
+++ b/docs/docs/file-system/local-and-cloud-storage.md
@@ -103,7 +103,9 @@ npm install @foal/aws-s3
 
 The bucket name is specified with the `settings.disk.s3.bucket` configuration key.
 
-AWS credentials are specified with the configuration keys `settings.aws.accessKeyId` and `settings.aws.secretAccessKey`  or using [AWS traditional techniques](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-shared.html).
+The region is specified with the `settings.aws.region` configuration key or using [AWS traditional technique](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-region.html).
+
+AWS credentials are specified with the configuration keys `settings.aws.accessKeyId` and `settings.aws.secretAccessKey`  or using [AWS traditional techniques](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-shared.html).
 
 <Tabs
   defaultValue="yaml"

--- a/docs/docs/file-system/local-and-cloud-storage.md
+++ b/docs/docs/file-system/local-and-cloud-storage.md
@@ -120,6 +120,7 @@ AWS credentials are specified with the configuration keys `settings.aws.accessKe
 ```yaml
 settings:
   aws:
+    region: zzz
     accessKeyId: xxx
     secretAccessKey: yyy
   disk:
@@ -135,6 +136,7 @@ settings:
 {
   "settings": {
     "aws": {
+      "region": "zzz",
       "accessKeyId": "xxx",
       "secretAccessKey": "yyy"
     },
@@ -155,6 +157,7 @@ settings:
 module.exports = {
   settings: {
     aws: {
+      region: "zzz",
       accessKeyId: "xxx",
       secretAccessKey: "yyy"
     },

--- a/packages/aws-s3/config/default.json
+++ b/packages/aws-s3/config/default.json
@@ -2,7 +2,8 @@
   "settings": {
     "aws": {
       "accessKeyId": "env(SETTINGS_AWS_ACCESS_KEY_ID)",
-      "secretAccessKey": "env(SETTINGS_AWS_SECRET_ACCESS_KEY)"
+      "secretAccessKey": "env(SETTINGS_AWS_SECRET_ACCESS_KEY)",
+      "region": "env(SETTINGS_AWS_REGION)"
     }
   }
 }

--- a/packages/aws-s3/package-lock.json
+++ b/packages/aws-s3/package-lock.json
@@ -481,6 +481,17 @@
 				"tslib": "^2.3.0"
 			}
 		},
+		"@aws-sdk/lib-storage": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.49.0.tgz",
+			"integrity": "sha512-3QIfre3IuAbRKBqqRC6hKQD0caVeP/X/+IlWl205o120MgVPIL8SW/sld6QcLRrrvNjzOT2npfn8i0oPYs8Q+w==",
+			"requires": {
+				"buffer": "5.6.0",
+				"events": "3.3.0",
+				"stream-browserify": "3.0.0",
+				"tslib": "^2.3.0"
+			}
+		},
 		"@aws-sdk/md5-js": {
 			"version": "3.49.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.49.0.tgz",
@@ -1046,6 +1057,11 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+		},
 		"binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1087,6 +1103,15 @@
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
+		},
+		"buffer": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+			"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+			"requires": {
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4"
+			}
 		},
 		"buffer-from": {
 			"version": "1.1.2",
@@ -1330,6 +1355,11 @@
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true
 		},
+		"events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+		},
 		"expand-tilde": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
@@ -1522,6 +1552,11 @@
 				"parse-passwd": "^1.0.0"
 			}
 		},
+		"ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1535,8 +1570,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.8",
@@ -2021,8 +2055,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"serialize-javascript": {
 			"version": "5.0.1",
@@ -2058,6 +2091,27 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"stream-browserify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+			"integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+			"requires": {
+				"inherits": "~2.0.4",
+				"readable-stream": "^3.5.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"string-width": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2072,7 +2126,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -2263,8 +2316,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"vinyl": {
 			"version": "1.2.0",

--- a/packages/aws-s3/package-lock.json
+++ b/packages/aws-s3/package-lock.json
@@ -4,6 +4,948 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@aws-crypto/crc32": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
+			"integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+			"requires": {
+				"@aws-crypto/util": "^2.0.0",
+				"@aws-sdk/types": "^3.1.0",
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@aws-crypto/ie11-detection": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+			"integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+			"requires": {
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@aws-crypto/sha256-browser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+			"integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+			"requires": {
+				"@aws-crypto/ie11-detection": "^2.0.0",
+				"@aws-crypto/sha256-js": "^2.0.0",
+				"@aws-crypto/supports-web-crypto": "^2.0.0",
+				"@aws-crypto/util": "^2.0.0",
+				"@aws-sdk/types": "^3.1.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@aws-crypto/sha256-js": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+			"integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+			"requires": {
+				"@aws-crypto/util": "^2.0.0",
+				"@aws-sdk/types": "^3.1.0",
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@aws-crypto/supports-web-crypto": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+			"integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+			"requires": {
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@aws-crypto/util": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+			"integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+			"requires": {
+				"@aws-sdk/types": "^3.1.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+				}
+			}
+		},
+		"@aws-sdk/abort-controller": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.49.0.tgz",
+			"integrity": "sha512-1qLlgOgg3yrtm+AJEP7yoIk90o6ns3Dia8S9DRjj29jY40446etH3v/tIbHPE+em69HLXl1K6e5KD6t7EDxnlg==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/chunked-blob-reader": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.49.0.tgz",
+			"integrity": "sha512-UI1rK4aBgwsQ6dOQs5Im1cNSb3c/RH1wKjD49zcwWyxe8e96C5G2LcshhVH3onWY5NgqQgs/ffEsXziGcNXRIg==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/chunked-blob-reader-native": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.49.0.tgz",
+			"integrity": "sha512-ppjmDWyufMB41Hmq5Gixd2+/c4kk2IPKKWT9zI9spKOYbbL/vY3FmRq4beQ6n5kWOzDPxKZ6wv04yrMS9yBy1A==",
+			"requires": {
+				"@aws-sdk/util-base64-browser": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/client-s3": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.49.0.tgz",
+			"integrity": "sha512-LidddhZFxYb/jlEtHnbBpqVZmjgZNKY/jaZy3jRNcVhw8L0m1IYVigqgw5E6ta9/dma5EwLOA8Z21O/rCuDapw==",
+			"requires": {
+				"@aws-crypto/sha256-browser": "2.0.0",
+				"@aws-crypto/sha256-js": "2.0.0",
+				"@aws-sdk/client-sts": "3.49.0",
+				"@aws-sdk/config-resolver": "3.49.0",
+				"@aws-sdk/credential-provider-node": "3.49.0",
+				"@aws-sdk/eventstream-serde-browser": "3.49.0",
+				"@aws-sdk/eventstream-serde-config-resolver": "3.49.0",
+				"@aws-sdk/eventstream-serde-node": "3.49.0",
+				"@aws-sdk/fetch-http-handler": "3.49.0",
+				"@aws-sdk/hash-blob-browser": "3.49.0",
+				"@aws-sdk/hash-node": "3.49.0",
+				"@aws-sdk/hash-stream-node": "3.49.0",
+				"@aws-sdk/invalid-dependency": "3.49.0",
+				"@aws-sdk/md5-js": "3.49.0",
+				"@aws-sdk/middleware-apply-body-checksum": "3.49.0",
+				"@aws-sdk/middleware-bucket-endpoint": "3.49.0",
+				"@aws-sdk/middleware-content-length": "3.49.0",
+				"@aws-sdk/middleware-expect-continue": "3.49.0",
+				"@aws-sdk/middleware-host-header": "3.49.0",
+				"@aws-sdk/middleware-location-constraint": "3.49.0",
+				"@aws-sdk/middleware-logger": "3.49.0",
+				"@aws-sdk/middleware-retry": "3.49.0",
+				"@aws-sdk/middleware-sdk-s3": "3.49.0",
+				"@aws-sdk/middleware-serde": "3.49.0",
+				"@aws-sdk/middleware-signing": "3.49.0",
+				"@aws-sdk/middleware-ssec": "3.49.0",
+				"@aws-sdk/middleware-stack": "3.49.0",
+				"@aws-sdk/middleware-user-agent": "3.49.0",
+				"@aws-sdk/node-config-provider": "3.49.0",
+				"@aws-sdk/node-http-handler": "3.49.0",
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/smithy-client": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/url-parser": "3.49.0",
+				"@aws-sdk/util-base64-browser": "3.49.0",
+				"@aws-sdk/util-base64-node": "3.49.0",
+				"@aws-sdk/util-body-length-browser": "3.49.0",
+				"@aws-sdk/util-body-length-node": "3.49.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.49.0",
+				"@aws-sdk/util-defaults-mode-node": "3.49.0",
+				"@aws-sdk/util-user-agent-browser": "3.49.0",
+				"@aws-sdk/util-user-agent-node": "3.49.0",
+				"@aws-sdk/util-utf8-browser": "3.49.0",
+				"@aws-sdk/util-utf8-node": "3.49.0",
+				"@aws-sdk/util-waiter": "3.49.0",
+				"@aws-sdk/xml-builder": "3.49.0",
+				"entities": "2.2.0",
+				"fast-xml-parser": "3.19.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/client-sso": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.49.0.tgz",
+			"integrity": "sha512-rY8uZo4DeNwwKf+Sx0TX/5ysXJKf+0SQSCTWD9S4a0AjtiaLc6hKCX+sJY43VDHvNYieKtXLDYHBdhhqZKwG+g==",
+			"requires": {
+				"@aws-crypto/sha256-browser": "2.0.0",
+				"@aws-crypto/sha256-js": "2.0.0",
+				"@aws-sdk/config-resolver": "3.49.0",
+				"@aws-sdk/fetch-http-handler": "3.49.0",
+				"@aws-sdk/hash-node": "3.49.0",
+				"@aws-sdk/invalid-dependency": "3.49.0",
+				"@aws-sdk/middleware-content-length": "3.49.0",
+				"@aws-sdk/middleware-host-header": "3.49.0",
+				"@aws-sdk/middleware-logger": "3.49.0",
+				"@aws-sdk/middleware-retry": "3.49.0",
+				"@aws-sdk/middleware-serde": "3.49.0",
+				"@aws-sdk/middleware-stack": "3.49.0",
+				"@aws-sdk/middleware-user-agent": "3.49.0",
+				"@aws-sdk/node-config-provider": "3.49.0",
+				"@aws-sdk/node-http-handler": "3.49.0",
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/smithy-client": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/url-parser": "3.49.0",
+				"@aws-sdk/util-base64-browser": "3.49.0",
+				"@aws-sdk/util-base64-node": "3.49.0",
+				"@aws-sdk/util-body-length-browser": "3.49.0",
+				"@aws-sdk/util-body-length-node": "3.49.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.49.0",
+				"@aws-sdk/util-defaults-mode-node": "3.49.0",
+				"@aws-sdk/util-user-agent-browser": "3.49.0",
+				"@aws-sdk/util-user-agent-node": "3.49.0",
+				"@aws-sdk/util-utf8-browser": "3.49.0",
+				"@aws-sdk/util-utf8-node": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/client-sts": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.49.0.tgz",
+			"integrity": "sha512-vqHNCuQriMZV1aeXc6cza5S9A/2zgfNiTelsmbDQdlCiZQ+YL3nTp1WFeYHap4ffYlLOAD0xv0yz/+naV4oHtQ==",
+			"requires": {
+				"@aws-crypto/sha256-browser": "2.0.0",
+				"@aws-crypto/sha256-js": "2.0.0",
+				"@aws-sdk/config-resolver": "3.49.0",
+				"@aws-sdk/credential-provider-node": "3.49.0",
+				"@aws-sdk/fetch-http-handler": "3.49.0",
+				"@aws-sdk/hash-node": "3.49.0",
+				"@aws-sdk/invalid-dependency": "3.49.0",
+				"@aws-sdk/middleware-content-length": "3.49.0",
+				"@aws-sdk/middleware-host-header": "3.49.0",
+				"@aws-sdk/middleware-logger": "3.49.0",
+				"@aws-sdk/middleware-retry": "3.49.0",
+				"@aws-sdk/middleware-sdk-sts": "3.49.0",
+				"@aws-sdk/middleware-serde": "3.49.0",
+				"@aws-sdk/middleware-signing": "3.49.0",
+				"@aws-sdk/middleware-stack": "3.49.0",
+				"@aws-sdk/middleware-user-agent": "3.49.0",
+				"@aws-sdk/node-config-provider": "3.49.0",
+				"@aws-sdk/node-http-handler": "3.49.0",
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/smithy-client": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/url-parser": "3.49.0",
+				"@aws-sdk/util-base64-browser": "3.49.0",
+				"@aws-sdk/util-base64-node": "3.49.0",
+				"@aws-sdk/util-body-length-browser": "3.49.0",
+				"@aws-sdk/util-body-length-node": "3.49.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.49.0",
+				"@aws-sdk/util-defaults-mode-node": "3.49.0",
+				"@aws-sdk/util-user-agent-browser": "3.49.0",
+				"@aws-sdk/util-user-agent-node": "3.49.0",
+				"@aws-sdk/util-utf8-browser": "3.49.0",
+				"@aws-sdk/util-utf8-node": "3.49.0",
+				"entities": "2.2.0",
+				"fast-xml-parser": "3.19.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/config-resolver": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.49.0.tgz",
+			"integrity": "sha512-4kYV+89E9MG+/wfPY3dmwqzquQxNd951jdfjQbSg1ii68X/owqmWda4bLulV0Z4iGUz9TXkbaJCWyRyjsFNe4w==",
+			"requires": {
+				"@aws-sdk/signature-v4": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-config-provider": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/credential-provider-env": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.49.0.tgz",
+			"integrity": "sha512-mx82N0un6URmmiM11X3ObK3ka5R99lEFdhwPc0jqsCPnXRVioUtK5DXkJ8FmgixbDcs5Pdij9A8MINSeBrG0bQ==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/credential-provider-imds": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.49.0.tgz",
+			"integrity": "sha512-d/H5VgmRiIupQdPg9QcX16kdvuiS/YytRYCQOncVstNXHvYZM9EgeIXJLXyPNaD2W8SS7CBf4KKWYJn3V+9AZw==",
+			"requires": {
+				"@aws-sdk/node-config-provider": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/url-parser": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/credential-provider-ini": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.49.0.tgz",
+			"integrity": "sha512-QlWfxDwZVyX36pghgkKGBR+fBmX/mjmvc0kzxUmqGhUYAkDQ0YKR11ybpGBrxBKT4lIOE+9z6Tu4nLjp3OlJIg==",
+			"requires": {
+				"@aws-sdk/credential-provider-env": "3.49.0",
+				"@aws-sdk/credential-provider-imds": "3.49.0",
+				"@aws-sdk/credential-provider-sso": "3.49.0",
+				"@aws-sdk/credential-provider-web-identity": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-credentials": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/credential-provider-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.49.0.tgz",
+			"integrity": "sha512-DonoqOZHcqfNuwMG1fGJpHJTqf1QinihRKzlOoUWzmseqBCiuagGouSN7nOQgee5BrzF0X9/nao9lnPc4on2TA==",
+			"requires": {
+				"@aws-sdk/credential-provider-env": "3.49.0",
+				"@aws-sdk/credential-provider-imds": "3.49.0",
+				"@aws-sdk/credential-provider-ini": "3.49.0",
+				"@aws-sdk/credential-provider-process": "3.49.0",
+				"@aws-sdk/credential-provider-sso": "3.49.0",
+				"@aws-sdk/credential-provider-web-identity": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-credentials": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/credential-provider-process": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.49.0.tgz",
+			"integrity": "sha512-Zn7CJHoXln8O+yBKdTBvcwCz6GDh48s7HtIsqjoOrqoL0oZWhgy8gn8S9KQ+HIqpiO8N0lMMteXuPl5fbC2zGg==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-credentials": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/credential-provider-sso": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.49.0.tgz",
+			"integrity": "sha512-sFTqbQOyGR88K10Y1OgauEPKDmEibxtAkLSFjkJ6Yw/Jyp+lftchoa+TxRrNvDY1zjZX+XauVI6UmD5Pi4E1NQ==",
+			"requires": {
+				"@aws-sdk/client-sso": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-credentials": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/credential-provider-web-identity": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.49.0.tgz",
+			"integrity": "sha512-mlIHUTn04unB0HEwEO12YIY5848uE9B+gYI+YwlNZ70KXGs3lj2horOgPgbxeIfulCVw0aRTKChUg2ActTosYg==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/eventstream-marshaller": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.49.0.tgz",
+			"integrity": "sha512-EDE7aim4c/G9vCWE+jaHQNWHzrHgF1WlUEok1tgLj+fbvqKduDK/1SNleMZbMLC7tFRARN+KKFB0Ctegyp8j4w==",
+			"requires": {
+				"@aws-crypto/crc32": "2.0.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-hex-encoding": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/eventstream-serde-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.49.0.tgz",
+			"integrity": "sha512-XHDHVGmxzEEXzHESzXYiycE3CxHLedBQljQPCIXKJkUhmwf84oUDB/cRsgWoOwOpcRQQBZGUPTPOOOHVWQOlZA==",
+			"requires": {
+				"@aws-sdk/eventstream-marshaller": "3.49.0",
+				"@aws-sdk/eventstream-serde-universal": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/eventstream-serde-config-resolver": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.49.0.tgz",
+			"integrity": "sha512-7xCaQGfZD0xLpWVUsGEQ2PDAkkfnl1gc10h4jLm0xtEGzr0x3B3fLrmDiZTz+wBxRRuCqjiaBaNuPT+HocGYmA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/eventstream-serde-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.49.0.tgz",
+			"integrity": "sha512-hRZa1QSCtSve3vSgOxtGRn7nlOJFGzaov6hDj+bFEWY6ukHWtG9lbit6ECALcud4BjxvaJet37kqToxnpDFMuQ==",
+			"requires": {
+				"@aws-sdk/eventstream-marshaller": "3.49.0",
+				"@aws-sdk/eventstream-serde-universal": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/eventstream-serde-universal": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.49.0.tgz",
+			"integrity": "sha512-oW/k0QdJTEwRLbdWpakIKABYKEOokBaPd+VSOYmCNceYPzv74RTDqlzTTRVIGj51Jp+Bm1af3l0k1cpjPDnWfQ==",
+			"requires": {
+				"@aws-sdk/eventstream-marshaller": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/fetch-http-handler": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.49.0.tgz",
+			"integrity": "sha512-ougJRsvoIGP0qTgHSGVF1B5Ui95Y/SP5CpY/y6B8vMGrwJ+MmvcCUE3Qd2UJGjO1PfUneno8PHK4u5x7hc2ceA==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/querystring-builder": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-base64-browser": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/hash-blob-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.49.0.tgz",
+			"integrity": "sha512-DLLP8dY0eYAXefJJzAYO1QxHW567MN4D2KDxyOKkWOVR2S6ZLgtJb24MhT9RpV3AOM/x686HOv5V4r1rPbuHhw==",
+			"requires": {
+				"@aws-sdk/chunked-blob-reader": "3.49.0",
+				"@aws-sdk/chunked-blob-reader-native": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/hash-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.49.0.tgz",
+			"integrity": "sha512-nRNCmSkcJOzWzKU6NihlKW/6H1HxaaBjUe9ETnwWIgwPC7NZ6IWtri48Cf7Itvveu3dln3ZM2WSXN20TlQpuBw==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-buffer-from": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/hash-stream-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.49.0.tgz",
+			"integrity": "sha512-ZsqGEs3yp5YH5vk1LhpIiSAzNzXHW89DvKn+BSSiDPdufPdOjLks8wKIVhAUfADcJ+S/AATTAt4SoA4mD+IHvQ==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/invalid-dependency": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.49.0.tgz",
+			"integrity": "sha512-MXf/9l/Oiy+KGKDvInv0RT4rtS+iNftYRTlTmUn3RR74Kz8Fvw+O0RcUjzSrNn5SpjCf/UsGrF+KBTm2gFYQCA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/is-array-buffer": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.49.0.tgz",
+			"integrity": "sha512-tLba+xvlm1+aAnv+bGieVZo8DCENbqfS9kLf/hp+9hrUSiNAsxs9Pqi34JBpMKGn6h9qORp6f8ClRS+gK8yvWg==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/md5-js": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.49.0.tgz",
+			"integrity": "sha512-CJJxl7FfTNseaw3RAPmihpys1cfbCyg7sLTev6PncqBhoVl+5AWOoITeZj3azE3CKevY2V7PEdmHjzKRNLmcdA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-utf8-browser": "3.49.0",
+				"@aws-sdk/util-utf8-node": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-apply-body-checksum": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.49.0.tgz",
+			"integrity": "sha512-uNUETgYrOLCZNad+vVsTblTqzuaCVCt67o4VawsziR5QuOCxX/27Ni3x1VNtpI5pUhD8FiT/9/lBpcMTvCSIgA==",
+			"requires": {
+				"@aws-sdk/is-array-buffer": "3.49.0",
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-bucket-endpoint": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.49.0.tgz",
+			"integrity": "sha512-6GK6BXNRRe+JpBUomW1Wrj7HGU3gdl9XvrQekj772kmiBLx/40ntAxZnhjFjkNKLy7IM+he8yygnEUhbV/dEmg==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-arn-parser": "3.49.0",
+				"@aws-sdk/util-config-provider": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-content-length": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.49.0.tgz",
+			"integrity": "sha512-7IaghPT7X92gNoyn9LzZj4V5YpGPDCYQTWhpzZoIlw88vOR4I0zKg7jwYeElRoNfRCI4OYhF26ajKnNHzNMlbA==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-expect-continue": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.49.0.tgz",
+			"integrity": "sha512-i0FMywhvCdn3+gPuUgtM0ZRd3xBHozropbhvs3fu9Y6g1/YiOgTYuVVqHtObvktVWCV72i8fTvn8TEkyFHRDYQ==",
+			"requires": {
+				"@aws-sdk/middleware-header-default": "3.49.0",
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-header-default": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.49.0.tgz",
+			"integrity": "sha512-3xRNPwFMWQqgGKgxDWMgQXNdIr4EVq5ltrLqwsZopXKZli9/fidOrDN9z9j4AW9YAXyEAYB0fscKT7LcsvxFZg==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-host-header": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.49.0.tgz",
+			"integrity": "sha512-5l1ILqHs2mGqNvJb5mRe7hHbTQOO292jghE/LItpNx2tiu7BBGzP1bslHcyEVYoRBX9Oqyfou7s9Ww2yBWtImQ==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-location-constraint": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.49.0.tgz",
+			"integrity": "sha512-PUQr06/9XQP0JfUY6nFvK5HHcO4aQbzn/iKvB8dl471IXcKVLnJdB2OuIjUUW6fQbKX1K4xcDEifWTSMIECIlg==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-logger": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.49.0.tgz",
+			"integrity": "sha512-OicQ0w5sCJXgpeZ+t3XeJA2R/09YfuSe53Ma6aWZm/2/r8vG/SW0yAnwFvwJeCm3DKtBxU1qO2eWhFqvJuWRVA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-retry": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.49.0.tgz",
+			"integrity": "sha512-RSS4R4PNULHA1b1eYR50YPPfOV2jRuXgLNLVVYMEzzC23MabKEXJYPge+pI1Q9rRrbahVj7aQcOTSpT0MsiEeA==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/service-error-classification": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0",
+				"uuid": "^8.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+				}
+			}
+		},
+		"@aws-sdk/middleware-sdk-s3": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.49.0.tgz",
+			"integrity": "sha512-PeQHJsecGCnXILgOPLgcoZXCa4+2bctus2krhN08ES5oh1obeQB+EOC4v1sWV0DdfyTHEZMDSVLS9qTFHl9IUA==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/signature-v4": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-arn-parser": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-sdk-sts": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.49.0.tgz",
+			"integrity": "sha512-ZnLV37HKpMdK2x+69ZNqAqKr8rmweyMc//yZQRLtUKpKyQ/XSr0/KUBZXkgIny27aaBsrkplA5g1X2GrClRRZA==",
+			"requires": {
+				"@aws-sdk/middleware-signing": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/signature-v4": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-serde": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.49.0.tgz",
+			"integrity": "sha512-bMAlwR19uFUZ4om+U+/vnPvkcyYw83HdtERF9wrjAqNUnqYsifA0xn4R7Sakg6CW8V0h82dsST6zVfmHd+E2VA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-signing": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.49.0.tgz",
+			"integrity": "sha512-9p0xZjxV9zEQdOpA4MtzmblPRUgchevg5Q70E23yAU/Wjwzwf/6J93cUxdcS8HnmOIl0zQjJaYMTcBsvgJF1eg==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/signature-v4": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-ssec": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.49.0.tgz",
+			"integrity": "sha512-S7hfgOCYoqPe4YegSnwhQJ0KBVEhP6dIp7yLa1/yCJkqW2KSnLTvg6ao9vEFf/lhctZ72YZjm8v/2siXWCnDEA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-stack": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.49.0.tgz",
+			"integrity": "sha512-OZxs2P7EH58gkvkTI7ESlUPGam0TkE0ZxOX35KjCOcYMuWvTMshKBzHRLX64nz3DYdaHSIGHgB1v8LKELZjltw==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/middleware-user-agent": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.49.0.tgz",
+			"integrity": "sha512-uAcKgafZ12L8UnyeQGgSFtwOKUfiBWDLt4P2fEHvZRz/HAIcK4pu1PXPArjwteinhUiCDNFfPw8hAPvstMoG6w==",
+			"requires": {
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/node-config-provider": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.49.0.tgz",
+			"integrity": "sha512-OCn5c6M/RJDEO80Q+Iy4ADSYgqd/uyEsvp+7lU4di4bMND9kYT4JO2ky2SWjIuARGq/mhMOhaN2DO9MbcqV20g==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/node-http-handler": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.49.0.tgz",
+			"integrity": "sha512-t7D9hoSigBihC9RRgYrkzgSER0fYzZe7192pJAaP6jk13ZOpccQRfXZoKge/cm42aHJsTy8DdQdGtLg7wLTp0g==",
+			"requires": {
+				"@aws-sdk/abort-controller": "3.49.0",
+				"@aws-sdk/protocol-http": "3.49.0",
+				"@aws-sdk/querystring-builder": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/property-provider": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.49.0.tgz",
+			"integrity": "sha512-6D48YpriOUpniezVuRI8J+MG+vgwb5C1SzBdgN4+S6DqbsEZy+kdEubXdoMICEd+Z8h7lH3p5zMr6po0icGCfA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/protocol-http": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.49.0.tgz",
+			"integrity": "sha512-lb9CO7/vm26v4UwveWb4jSapqWWP/p0b9SuHpRExq+yMuvHqwxcoGrxmvS7FsanWbepRF1895dxU/Ar6/4pviA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/querystring-builder": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.49.0.tgz",
+			"integrity": "sha512-+NlgIYihVyUetZcrF1ADY0eg8WW1/ETD5bzTwguTiKduXVHmavSakXK1jJF5vg05mefljToZXjQnOaEs9+K9LA==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-uri-escape": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/querystring-parser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.49.0.tgz",
+			"integrity": "sha512-4bSCHI5A8wi+JjsD1gAhMuGRGjDmlw6MoMWUiv4R2J8Ow/9mV8biKRo2ZytUPiSSu4G5JQ7mEkqFsm/VgkstDQ==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/service-error-classification": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.49.0.tgz",
+			"integrity": "sha512-iVmf7RcrIsM/We5ip8fe14RzEpSLF5eN8oqhCMftEdmMVnOYMd/9x0f1w69fbyBJNIIpyREqM8eAKz5OWQn5/g=="
+		},
+		"@aws-sdk/shared-ini-file-loader": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.49.0.tgz",
+			"integrity": "sha512-TcgKU6U/3JZpenRFhGSy5R5QsBWkYoeawTK1rTK6deu3UbxVwtOkietbfwP3kIwKZ4hz6OkNeHcOJtXX/InZKw==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/signature-v4": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.49.0.tgz",
+			"integrity": "sha512-mQSGclWmv/9/MsgthBuKMHN6nkkhGTLXspkhqJ9xSUhjhoaHQVwMoJc39PowJGbYFn1AtCvHAqJtFXTGsMRwPA==",
+			"requires": {
+				"@aws-sdk/is-array-buffer": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"@aws-sdk/util-hex-encoding": "3.49.0",
+				"@aws-sdk/util-uri-escape": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/smithy-client": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.49.0.tgz",
+			"integrity": "sha512-ANh9SlEvuru1DcalVoQ7K6wSCYuw4jyeTsIDsJSa13ckrmXAg+ql9vq61ELAXTSNVmuAISuuPjbVaWvOYCtdCQ==",
+			"requires": {
+				"@aws-sdk/middleware-stack": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/types": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.49.0.tgz",
+			"integrity": "sha512-8bCqEpquTlPN6xkjaJ+s+RoEFIu5r4G8oXOsQ5HYBvBdpx62HnCqzHLFNHycL2b8sE+VysQgNvmdQYR98vdMGQ=="
+		},
+		"@aws-sdk/url-parser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.49.0.tgz",
+			"integrity": "sha512-l5td6eu+sIjzNsZYVGr7Mz6vssf2j/8/QrrTYF76J2R6OoceCsKdyJgJPP/tXBdcp4HUZDdVcMqtWRbxGC4izQ==",
+			"requires": {
+				"@aws-sdk/querystring-parser": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-arn-parser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.49.0.tgz",
+			"integrity": "sha512-mAF4lzxqMUFMQAf+NQSxW7jC5hYXNM7mPItBFs/yI3F25MXBw88Q+wAof7iIyRnRcpJvgZ3I7P8vJriAwrSbFg==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-base64-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.49.0.tgz",
+			"integrity": "sha512-HFXJbsJC6AfrnO9M8KuFDo4ihvLbCbCFCfpWy0Gs4t8kTcvGqH8fIpfVsQKAtFHMmb8fen2LduOk+NNSA7srYw==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-base64-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.49.0.tgz",
+			"integrity": "sha512-xFAzOLZJOEZipG3KVLjB5z1g5PJSi6cmZOGWg2NC2/H5N0/Z+e5ObnIH8mpfO1d6kWchUuo3qJ6fTOvg/ynw7A==",
+			"requires": {
+				"@aws-sdk/util-buffer-from": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-body-length-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.49.0.tgz",
+			"integrity": "sha512-4a9Bw33JGKefaZDORlosQRMKxJGEYEiDD5kgNvwIv+KRl5yj2unePia6aFWMqXTWqidOb9WVlqc0Lh73ei5pTg==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-body-length-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.49.0.tgz",
+			"integrity": "sha512-ME5Sc8jo9BzToUjWskQKZM/NqN9PpwRDTOSH6EISDBUiH5bhWfY8MLkZqIN2UZz/XOiV3yOeWAU+fMYNnGdAQQ==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-buffer-from": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.49.0.tgz",
+			"integrity": "sha512-8JbIPYn91f+16QpDk000PdIBlBZu8/SoL1nF2fpAJ+M98jXpKUws3oiCztJ2FPIKRe/3ikKuZM4HxWrDyJa40Q==",
+			"requires": {
+				"@aws-sdk/is-array-buffer": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-config-provider": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.49.0.tgz",
+			"integrity": "sha512-oVGT9q9UIGdv9Cra4B51QNciWKYQXTlfh8oD2FgLp91NbGTIkQLvK7Pah4TbBoa5+0u/obBI07UwCVn7wphWBQ==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-credentials": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.49.0.tgz",
+			"integrity": "sha512-RzbKeuylb56m0zPuLGl5/TkN07+c4PKhZu3hikpsvN8n8n7aFHWPUus63QEGgVaUMCZD0QV6HqJfsCVVFF7UIg==",
+			"requires": {
+				"@aws-sdk/shared-ini-file-loader": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-defaults-mode-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.49.0.tgz",
+			"integrity": "sha512-MNOvFET5TNBHgvsmfcLuxVDDUV0OIjE1lxrdbXWol7bMgLc2uL3/QOXWKCOUzcFCqTOnWCvbnwkOjs3f7Dpzmw==",
+			"requires": {
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-defaults-mode-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.49.0.tgz",
+			"integrity": "sha512-bd5/ZJlNIX25n83mvcCh9eYQiDdf6gLHNH6ZftA/EbFfkE0o/qHrFhBhiB9HBY9ZoHhtoqrJNv5W9qKFHx1EIA==",
+			"requires": {
+				"@aws-sdk/config-resolver": "3.49.0",
+				"@aws-sdk/credential-provider-imds": "3.49.0",
+				"@aws-sdk/node-config-provider": "3.49.0",
+				"@aws-sdk/property-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-hex-encoding": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.49.0.tgz",
+			"integrity": "sha512-ZbPu8Dd3Qm0BMP71FWUH7KPpZA/6izfkDlxbvHxtHdW7XYZALuJ0cVRpWGIY2fCSuA9X8Jfn60KMyjuSAuzM1w==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-locate-window": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.49.0.tgz",
+			"integrity": "sha512-ryw+t+quF1raaK0nXSplMiCVnahNLNgNDijZCFFkddGTMaCy+L4VRLYyNms3bgwt3G0BmVn9f3uyDWRSkn5sSg==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-uri-escape": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.49.0.tgz",
+			"integrity": "sha512-NH7iQUYvijYZEOzZkF/QQrp8kBOA9H0Z89hR/63FDCjr1M0Cdcs1bLaFO0a0qbW9NQtoYNsMBMk7pTveDrAzTw==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-user-agent-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.49.0.tgz",
+			"integrity": "sha512-RR4E6WlDSu9SivPjx/Jddo87PeVg6dhRL0XGdDBpew7i8bfwqCvxQydkbWIetxucLrt9zII9QnLDQUPBue1xUw==",
+			"requires": {
+				"@aws-sdk/types": "3.49.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-user-agent-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.49.0.tgz",
+			"integrity": "sha512-ixUkF6kcDfsWO0kivyOKAnBITJm7InGa04ALbgAfuuE7RU1cVkXVMFIn5vux7QkziK7+JwozM9SNPIwNukElDw==",
+			"requires": {
+				"@aws-sdk/node-config-provider": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-utf8-browser": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.49.0.tgz",
+			"integrity": "sha512-u9ZgAiTWX9yZFQ/ptlnVpYJ/rXF7aE2Wagar1IjhZrnxXbpVJvcX1EeRayxI1P5AAp2y2fiEKHZzX9ugTwOcEg==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-utf8-node": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.49.0.tgz",
+			"integrity": "sha512-QTF5b5OT2y6xsQl8sDiiXqg2n/VtgqFA+tP3WMooOSFd/ZFBbT6HoiSHXHMeTjpB/L9ZT+eUaCoBz8Jq09lBDg==",
+			"requires": {
+				"@aws-sdk/util-buffer-from": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/util-waiter": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.49.0.tgz",
+			"integrity": "sha512-eKrKOLcIhjA/MyjIfwgLL6ZUfGYf6VxBXryuRf8CmJKAo71ZO6ipAsy1X3uYrfwQQBMKV4VZu48BJx5PUBM7GA==",
+			"requires": {
+				"@aws-sdk/abort-controller": "3.49.0",
+				"@aws-sdk/types": "3.49.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"@aws-sdk/xml-builder": {
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.49.0.tgz",
+			"integrity": "sha512-eU5sIZRWq8pNmw++RfpFI8396UtDW8JxYLcKfJLGQC/qDhwCo+sNPKydXFmDrXTIt/khs3K0qx/vZ5V76irc2Q==",
+			"requires": {
+				"tslib": "^2.3.0"
+			}
+		},
 		"@types/mocha": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
@@ -98,32 +1040,11 @@
 			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
 			"dev": true
 		},
-		"aws-sdk": {
-			"version": "2.834.0",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.834.0.tgz",
-			"integrity": "sha512-9WRULrn4qAmgXI+tEW/IG5s/6ixJGZqjPOrmJsFZQev7/WRkxAZmJAjcwd4Ifm/jsJbXx2FSwO76gOPEvu2LqA==",
-			"requires": {
-				"buffer": "4.9.2",
-				"events": "1.1.1",
-				"ieee754": "1.1.13",
-				"jmespath": "0.15.0",
-				"querystring": "0.2.0",
-				"sax": "1.2.1",
-				"url": "0.10.3",
-				"uuid": "3.3.2",
-				"xml2js": "0.4.19"
-			}
-		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
-		},
-		"base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 		},
 		"binary-extensions": {
 			"version": "2.2.0",
@@ -136,6 +1057,11 @@
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
 			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
 			"dev": true
+		},
+		"bowser": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -161,16 +1087,6 @@
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
-		},
-		"buffer": {
-			"version": "4.9.2",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-			"integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4",
-				"isarray": "^1.0.0"
-			}
 		},
 		"buffer-from": {
 			"version": "1.1.2",
@@ -397,6 +1313,11 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"dev": true
 		},
+		"entities": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+		},
 		"escalade": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -408,11 +1329,6 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true
-		},
-		"events": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
 		},
 		"expand-tilde": {
 			"version": "1.2.2",
@@ -431,6 +1347,11 @@
 			"requires": {
 				"is-extendable": "^0.1.0"
 			}
+		},
+		"fast-xml-parser": {
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+			"integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
 		},
 		"file-contents": {
 			"version": "0.3.2",
@@ -600,11 +1521,6 @@
 			"requires": {
 				"parse-passwd": "^1.0.0"
 			}
-		},
-		"ieee754": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -782,7 +1698,8 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -798,11 +1715,6 @@
 			"requires": {
 				"isarray": "1.0.0"
 			}
-		},
-		"jmespath": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
 		},
 		"js-yaml": {
 			"version": "4.0.0",
@@ -1042,16 +1954,6 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
 		},
-		"punycode": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-			"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-		},
-		"querystring": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-		},
 		"randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -1121,11 +2023,6 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true
-		},
-		"sax": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-			"integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
 		},
 		"serialize-javascript": {
 			"version": "5.0.1",
@@ -1346,6 +2243,11 @@
 				}
 			}
 		},
+		"tslib": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+		},
 		"typescript": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
@@ -1358,25 +2260,11 @@
 			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
 			"dev": true
 		},
-		"url": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-			"integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-			"requires": {
-				"punycode": "1.3.2",
-				"querystring": "0.2.0"
-			}
-		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true
-		},
-		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"vinyl": {
 			"version": "1.2.0",
@@ -1463,20 +2351,6 @@
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true
-		},
-		"xml2js": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-			"requires": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "~9.0.1"
-			}
-		},
-		"xmlbuilder": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/packages/aws-s3/package.json
+++ b/packages/aws-s3/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@foal/core": "^2.7.2",
     "@foal/storage": "^2.7.2",
-    "aws-sdk": "~2.834.0"
+    "@aws-sdk/client-s3": "~3.49.0"
   },
   "devDependencies": {
     "@types/mocha": "7.0.2",

--- a/packages/aws-s3/package.json
+++ b/packages/aws-s3/package.json
@@ -43,9 +43,10 @@
     "lib/"
   ],
   "dependencies": {
+    "@aws-sdk/client-s3": "~3.49.0",
+    "@aws-sdk/lib-storage": "~3.49.0",
     "@foal/core": "^2.7.2",
-    "@foal/storage": "^2.7.2",
-    "@aws-sdk/client-s3": "~3.49.0"
+    "@foal/storage": "^2.7.2"
   },
   "devDependencies": {
     "@types/mocha": "7.0.2",

--- a/packages/aws-s3/src/s3-disk.service.spec.ts
+++ b/packages/aws-s3/src/s3-disk.service.spec.ts
@@ -5,7 +5,7 @@ import { Readable } from 'stream';
 // 3p
 import { Config, ConfigNotFoundError, ConfigTypeError, createService, streamToBuffer } from '@foal/core';
 import { FileDoesNotExist } from '@foal/storage';
-import * as S3 from 'aws-sdk/clients/s3';
+import { S3 } from '@aws-sdk/client-s3';
 
 // FoalTS
 import { S3Disk } from './s3-disk.service';
@@ -16,7 +16,7 @@ const bucketName = `foal-test-${process.env.NODE_VERSION || 10}`;
 async function rmObjectsIfExist(s3: S3) {
   const response = await s3.listObjects({
     Bucket: bucketName
-  }).promise();
+  });
 
   const objects: { Key: string }[] = [];
   for (const { Key } of response.Contents || []) {
@@ -35,7 +35,7 @@ async function rmObjectsIfExist(s3: S3) {
       Objects: objects,
       Quiet: false
     }
-  }).promise();
+  });
 }
 
 describe('S3Disk', () => {
@@ -44,17 +44,21 @@ describe('S3Disk', () => {
   let s3: S3;
 
   const accessKeyId = Config.get('settings.aws.accessKeyId', 'string');
-  const secretAccessKey = Config.get('settings.aws.secretAccessKey', 'string');
 
   if (!accessKeyId) {
     console.warn('SETTINGS_AWS_ACCESS_KEY_ID not defined. Skipping S3Disk tests...');
     return;
   }
 
+  const secretAccessKey = Config.getOrThrow('settings.aws.secretAccessKey', 'string');
+  const region = Config.getOrThrow('settings.aws.region', 'string');
+
   before(() => s3 = new S3({
-    accessKeyId,
-    apiVersion: '2006-03-01',
-    secretAccessKey,
+    region,
+    credentials: {
+      accessKeyId,
+      secretAccessKey,
+    },
   }));
 
   beforeEach(() => {
@@ -74,14 +78,10 @@ describe('S3Disk', () => {
     // This test assumes that the "delete" method tries at least to connect to AWS.
     Config.set('settings.aws.endpoint', 'foobar');
 
-    try {
-      await disk.delete('foo/test.txt');
-      throw new Error('An error should have been thrown.');
-    } catch (error: any) {
-      if (error.code !== 'NetworkingError' && error.code !== 'UnknownEndpoint') {
-        throw new Error(`Invalid error code: ${error.code}`);
-      }
-    }
+    await rejects(
+      () => disk.delete('foo/test.txt'),
+      (error: any) => error.code === 'ERR_INVALID_URL',
+    );
   });
 
   describe('has a "write" method that', () => {
@@ -104,12 +104,11 @@ describe('S3Disk', () => {
     it('should write the file at the given path (buffer) (name given).', async () => {
       await disk.write('foo', Buffer.from('hello', 'utf8'), { name: 'test.txt' });
 
-      const response = await s3.getObject({ Bucket: bucketName, Key: 'foo/test.txt' }).promise();
-      if (!(response.Body instanceof Buffer)) {
-        throw new Error('response.Body should be a buffer');
-      }
+      const response = await s3.getObject({ Bucket: bucketName, Key: 'foo/test.txt' });
+      const buffer = await streamToBuffer(response.Body as Readable);
+
       strictEqual(
-        response.Body.toString('utf8'),
+        buffer.toString('utf8'),
         'hello'
       );
     });
@@ -120,12 +119,11 @@ describe('S3Disk', () => {
       stream.push(null);
       await disk.write('foo', stream, { name: 'test.txt' });
 
-      const response = await s3.getObject({ Bucket: bucketName, Key: 'foo/test.txt' }).promise();
-      if (!(response.Body instanceof Buffer)) {
-        throw new Error('response.Body should be a buffer');
-      }
+      const response = await s3.getObject({ Bucket: bucketName, Key: 'foo/test.txt' });
+      const buffer = await streamToBuffer(response.Body as Readable);
+
       strictEqual(
-        response.Body.toString('utf8'),
+        buffer.toString('utf8'),
         'hello'
       );
     });
@@ -162,7 +160,7 @@ describe('S3Disk', () => {
 
       await disk.write('foo', Buffer.from('hello', 'utf8'), { name: 'test.txt' });
 
-      const { ServerSideEncryption } = await s3.getObject({ Bucket: bucketName, Key: 'foo/test.txt' }).promise();
+      const { ServerSideEncryption } = await s3.getObject({ Bucket: bucketName, Key: 'foo/test.txt' });
 
       strictEqual(ServerSideEncryption, 'AES256');
     });
@@ -191,7 +189,7 @@ describe('S3Disk', () => {
         Body: 'hello',
         Bucket: bucketName,
         Key: 'foo/test.txt',
-      }).promise();
+      });
 
       const { file } = await disk.read('foo/test.txt', 'buffer');
       strictEqual(file.toString('utf8'), 'hello');
@@ -202,7 +200,7 @@ describe('S3Disk', () => {
         Body: 'hello',
         Bucket: bucketName,
         Key: 'foo/test.txt',
-      }).promise();
+      });
 
       const { file } = await disk.read('foo/test.txt', 'stream');
       const buffer = await streamToBuffer(file);
@@ -238,7 +236,7 @@ describe('S3Disk', () => {
         Body: Buffer.from('hello', 'utf8'),
         Bucket: bucketName,
         Key: 'foo/test.txt',
-      }).promise();
+      });
 
       const { size } = await disk.read('foo/test.txt', 'buffer');
       strictEqual(size, 5);
@@ -249,7 +247,7 @@ describe('S3Disk', () => {
         Body: Buffer.from('hello', 'utf8'),
         Bucket: bucketName,
         Key: 'foo/test.txt',
-      }).promise();
+      });
 
       const { size } = await disk.read('foo/test.txt', 'stream');
       strictEqual(size, 5);
@@ -291,7 +289,7 @@ describe('S3Disk', () => {
         Body: Buffer.from('hello', 'utf8'),
         Bucket: bucketName,
         Key: 'foo/test.txt',
-      }).promise();
+      });
 
       const size = await disk.readSize('foo/test.txt');
       strictEqual(size, 5);
@@ -321,21 +319,17 @@ describe('S3Disk', () => {
         Body: 'hello',
         Bucket: bucketName,
         Key: 'foo/test.txt',
-      }).promise();
+      });
 
       await disk.delete('foo/test.txt');
 
-      try {
-        await s3.getObject({
+      await rejects(
+        () => s3.getObject({
           Bucket: bucketName,
           Key: 'foo/test.txt',
-        }).promise();
-        throw new Error('An error should have been thrown');
-      } catch (error: any) {
-        if (error.code !== 'NoSuchKey') {
-          throw error;
-        }
-      }
+        }),
+        (error: any) => error.name === 'NoSuchKey',
+      );
     });
 
   });

--- a/packages/aws-s3/src/s3-disk.service.ts
+++ b/packages/aws-s3/src/s3-disk.service.ts
@@ -19,7 +19,7 @@ export class S3Disk extends Disk {
 
   async write(
     dirname: string,
-    content: Buffer | NodeJS.ReadableStream,
+    content: Buffer | Readable,
     options: { name?: string } | { extension?: string } = {}
   ): Promise<{ path: string; }> {
     let name = this.hasName(options) ? options.name : await generateToken();

--- a/packages/aws-s3/src/s3-disk.service.ts
+++ b/packages/aws-s3/src/s3-disk.service.ts
@@ -2,9 +2,10 @@
 import { Readable } from 'stream';
 
 // 3p
-import { Config, generateToken } from '@foal/core';
+import { Config, generateToken, streamToBuffer } from '@foal/core';
 import { Disk, FileDoesNotExist } from '@foal/storage';
-import * as S3 from 'aws-sdk/clients/s3';
+import { DeleteObjectCommand, GetObjectCommand, HeadObjectCommand, S3Client, S3ClientConfig } from '@aws-sdk/client-s3';
+import { Upload } from '@aws-sdk/lib-storage';
 
 /**
  * File storage to read, write and delete files in AWS S3.
@@ -14,8 +15,6 @@ import * as S3 from 'aws-sdk/clients/s3';
  * @extends {Disk}
  */
 export class S3Disk extends Disk {
-
-  private s3: S3;
 
   async write(
     dirname: string,
@@ -30,12 +29,18 @@ export class S3Disk extends Disk {
 
     const path = `${dirname}/${name}`;
 
-    await this.getS3().upload({
-      Body: content,
-      Bucket: this.getBucket(),
-      Key: path,
-      ServerSideEncryption: Config.get('settings.disk.s3.serverSideEncryption', 'string'),
-    }).promise();
+    // We cannot use a "PutObjectCommand" command here
+    // because we would need to know the file size when "content" is a stream.
+    const parallelUploads = new Upload({
+      client: this.s3,
+      params: {
+        Body: content,
+        Bucket: this.bucket,
+        Key: path,
+        ServerSideEncryption: Config.get('settings.disk.s3.serverSideEncryption', 'string'),
+      }
+    })
+    await parallelUploads.done();
 
     return { path };
   }
@@ -45,39 +50,35 @@ export class S3Disk extends Disk {
     content: C
   ): Promise<{ file: C extends 'buffer' ? Buffer : C extends 'stream' ? Readable : never; size: number; }> {
     try {
-      if (content === 'buffer') {
-        const { Body, ContentLength } = await this.getS3().getObject({
-          Bucket: this.getBucket(),
-          Key: path,
-        }).promise();
+      const command = new GetObjectCommand({
+        Bucket: this.bucket,
+        Key: path,
+      });
+      const { Body, ContentLength } = await this.s3.send(command);
 
-        return {
-          file: Body as any,
-          size: ContentLength as number
-        };
+      if (ContentLength === undefined) {
+        throw new Error('Expected to have a content-length header in HTTP response.');
       }
 
-      const { ContentLength }  = await this.getS3().headObject({
-        Bucket: this.getBucket(),
-        Key: path,
-      }).promise();
+      if (Body === undefined) {
+        throw new Error('Expected to have a body in HTTP response.');
+      }
 
-      const stream = this.getS3().getObject({
-        Bucket: this.getBucket(),
-        Key: path,
-      }).createReadStream()
-        // Do not kill the process (and crash the server) if the stream emits an error.
-        // Note: users can still add other listeners to the stream to "catch" the error.
-        // Note: error streams are unlikely to occur ("headObject" may have thrown these errors previously).
-        // TODO: test this line.
-        .on('error', () => {});
+      // "Body" is of type Readable on Node and of type ReadableStream | Blob on the browser.
+      // See https://github.com/aws/aws-sdk-js-v3/issues/1877.
+      const stream = Body as Readable;
+
+      // Do not kill the process (and crash the server) if the stream emits an error.
+      // Note: users can still add other listeners to the stream to "catch" the error.
+      // TODO: test this line.
+      stream.on('error', () => {});
 
       return {
-        file: stream as any,
-        size: ContentLength as number
+        file: (content === 'buffer' ? await streamToBuffer(stream) : stream) as any,
+        size: ContentLength
       };
     } catch (error: any) {
-      if (error.code === 'NoSuchKey' || error.code === 'NotFound') {
+      if (error.name === 'NoSuchKey') {
         throw new FileDoesNotExist(path);
       }
       // TODO: test this line.
@@ -87,13 +88,19 @@ export class S3Disk extends Disk {
 
   async readSize(path: string): Promise<number> {
     try {
-      const { ContentLength }  = await this.getS3().headObject({
-        Bucket: this.getBucket(),
+      const command = new HeadObjectCommand({
+        Bucket: this.bucket,
         Key: path,
-      }).promise();
-      return ContentLength as number;
+      });
+      const { ContentLength }  = await this.s3.send(command);
+
+      if (ContentLength === undefined) {
+        throw new Error('Expected to have a content-length header in HTTP response.');
+      }
+
+      return ContentLength;
     } catch (error: any) {
-      if (error.code === 'NotFound') {
+      if (error.name === 'NotFound') {
         throw new FileDoesNotExist(path);
       }
       // TODO: test this line.
@@ -102,13 +109,14 @@ export class S3Disk extends Disk {
   }
 
   async delete(path: string): Promise<void> {
-    await this.getS3().deleteObject({
-      Bucket: this.getBucket(),
+    const command = new DeleteObjectCommand({
+      Bucket: this.bucket,
       Key: path
-    }).promise();
+    });
+    await this.s3.send(command);
   }
 
-  private getBucket(): string {
+  private get bucket(): string {
     return Config.getOrThrow(
       'settings.disk.s3.bucket',
       'string',
@@ -116,16 +124,29 @@ export class S3Disk extends Disk {
     );
   }
 
-  private getS3(): S3 {
-    if (!this.s3) {
-      this.s3 = new S3({
-        accessKeyId: Config.get('settings.aws.accessKeyId', 'string'),
-        apiVersion: '2006-03-01',
+  private _s3: S3Client;
+
+  private get s3(): S3Client {
+    if (!this._s3) {
+      const s3Config: S3ClientConfig = {
         endpoint: Config.get('settings.aws.endpoint', 'string'),
-        secretAccessKey: Config.get('settings.aws.secretAccessKey', 'string'),
-      });
+      };
+
+      const accessKeyId = Config.get('settings.aws.accessKeyId', 'string');
+      const secretAccessKey = Config.get('settings.aws.secretAccessKey', 'string');
+      if (accessKeyId && secretAccessKey) {
+        s3Config.credentials = { accessKeyId, secretAccessKey }
+      }
+
+      const region = Config.get('settings.aws.region', 'string');
+      if (region) {
+        s3Config.region = region;
+      }
+
+      this._s3 = new S3Client(s3Config);
     }
-    return this.s3;
+
+    return this._s3;
   }
 
 }

--- a/packages/storage/src/disk.service.ts
+++ b/packages/storage/src/disk.service.ts
@@ -64,7 +64,7 @@ export abstract class Disk {
    * @abstract
    * @param {string} dirname - Name or path of the directory where the file must
    * be saved.
-   * @param {(Buffer|NodeJS.ReadableStream)} content - Content of the file (buffer or readable
+   * @param {(Buffer|Readable)} content - Content of the file (buffer or readable
    * stream).
    * @param {({ name?: string } | { extension?: string })} [options] - Optional name
    * or extension of the file. If no name is provided, the method generates one.
@@ -74,7 +74,7 @@ export abstract class Disk {
    */
   abstract write(
     dirname: string,
-    content: Buffer|NodeJS.ReadableStream,
+    content: Buffer|Readable,
     options?: { name?: string } | { extension?: string },
   ): Promise<{ path: string }>;
 

--- a/packages/storage/src/local-disk.service.ts
+++ b/packages/storage/src/local-disk.service.ts
@@ -21,7 +21,7 @@ export class LocalDisk extends Disk {
 
   async write(
     dirname: string,
-    content: Buffer | NodeJS.ReadableStream,
+    content: Buffer | Readable,
     options: { name?: string } | { extension?: string } = {}
   ): Promise<{ path: string; }> {
     let name = this.hasName(options) ? options.name : await generateToken();

--- a/packages/storage/src/validate-multipart-form-data-body.hook.ts
+++ b/packages/storage/src/validate-multipart-form-data-body.hook.ts
@@ -1,5 +1,6 @@
 // std
 import { extname } from 'path';
+import { Readable } from 'stream';
 
 // 3p
 import {
@@ -80,7 +81,7 @@ export function ValidateMultipartFormDataBody(
 
       busboy.on('field', (name: string, value: string) => fields[name] = value);
       // tslint:disable-next-line: max-line-length
-      busboy.on('file', (name: string, stream: NodeJS.ReadableStream, filename: string, encoding: string, mimeType: string) => {
+      busboy.on('file', (name: string, stream: Readable, filename: string, encoding: string, mimeType: string) => {
         latestFileHasBeenUploaded = convertRejectedPromise(async () => {
           stream.on('limit', () => sizeLimitReached = name);
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

- Upgrade all major versions for v3.
- Reduce `node_modules/` size.

# Solution and steps

- [x] Make `Disk.write` use `Readable`.
- [x] Upgrade from `aws-sdk@2` to `@aws-sdk/client-s3@3`.
- [x] Update `@foal/aws-s3` code.

Related PR: #914

# Breaking changes

- All `Disk.write` take a `Readable` as parameter and not a `NodeJS.ReadableStream` anymore.
- The AWS region must be provided to connect to S3.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
