### PR TITLE
Add PKCE and Twitter provider - #1014 #1047

### DIFF
--- a/docs/docs/authentication-and-access-control/social-auth.md
+++ b/docs/docs/authentication-and-access-control/social-auth.md
@@ -366,16 +366,18 @@ export class GithubProvider extends AbstractProvider<GithubAuthParameter, Github
 } 
 ```
 
-### Enable Code Flow with PKCE
+### Sending the Client Credentials in an Authorization Header
 
-PKCE can be enabled extending Abstract Provider class and setting useCodeVerifier property as true. 
-By default it use SHA256 encryption as standard Code Challenge Method but there's another property to set Plain method if is needed:
-```typescript
-  useCodeVerifier: boolean;
-  codeChallengeMethodPlain: boolean = false; // Optional: default false
-```
+When requesting the token endpoint, the provider sends the client ID and secret as a query parameter by default. If you want to send them in an `Authorization` header using the *basic* scheme, you can do so by setting the `useAuthorizationHeaderForTokenEndpoint` property to `true`.
 
-If you use this feature, then you must provide a secret to encrypt the code verifier. Secret can be configured like this:
+### Enabling Code Flow with PKCE
+
+If you want to enable code flow with PKCE, you can do so by setting the `usePKCE` property to `true`.
+
+> By default, the provider will perform a SHA256 hash to generate the code challenge. If you wish to use the plaintext code verifier string as code challenge, you can do so by setting the `useCodeVerifierAsCodeChallenge` property to `true`.
+
+When using this feature, the provider encrypts the code verifier and stores it in a cookie on the client. In order to do this, you need to provide a secret using the configuration key `settings.social.secret.codeVerifierSecret`.
+
 <Tabs
   defaultValue="yaml"
   values={[
@@ -425,7 +427,6 @@ module.exports = {
 
 </TabItem>
 </Tabs>
-
 
 
 ## Official Providers
@@ -567,7 +568,7 @@ There are no community providers available yet! If you want to share one, feel f
 | Error | Description |
 | --- | --- |
 | `InvalidStateError` | The `state` query does not match the value found in the cookie. |
-| `InvalidCodeChallengeError` | The `code_verifier` query does not match the value found in the cookie. |
+| `CodeVerifierNotFound` | The encrypted code verifier was not found in the cookie (only when using PKCE). |
 | `AuthorizationError` | The authorization server returns an error. This can happen when a user does not give consent on the provider page. |
 | `UserInfoError` | Thrown in `AbstractProvider.getUserFromTokens` if the request to the resource server is unsuccessful. |
 

--- a/docs/docs/authentication-and-access-control/social-auth.md
+++ b/docs/docs/authentication-and-access-control/social-auth.md
@@ -12,6 +12,7 @@ In addition to traditional password authentication, Foal provides services to au
 - Facebook
 - Github
 - Linkedin
+- Twitter
 
 If your provider is not listed here but supports OAuth 2.0, then you can still [extend the `AbstractProvider`](#custom-provider) class to integrate it or use a [community provider](#community-providers) below.
 

--- a/docs/docs/authentication-and-access-control/social-auth.md
+++ b/docs/docs/authentication-and-access-control/social-auth.md
@@ -324,67 +324,6 @@ export class AuthController {
 }
 ```
 
-## Enable Code Flow with PKCE
-
-PKCE can be enabled extending Abstract Provider class and setting useCodeChallenge property as true. 
-By default it use SHA256 encription as standard Code Challenge Method but there's another property to set Plain method if is needed:
-```typescript
-  useCodeChallenge: boolean;
-  codeChallengeMethodPlain: boolean = false; // Optional: default false
-```
-
-If you use this feature, then you must provide a secret to encrypt the code verifier. Secret can be configured like this:
-<Tabs
-  defaultValue="yaml"
-  values={[
-    {label: 'YAML', value: 'yaml'},
-    {label: 'JSON', value: 'json'},
-    {label: 'JS', value: 'js'},
-  ]}
->
-<TabItem value="yaml">
-
-```yaml
-settings:
-  social:
-    secret:
-      codeChallengeSecret: 'xxx'
-```
-
-</TabItem>
-<TabItem value="json">
-
-```json
-{
-  "settings": {
-    "social": {
-      "secret": {
-        "codeChallengeSecret": "xxx"
-      }
-    }
-  }
-}
-```
-
-</TabItem>
-<TabItem value="js">
-
-```javascript
-module.exports = {
-  settings: {
-    social: {
-      secret: {
-        codeChallengeSecret: 'xxx'
-      }
-    }
-  }
-}
-```
-
-</TabItem>
-</Tabs>
-
-
 ## Custom Provider
 
 If your provider is not officially supported by Foal but supports the OAuth 2.0 protocol, you can still implement your own social service. All you need to do is to make it inherit from the `AbstractProvider` class.
@@ -425,6 +364,68 @@ export class GithubProvider extends AbstractProvider<GithubAuthParameter, Github
 
 } 
 ```
+
+### Enable Code Flow with PKCE
+
+PKCE can be enabled extending Abstract Provider class and setting useCodeVerifier property as true. 
+By default it use SHA256 encryption as standard Code Challenge Method but there's another property to set Plain method if is needed:
+```typescript
+  useCodeVerifier: boolean;
+  codeChallengeMethodPlain: boolean = false; // Optional: default false
+```
+
+If you use this feature, then you must provide a secret to encrypt the code verifier. Secret can be configured like this:
+<Tabs
+  defaultValue="yaml"
+  values={[
+    {label: 'YAML', value: 'yaml'},
+    {label: 'JSON', value: 'json'},
+    {label: 'JS', value: 'js'},
+  ]}
+>
+<TabItem value="yaml">
+
+```yaml
+settings:
+  social:
+    secret:
+      codeVerifierSecret: 'xxx'
+```
+
+</TabItem>
+<TabItem value="json">
+
+```json
+{
+  "settings": {
+    "social": {
+      "secret": {
+        "codeVerifierSecret": "xxx"
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+<TabItem value="js">
+
+```javascript
+module.exports = {
+  settings: {
+    social: {
+      secret: {
+        codeVerifierSecret: 'xxx'
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+
 
 ## Official Providers
 
@@ -553,7 +554,7 @@ const { userInfo } = await this.linkedin.getUserInfo(ctx, {
 
 #### Register an OAuth application
 
-Visit [this page](https://developer.twitter.com/en/portal/dashboard) to create an application and obtain a client ID and a client secret.
+Visit [this page](https://developer.twitter.com/en/portal/dashboard) to create an application and obtain a client ID and a client secret. You must configure Oauth2 settings to be used with public client; 
 
 
 ## Community Providers

--- a/docs/docs/authentication-and-access-control/social-auth.md
+++ b/docs/docs/authentication-and-access-control/social-auth.md
@@ -57,15 +57,6 @@ npm install @foal/social
 
 Then, you will need to provide your client ID, client secret and your redirect URIs to Foal. This can be done through the usual [configuration files](../architecture/configuration.md).
 
-#### Enable Code Flow with PKCE
-
-PKCE Flow can be enable through config file too. There're two aditional parameters:
-```
-  useCodeChallenge: boolean
-  codeChallengeMethodPlain: boolean (optional)
-```
-By default it use SHA256 encription as standard Code Challenge Method.
-
 <Tabs
   defaultValue="yaml"
   values={[
@@ -332,6 +323,67 @@ export class AuthController {
 
 }
 ```
+
+## Enable Code Flow with PKCE
+
+PKCE can be enabled extending Abstract Provider class and setting useCodeChallenge property as true. 
+By default it use SHA256 encription as standard Code Challenge Method but there's another property to set Plain method if is needed:
+```typescript
+  useCodeChallenge: boolean;
+  codeChallengeMethodPlain: boolean = false; // Optional: default false
+```
+
+If you use this feature, then you must provide a secret to encrypt the code verifier. Secret can be configured like this:
+<Tabs
+  defaultValue="yaml"
+  values={[
+    {label: 'YAML', value: 'yaml'},
+    {label: 'JSON', value: 'json'},
+    {label: 'JS', value: 'js'},
+  ]}
+>
+<TabItem value="yaml">
+
+```yaml
+settings:
+  social:
+    secret:
+      codeChallengeSecret: 'xxx'
+```
+
+</TabItem>
+<TabItem value="json">
+
+```json
+{
+  "settings": {
+    "social": {
+      "secret": {
+        "codeChallengeSecret": "xxx"
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+<TabItem value="js">
+
+```javascript
+module.exports = {
+  settings: {
+    social: {
+      secret: {
+        codeChallengeSecret: 'xxx'
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
 
 ## Custom Provider
 

--- a/docs/docs/authentication-and-access-control/social-auth.md
+++ b/docs/docs/authentication-and-access-control/social-auth.md
@@ -57,6 +57,15 @@ npm install @foal/social
 
 Then, you will need to provide your client ID, client secret and your redirect URIs to Foal. This can be done through the usual [configuration files](../architecture/configuration.md).
 
+#### Enable Code Flow with PKCE
+
+PKCE Flow can be enable through config file too. There're two aditional parameters:
+```
+  useCodeChallenge: boolean
+  codeChallengeMethodPlain: boolean (optional)
+```
+By default it use SHA256 encription as standard Code Challenge Method.
+
 <Tabs
   defaultValue="yaml"
   values={[
@@ -484,6 +493,17 @@ const { userInfo } = await this.linkedin.getUserInfo(ctx, {
 | `fields` | `string[]` | List of fields that the returned user info object should contain. Additional documentation on [field projections](https://developer.linkedin.com/docs/guide/v2/concepts/projections). |
 | `projection` | `string` | LinkedIn projection parameter. |
 
+### Twitter
+
+|Service name| Default scopes | Available scopes |
+|---|---|---|
+| `TwitterProvider` | `users.read tweet.read` | [API documentation](https://developer.twitter.com/en/docs/twitter-api/users/lookup/api-reference/get-users-me) |
+
+#### Register an OAuth application
+
+Visit [this page](https://developer.twitter.com/en/portal/dashboard) to create an application and obtain a client ID and a client secret.
+
+
 ## Community Providers
 
 There are no community providers available yet! If you want to share one, feel free to [open a PR](https://github.com/FoalTS/foal) on Github.
@@ -493,6 +513,7 @@ There are no community providers available yet! If you want to share one, feel f
 | Error | Description |
 | --- | --- |
 | `InvalidStateError` | The `state` query does not match the value found in the cookie. |
+| `InvalidCodeChallengeError` | The `code_verifier` query does not match the value found in the cookie. |
 | `AuthorizationError` | The authorization server returns an error. This can happen when a user does not give consent on the provider page. |
 | `UserInfoError` | Thrown in `AbstractProvider.getUserFromTokens` if the request to the resource server is unsuccessful. |
 

--- a/packages/examples/config/default.yml
+++ b/packages/examples/config/default.yml
@@ -13,16 +13,26 @@ settings:
     local:
       directory: 'uploaded'
   social:
+    secret: 
+      codeVerifierSecret: 'my secret'
     google:
-      clientId: '635863747771-ihd9cqkij7eb6dsh4o0pel0licaouftk.apps.googleusercontent.com'
+      clientId: 'env(GOOGLE_CLIENTID)'
+      clientSecret: 'env(GOOGLE_SECRET)'
       redirectUri: 'http://localhost:3001/signin/google/cb'
     facebook:
-      clientId: '2347404038904704'
+      clientId: 'env(FACEBOOK_CLIENTID)'
+      clientSecret: 'env(FACEBOOK_SECRET)'
       redirectUri: 'http://localhost:3001/signin/facebook/cb'
     github:
-      clientId: '990d351d6696637faa20'
+      clientId: 'env(GITHUB_CLIENTID)'
+      clientSecret: 'env(GITHUB_SECRET)'
       redirectUri: 'http://localhost:3001/signin/github/cb'
     linkedin:
-      clientId: '77na9s6izn8vrs'
+      clientId: 'env(LINKEDIN_CLIENTID)'
+      clientSecret: 'env(LINKEDIN_SECRET)'
       redirectUri: 'http://localhost:3001/signin/linkedin/cb'
+    twitter:
+      clientId: 'env(TWITTER_CLIENTID)'
+      clientSecret: 'env(TWITTER_SECRET)'
+      redirectUri: 'http://localhost:3001/signin/twitter/cb'
 

--- a/packages/examples/ormconfig.json
+++ b/packages/examples/ormconfig.json
@@ -1,5 +1,5 @@
 {
-  "type": "sqlite",
+  "type": "better-sqlite3",
   "database": "./test_db.sqlite",
   "entities": ["build/app/**/*.entity.js"],
   "migrations": ["build/migrations/*.js"],

--- a/packages/examples/src/app/controllers/auth.controller.ts
+++ b/packages/examples/src/app/controllers/auth.controller.ts
@@ -8,7 +8,7 @@ import {
   Session,
   UseSessions,
 } from '@foal/core';
-import { FacebookProvider, GithubProvider, GoogleProvider, LinkedInProvider } from '@foal/social';
+import { FacebookProvider, GithubProvider, GoogleProvider, LinkedInProvider, TwitterProvider } from '@foal/social';
 import { TypeORMStore } from '@foal/typeorm';
 
 @UseSessions({ cookie: true })
@@ -24,6 +24,9 @@ export class AuthController {
 
   @dependency
   linkedin: LinkedInProvider;
+
+  @dependency
+  twitter: TwitterProvider;
 
   @dependency
   store: TypeORMStore;
@@ -69,6 +72,17 @@ export class AuthController {
   @Get('/signin/linkedin/cb')
   async handleLinkedInRedirection(ctx: Context<any, Session>) {
     const { userInfo } = await this.linkedin.getUserInfo(ctx);
+    return this.createSessionAndSaveUserInfo(userInfo, ctx);
+  }
+
+  @Get('/signin/twitter')
+  redirectToTwittern() {
+    return this.twitter.redirect();
+  }
+
+  @Get('/signin/twitter/cb')
+  async handleTwitterRedirection(ctx: Context<any, Session>) {
+    const { userInfo } = await this.twitter.getUserInfo(ctx);
     return this.createSessionAndSaveUserInfo(userInfo, ctx);
   }
 

--- a/packages/examples/src/app/controllers/auth.controller.ts
+++ b/packages/examples/src/app/controllers/auth.controller.ts
@@ -11,7 +11,7 @@ import {
 import { FacebookProvider, GithubProvider, GoogleProvider, LinkedInProvider, TwitterProvider } from '@foal/social';
 import { TypeORMStore } from '@foal/typeorm';
 
-@UseSessions({ cookie: true })
+@UseSessions({ cookie: true, store: TypeORMStore })
 export class AuthController {
   @dependency
   google: GoogleProvider;

--- a/packages/examples/src/app/entities/user.entity.ts
+++ b/packages/examples/src/app/entities/user.entity.ts
@@ -24,4 +24,4 @@ export class User extends UserWithPermissions {
 
 }
 
-export { Group, Permission } from '@foal/typeorm';
+export { Group, Permission, DatabaseSession } from '@foal/typeorm';

--- a/packages/examples/src/migrations/1651699145020-sessions.ts
+++ b/packages/examples/src/migrations/1651699145020-sessions.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class sessions1651699145020 implements MigrationInterface {
+    name = 'sessions1651699145020'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "sessions" ("id" varchar(44) PRIMARY KEY NOT NULL, "user_id" integer, "content" text NOT NULL, "flash" text NOT NULL, "updated_at" integer NOT NULL, "created_at" integer NOT NULL)`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "sessions"`);
+    }
+
+}

--- a/packages/examples/templates/signin.html
+++ b/packages/examples/templates/signin.html
@@ -11,5 +11,6 @@
   <a href="/signin/facebook">Log In with Facebook</a>
   <a href="/signin/github">Log In with Github</a>
   <a href="/signin/linkedin">Log In with LinkedIn</a>
+  <a href="/signin/twitter">Log In with Twitter</a>
 </body>
 </html>

--- a/packages/social/src/abstract-provider.service.spec.ts
+++ b/packages/social/src/abstract-provider.service.spec.ts
@@ -28,7 +28,7 @@ import {
 } from './abstract-provider.service';
 
 const STATE_COOKIE_NAME = 'oauth2-state';
-const CODE_VERIFIER_NAME = 'oauth2-code-challenge';
+const CODE_VERIFIER_NAME = 'oauth2-code-verifier';
 
 describe('InvalidStateError', () => {
 
@@ -622,11 +622,11 @@ describe('Abstract Provider With PKCE', () => {
     describe('should return an HttpResponseRedirect object', () => {
 
       beforeEach(() => {
-        Config.set('settings.social.secret.codeChallengeSecret', 'SECRET');
+        Config.set('settings.social.secret.codeVerifierSecret', 'SECRET');
       });
 
       afterEach(() => {
-        Config.remove('settings.social.secret.codeChallengeSecret');
+        Config.remove('settings.social.secret.codeVerifierSecret');
       });
 
       it('with a redirect path which contains a client ID, a response type, a redirect URI, code_challenge and code_challenge_method (S256) if pkce enabled.', async () => {
@@ -652,17 +652,17 @@ describe('Abstract Provider With PKCE', () => {
         if (server) {
           server.close();
         }
-        Config.remove('settings.social.secret.codeChallengeSecret');
+        Config.remove('settings.social.secret.codeVerifierSecret');
       });
 
       beforeEach(() => {
-        Config.set('settings.social.secret.codeChallengeSecret', secret);
+        Config.set('settings.social.secret.codeVerifierSecret', secret);
       });
 
       it('should send a request which contains a grant type, a code, a redirect URI,'
         + 'a client ID, a client secret and code_verifier and return the response body.', async () => {
 
-        const codeChallenge = 'challenge';
+        const codeVerifier = 'challenge';
 
         class AppController {
           @Post('/token')
@@ -674,7 +674,7 @@ describe('Abstract Provider With PKCE', () => {
             strictEqual(redirect_uri, redirectUri);
             strictEqual(client_id, clientId);
             strictEqual(client_secret, clientSecret);
-            strictEqual(code_verifier, codeChallenge)
+            strictEqual(code_verifier, codeVerifier)
             return new HttpResponseOK({
               access_token: 'an_access_token',
               token_type: 'bearer'
@@ -689,7 +689,7 @@ describe('Abstract Provider With PKCE', () => {
         const ctx = new Context({
           cookies: {
             [STATE_COOKIE_NAME]: 'xxx',
-            [CODE_VERIFIER_NAME]: encryptHelper(codeChallenge, iv, secret)
+            [CODE_VERIFIER_NAME]: encryptHelper(codeVerifier, iv, secret)
           },
           query: {
             code: 'an_authorization_code',
@@ -782,11 +782,11 @@ describe('Abstract Provider With PKCE and Plain Method', () => {
     describe('should return an HttpResponseRedirect object', () => {
 
       beforeEach(() => {
-        Config.set('settings.social.secret.codeChallengeSecret', 'SECRET');
+        Config.set('settings.social.secret.codeVerifierSecret', 'SECRET');
       });
 
       afterEach(() => {
-        Config.remove('settings.social.secret.codeChallengeSecret');
+        Config.remove('settings.social.secret.codeVerifierSecret');
       });
 
       it('with a redirect path which contains a client ID, a response type, a redirect URI, code_challenge and code_challenge_method (plain) if pkce enabled.', async () => {

--- a/packages/social/src/abstract-provider.service.spec.ts
+++ b/packages/social/src/abstract-provider.service.spec.ts
@@ -28,7 +28,7 @@ import {
 } from './abstract-provider.service';
 
 const STATE_COOKIE_NAME = 'oauth2-state';
-const CODE_VERIFIER_NAME = 'oauth2-code-verifier';
+const CODE_VERIFIER_COOKIE_NAME = 'oauth2-code-verifier';
 
 describe('InvalidStateError', () => {
 
@@ -735,7 +735,7 @@ describe('Abstract Provider With PKCE', () => {
       it('should send a request which contains a grant type, a code, a redirect URI,'
         + 'a client ID, a client secret and code_verifier and return the response body.', async () => {
 
-        const codeVerifier = 'challenge';
+        const codeVerifier = 'code verifier';
 
         class AppController {
           @Post('/token')
@@ -763,7 +763,7 @@ describe('Abstract Provider With PKCE', () => {
         const ctx = new Context({
           cookies: {
             [STATE_COOKIE_NAME]: 'xxx',
-            [CODE_VERIFIER_NAME]: encryptHelper(codeVerifier, iv, secret)
+            [CODE_VERIFIER_COOKIE_NAME]: encryptHelper(codeVerifier, iv, secret)
           },
           query: {
             code: 'an_authorization_code',

--- a/packages/social/src/abstract-provider.service.spec.ts
+++ b/packages/social/src/abstract-provider.service.spec.ts
@@ -28,7 +28,7 @@ import {
 } from './abstract-provider.service';
 
 const STATE_COOKIE_NAME = 'oauth2-state';
-const CODE_CHALLENGE_NAME = 'oauth2-code-challenge';
+const CODE_VERIFIER_NAME = 'oauth2-code-challenge';
 
 describe('InvalidStateError', () => {
 
@@ -578,7 +578,7 @@ describe('Abstract Provider With PKCE', () => {
       clientSecret: 'settings.social.example.clientSecret',
       redirectUri: 'settings.social.example.redirectUri'
     };
-    protected useCodeChallenge = true;
+    protected useCodeVerifier: boolean = true;
     protected authEndpoint = 'https://example2.com/auth';
     protected tokenEndpoint = 'http://localhost:3000/token';
     getUserInfoFromTokens(tokens: SocialTokens) {
@@ -689,7 +689,7 @@ describe('Abstract Provider With PKCE', () => {
         const ctx = new Context({
           cookies: {
             [STATE_COOKIE_NAME]: 'xxx',
-            [CODE_CHALLENGE_NAME]: encryptHelper(codeChallenge, iv, secret)
+            [CODE_VERIFIER_NAME]: encryptHelper(codeChallenge, iv, secret)
           },
           query: {
             code: 'an_authorization_code',
@@ -748,7 +748,7 @@ describe('Abstract Provider With PKCE and Plain Method', () => {
       clientSecret: 'settings.social.example.clientSecret',
       redirectUri: 'settings.social.example.redirectUri'
     };
-    protected useCodeChallenge = true;
+    protected useCodeVerifier: boolean = true;
     protected codeChallengeMethodPlain = true;
     protected authEndpoint = 'https://example2.com/auth';
     protected tokenEndpoint = 'http://localhost:3000/token';

--- a/packages/social/src/abstract-provider.service.spec.ts
+++ b/packages/social/src/abstract-provider.service.spec.ts
@@ -21,7 +21,7 @@ import {
 import {
   AbstractProvider,
   AuthorizationError,
-  InvalidCodeChallengeError,
+  CodeVerifierNotFound,
   InvalidStateError,
   SocialTokens,
   TokenError
@@ -48,20 +48,20 @@ describe('InvalidStateError', () => {
 
 });
 
-describe('InvalidCodeChallengeError', () => {
+describe('CodeVerifierNotFound', () => {
 
   it('should have a "message" property.', () => {
-    const error = new InvalidCodeChallengeError();
+    const error = new CodeVerifierNotFound();
 
     strictEqual(
       error.message,
-      'Suspicious operation: code challenge sent with authorize cannot be empty.');
+      'Suspicious operation: encrypted code verifier not found in cookie.');
   });
 
   it('should have a "name" property.', () => {
-    const error = new InvalidCodeChallengeError();
+    const error = new CodeVerifierNotFound();
 
-    strictEqual(error.name, 'InvalidCodeChallengeError');
+    strictEqual(error.name, 'CodeVerifierNotFound');
   });
 
 });
@@ -641,7 +641,7 @@ describe('Abstract Provider With PKCE', () => {
       clientSecret: 'settings.social.example.clientSecret',
       redirectUri: 'settings.social.example.redirectUri'
     };
-    protected useCodeVerifier: boolean = true;
+    protected usePKCE: boolean = true;
     protected authEndpoint = 'https://example2.com/auth';
     protected tokenEndpoint = 'http://localhost:3000/token';
     getUserInfoFromTokens(tokens: SocialTokens) {
@@ -769,7 +769,7 @@ describe('Abstract Provider With PKCE', () => {
         deepStrictEqual(actual, expected);
       });
 
-      it('should throw a InvalidCodeChallengeError if Code Verifier not exists or is not valid', async () => {
+      it('should throw a CodeVerifierNotFound if Code Verifier not exists or is not valid', async () => {
         class AppController {
           @Post('/token')
           token() {
@@ -793,9 +793,9 @@ describe('Abstract Provider With PKCE', () => {
 
         try {
           await provider.getTokens(ctx);
-          throw new Error('getTokens should have thrown a InvalidCodeChallengeError.');
+          throw new Error('getTokens should have thrown a CodeVerifierNotFound.');
         } catch (error) {
-          if (!(error instanceof InvalidCodeChallengeError)) {
+          if (!(error instanceof CodeVerifierNotFound)) {
             throw error;
           }
         }
@@ -812,8 +812,8 @@ describe('Abstract Provider With PKCE and Plain Method', () => {
       clientSecret: 'settings.social.example.clientSecret',
       redirectUri: 'settings.social.example.redirectUri'
     };
-    protected useCodeVerifier: boolean = true;
-    protected codeChallengeMethodPlain = true;
+    protected usePKCE: boolean = true;
+    protected useCodeVerifierAsCodeChallenge = true;
     protected authEndpoint = 'https://example2.com/auth';
     protected tokenEndpoint = 'http://localhost:3000/token';
     getUserInfoFromTokens(tokens: SocialTokens) {

--- a/packages/social/src/abstract-provider.service.spec.ts
+++ b/packages/social/src/abstract-provider.service.spec.ts
@@ -303,6 +303,16 @@ describe('AbstractProvider', () => {
         strictEqual(searchParams.get('foo'), 'bar2');
       });
 
+      it('with a redirect path that do NOT contain PKCE parameters.', async () => {
+        provider = createService(ConcreteProvider);
+
+        const response = await provider.redirect();
+        const searchParams = new URLSearchParams(response.path);
+
+        strictEqual(searchParams.get('code_challenge'), null);
+        strictEqual(searchParams.get('code_challenge_method'), null);
+      });
+
     });
 
   });

--- a/packages/social/src/abstract-provider.service.spec.ts
+++ b/packages/social/src/abstract-provider.service.spec.ts
@@ -2,10 +2,12 @@
 import { deepStrictEqual, notStrictEqual, ok, strictEqual } from 'assert';
 import { Server } from 'http';
 import { URLSearchParams } from 'url';
+import * as crypto from 'crypto'
 
 // 3p
 import {
   Config,
+  ConfigNotFoundError,
   Context,
   createApp,
   createService,
@@ -144,9 +146,7 @@ describe('AbstractProvider', () => {
     protected configPaths = {
       clientId: 'settings.social.example.clientId',
       clientSecret: 'settings.social.example.clientSecret',
-      redirectUri: 'settings.social.example.redirectUri',
-      useCodeChallenge: 'settings.social.example.useCodeChallenge',
-      codeChallengeMethodPlain: 'settings.social.example.codeChallengeMethodPlain'
+      redirectUri: 'settings.social.example.redirectUri'
     };
     protected authEndpoint = 'https://example2.com/auth';
     protected tokenEndpoint = 'http://localhost:3000/token';
@@ -194,53 +194,6 @@ describe('AbstractProvider', () => {
           + 'redirect_uri=https%3A%2F%2Fexample.com%2Fcallback'
         ));
       });
-
-      describe('if code_challenge is configured as active in config', () => {
-
-        beforeEach(() => {
-          Config.set('settings.social.example.useCodeChallenge', true);
-        });
-
-        afterEach(() => {
-          Config.remove('settings.social.example.useCodeChallenge');
-        });
-
-        it('with code_challenge_method (S256) - codeChallengeMethodPlain: false', async () => {
-          const response = await provider.redirect();
-          ok(response.path.startsWith(
-            'https://example2.com/auth?'
-            + 'response_type=code&'
-            + 'client_id=clientIdXXX&'
-            + 'redirect_uri=https%3A%2F%2Fexample.com%2Fcallback'
-          ));
-          // code_challenge is random so we test if field exists and have some data
-          ok(response.path.indexOf('code_challenge=') > 0);
-          const subPath = response.path.substring(response.path.indexOf('code_challenge=')).split('&');
-          const codeChallenge = subPath[0].split('=');
-          ok(codeChallenge[1].length>0);
-          const codeChallengeMethod = subPath[1].split('=');
-          strictEqual(codeChallengeMethod[1], 'S256');
-        });
-
-        it('with code_challenge_method (plain) - codeChallengeMethodPlain: true', async () => {
-          Config.set('settings.social.example.codeChallengeMethodPlain', true);
-          const response = await provider.redirect();
-          ok(response.path.startsWith(
-            'https://example2.com/auth?'
-            + 'response_type=code&'
-            + 'client_id=clientIdXXX&'
-            + 'redirect_uri=https%3A%2F%2Fexample.com%2Fcallback'
-          ));
-          // code_challenge is random so we test if field exists and have some data
-          ok(response.path.indexOf('code_challenge=') > 0);
-          const subPath = response.path.substring(response.path.indexOf('code_challenge=')).split('&');
-          const codeChallenge = subPath[0].split('=');
-          ok(codeChallenge[1].length>0);
-          const codeChallengeMethod = subPath[1].split('=');
-          strictEqual(codeChallengeMethod[1], 'plain');
-          Config.remove('settings.social.example.codeChallengeMethodPlain');
-        });
-      })
 
       it('with a redirect path which does not contain a scope if none was provided.', async () => {
         const response = await provider.redirect();
@@ -446,94 +399,6 @@ describe('AbstractProvider', () => {
       deepStrictEqual(actual, expected);
     });
 
-    describe('if code_challenge is configured as active in config', () => {
-
-      beforeEach(() => {
-        Config.set('settings.social.example.useCodeChallenge', true);
-      });
-
-      afterEach(() => {
-        Config.remove('settings.social.example.useCodeChallenge');
-      });
-
-      it('should send a request which contains a grant type, a code, a redirect URI,'
-        + 'a client ID, a client secret and code_verifier and return the response body.', async () => {
-
-        const codeChallenge = 'challenge';
-
-        class AppController {
-          @Post('/token')
-          token(ctx: Context) {
-            strictEqual(ctx.request.headers.accept, 'application/json');
-            const { grant_type, code, redirect_uri, client_id, client_secret, code_verifier } = ctx.request.body;
-            strictEqual(grant_type, 'authorization_code');
-            strictEqual(code, 'an_authorization_code');
-            strictEqual(redirect_uri, redirectUri);
-            strictEqual(client_id, clientId);
-            strictEqual(client_secret, clientSecret);
-            strictEqual(code_verifier, codeChallenge)
-            return new HttpResponseOK({
-              access_token: 'an_access_token',
-              token_type: 'bearer'
-            });
-          }
-        }
-
-        server = (await createApp(AppController)).listen(3000);
-
-        const ctx = new Context({
-          cookies: {
-            [STATE_COOKIE_NAME]: 'xxx',
-            [CODE_CHALLENGE_NAME]: codeChallenge
-          },
-          query: {
-            code: 'an_authorization_code',
-            state: 'xxx',
-          },
-        });
-
-        const actual = await provider.getTokens(ctx);
-        const expected: SocialTokens = {
-          access_token: 'an_access_token',
-          token_type: 'bearer'
-        };
-        deepStrictEqual(actual, expected);
-      });
-
-      it('should throw a InvalidCodeChallengeError if Code Verifier not exists or is not valid', async () => {
-        class AppController {
-          @Post('/token')
-          token() {
-            return new HttpResponseBadRequest({
-              error: 'bad request'
-            });
-          }
-        }
-
-        server = (await createApp(AppController)).listen(3000);
-
-        const ctx = new Context({
-          cookies: {
-            [STATE_COOKIE_NAME]: 'xxx'
-          },
-          query: {
-            code: 'an_authorization_code',
-            state: 'xxx',
-          },
-        });
-
-        try {
-          await provider.getTokens(ctx);
-          throw new Error('getTokens should have thrown a InvalidCodeChallengeError.');
-        } catch (error) {
-          if (!(error instanceof InvalidCodeChallengeError)) {
-            throw error;
-          }
-          deepStrictEqual(error.message, 'Suspicious operation: code challenge sent with authorize cannot be empty.');
-        }
-      })
-    });
-
     it('should throw a TokenError if the token endpoint returns an error.', async () => {
       class AppController {
         @Post('/token')
@@ -704,3 +569,252 @@ describe('AbstractProvider', () => {
   });
 
 });
+
+describe('Abstract Provider With PKCE', () => {
+
+  class ConcreteProvider extends AbstractProvider<any, any> {
+    protected configPaths = {
+      clientId: 'settings.social.example.clientId',
+      clientSecret: 'settings.social.example.clientSecret',
+      redirectUri: 'settings.social.example.redirectUri'
+    };
+    protected useCodeChallenge = true;
+    protected authEndpoint = 'https://example2.com/auth';
+    protected tokenEndpoint = 'http://localhost:3000/token';
+    getUserInfoFromTokens(tokens: SocialTokens) {
+      throw new Error('Method not implemented.');
+    }
+  }
+
+  let provider: ConcreteProvider;
+  const clientId = 'clientIdXXX';
+  const clientSecret = 'clientSecretYYY';
+  const redirectUri = 'https://example.com/callback';
+
+  beforeEach(() => {
+    Config.set('settings.social.example.clientId', clientId);
+    Config.set('settings.social.example.clientSecret', clientSecret);
+    Config.set('settings.social.example.redirectUri', redirectUri);
+    Config.set('settings.loggerFormat', 'none');
+
+    provider = createService(ConcreteProvider);
+  });
+
+  afterEach(() => {
+    Config.remove('settings.social.example.clientId');
+    Config.remove('settings.social.example.clientSecret');
+    Config.remove('settings.social.example.redirectUri');
+    Config.remove('settings.social.cookie.secure');
+  });
+
+  describe('has a "redirect" method that', () => {
+
+    it('should fail if secret is not configured', async () => {
+      try {
+        await provider.redirect();
+      } catch(error) {
+        if(!(error instanceof ConfigNotFoundError)){
+          throw error;
+        }
+      }
+    });
+
+    describe('should return an HttpResponseRedirect object', () => {
+
+      beforeEach(() => {
+        Config.set('settings.social.secret.codeChallengeSecret', 'SECRET');
+      });
+
+      afterEach(() => {
+        Config.remove('settings.social.secret.codeChallengeSecret');
+      });
+
+      it('with a redirect path which contains a client ID, a response type, a redirect URI, code_challenge and code_challenge_method (S256) if pkce enabled.', async () => {
+        const response = await provider.redirect();
+        ok(response.path.startsWith(
+          'https://example2.com/auth?'
+          + 'response_type=code&'
+          + 'client_id=clientIdXXX&'
+          + 'redirect_uri=https%3A%2F%2Fexample.com%2Fcallback'
+        ));
+        const searchParams = new URLSearchParams(response.path);
+        ok(searchParams.get('code_challenge'));
+        strictEqual(searchParams.get('code_challenge_method'), 'S256');
+      });
+    });
+
+    describe('has a "getTokens" method that', () => {
+
+      let server: Server;
+      const secret: string = 'SECRETCODE';
+
+      afterEach(() => {
+        if (server) {
+          server.close();
+        }
+        Config.remove('settings.social.secret.codeChallengeSecret');
+      });
+
+      beforeEach(() => {
+        Config.set('settings.social.secret.codeChallengeSecret', secret);
+      });
+
+      it('should send a request which contains a grant type, a code, a redirect URI,'
+        + 'a client ID, a client secret and code_verifier and return the response body.', async () => {
+
+        const codeChallenge = 'challenge';
+
+        class AppController {
+          @Post('/token')
+          token(ctx: Context) {
+            strictEqual(ctx.request.headers.accept, 'application/json');
+            const { grant_type, code, redirect_uri, client_id, client_secret, code_verifier } = ctx.request.body;
+            strictEqual(grant_type, 'authorization_code');
+            strictEqual(code, 'an_authorization_code');
+            strictEqual(redirect_uri, redirectUri);
+            strictEqual(client_id, clientId);
+            strictEqual(client_secret, clientSecret);
+            strictEqual(code_verifier, codeChallenge)
+            return new HttpResponseOK({
+              access_token: 'an_access_token',
+              token_type: 'bearer'
+            });
+          }
+        }
+
+        server = (await createApp(AppController)).listen(3000);
+
+        const iv = crypto.randomBytes(16); // temporary for testing purpose
+
+        const ctx = new Context({
+          cookies: {
+            [STATE_COOKIE_NAME]: 'xxx',
+            [CODE_CHALLENGE_NAME]: encryptHelper(codeChallenge, iv, secret)
+          },
+          query: {
+            code: 'an_authorization_code',
+            state: 'xxx',
+          },
+        });
+
+        const actual = await provider.getTokens(ctx);
+        const expected: SocialTokens = {
+          access_token: 'an_access_token',
+          token_type: 'bearer'
+        };
+        deepStrictEqual(actual, expected);
+      });
+
+      it('should throw a InvalidCodeChallengeError if Code Verifier not exists or is not valid', async () => {
+        class AppController {
+          @Post('/token')
+          token() {
+            return new HttpResponseBadRequest({
+              error: 'bad request'
+            });
+          }
+        }
+
+        server = (await createApp(AppController)).listen(3000);
+
+        const ctx = new Context({
+          cookies: {
+            [STATE_COOKIE_NAME]: 'xxx'
+          },
+          query: {
+            code: 'an_authorization_code',
+            state: 'xxx',
+          },
+        });
+
+        try {
+          await provider.getTokens(ctx);
+          throw new Error('getTokens should have thrown a InvalidCodeChallengeError.');
+        } catch (error) {
+          if (!(error instanceof InvalidCodeChallengeError)) {
+            throw error;
+          }
+        }
+      })
+    });
+  });
+
+});
+
+describe('Abstract Provider With PKCE and Plain Method', () => {
+  class ConcreteProvider extends AbstractProvider<any, any> {
+    protected configPaths = {
+      clientId: 'settings.social.example.clientId',
+      clientSecret: 'settings.social.example.clientSecret',
+      redirectUri: 'settings.social.example.redirectUri'
+    };
+    protected useCodeChallenge = true;
+    protected codeChallengeMethodPlain = true;
+    protected authEndpoint = 'https://example2.com/auth';
+    protected tokenEndpoint = 'http://localhost:3000/token';
+    getUserInfoFromTokens(tokens: SocialTokens) {
+      throw new Error('Method not implemented.');
+    }
+  }
+
+  let provider: ConcreteProvider;
+  const clientId = 'clientIdXXX';
+  const clientSecret = 'clientSecretYYY';
+  const redirectUri = 'https://example.com/callback';
+
+  beforeEach(() => {
+    Config.set('settings.social.example.clientId', clientId);
+    Config.set('settings.social.example.clientSecret', clientSecret);
+    Config.set('settings.social.example.redirectUri', redirectUri);
+    Config.set('settings.loggerFormat', 'none');
+
+    provider = createService(ConcreteProvider);
+  });
+
+  afterEach(() => {
+    Config.remove('settings.social.example.clientId');
+    Config.remove('settings.social.example.clientSecret');
+    Config.remove('settings.social.example.redirectUri');
+    Config.remove('settings.social.cookie.secure');
+  });
+
+  describe('has a "redirect" method that', () => {
+    describe('should return an HttpResponseRedirect object', () => {
+
+      beforeEach(() => {
+        Config.set('settings.social.secret.codeChallengeSecret', 'SECRET');
+      });
+
+      afterEach(() => {
+        Config.remove('settings.social.secret.codeChallengeSecret');
+      });
+
+      it('with a redirect path which contains a client ID, a response type, a redirect URI, code_challenge and code_challenge_method (plain) if pkce enabled.', async () => {
+        const response = await provider.redirect();
+        ok(response.path.startsWith(
+          'https://example2.com/auth?'
+          + 'response_type=code&'
+          + 'client_id=clientIdXXX&'
+          + 'redirect_uri=https%3A%2F%2Fexample.com%2Fcallback'
+        ));
+        const searchParams = new URLSearchParams(response.path);
+        ok(searchParams.get('code_challenge'));
+        strictEqual(searchParams.get('code_challenge_method'), 'plain');
+      });
+    });
+  });
+});
+
+function encryptHelper(message: string, iv: Buffer, secret: string): string {
+  // Hash secret
+  const hashedSecret = crypto.createHash('sha256').update(secret).digest();
+
+  // Create cipher
+  const cipher = crypto.createCipheriv('aes-256-ctr', hashedSecret, iv); // aes-256-ctr is default
+
+  // Encrypt data, concat final
+  const data = cipher.update(Buffer.from(message));
+  const encryptedMessage = Buffer.concat([data, cipher.final()])
+
+  return `${iv.toString('base64')}${encryptedMessage.toString('base64')}`
+}

--- a/packages/social/src/abstract-provider.service.ts
+++ b/packages/social/src/abstract-provider.service.ts
@@ -100,7 +100,7 @@ export class TokenError extends Error {
 }
 
 const STATE_COOKIE_NAME = 'oauth2-state';
-const CODE_CHALLENGE_NAME = 'oauth2-code-challenge'
+const CODE_VERIFIER_NAME = 'oauth2-code-verifier'
 
 export interface ObjectType {
   [name: string]: any;
@@ -179,7 +179,7 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
    * @type {boolean}
    * @memberof AbstractProvider
    */
-   protected readonly useCodeChallenge: boolean = false;
+   protected readonly useCodeVerifier: boolean = false;
 
   /**
    * Property use Plain Method within code challenge on PCKE.
@@ -264,8 +264,8 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
     // We use a base64url-encoded random token making OAuth2 PKCE spec compliant - see https://datatracker.ietf.org/doc/html/rfc7636#appendix-B for more information
     const codeVerifier = await generateToken();
 
-    // Add PKCE if config.useCodeChallenge is true
-    if (this.useCodeChallenge) {
+    // Add PKCE if config.useCodeVerifier is true
+    if (this.useCodeVerifier) {
 
       const hash = crypto.createHash('sha256').update(codeVerifier).digest('base64');
       url.searchParams.set('code_challenge', this.codeChallengeMethodPlain ? codeVerifier : convertBase64ToBase64url(hash));
@@ -275,10 +275,10 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
     const redirectResponse = new HttpResponseRedirect(url.href);
 
     // Add Code Challenge COOKIE for token request
-    if (this.useCodeChallenge) {
+    if (this.useCodeVerifier) {
 
       // Encrypt this code_challenge cookie for security reasons
-      redirectResponse.setCookie(CODE_CHALLENGE_NAME, this.encryptString(codeVerifier), {
+      redirectResponse.setCookie(CODE_VERIFIER_NAME, this.encryptString(codeVerifier), {
         httpOnly: true,
         maxAge: 300,
         path: '/',
@@ -324,9 +324,9 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
     params.set('client_id', this.config.clientId);
     params.set('client_secret', this.config.clientSecret);
 
-    // Add code_verifier if config.useCodeChallenge is true
-    if (this.useCodeChallenge) {
-      const codeChallenge = ctx.request.cookies[CODE_CHALLENGE_NAME]
+    // Add code_verifier if config.useCodeVerifier is true
+    if (this.useCodeVerifier) {
+      const codeChallenge = ctx.request.cookies[CODE_VERIFIER_NAME]
       if (!codeChallenge) {
         throw new InvalidCodeChallengeError();
       }

--- a/packages/social/src/abstract-provider.service.ts
+++ b/packages/social/src/abstract-provider.service.ts
@@ -214,7 +214,7 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
    * @type {string}
    * @memberof AbstractProvider
    */
-  protected readonly cryptAlgorithm: string = 'aes-256-ctr' ;
+  private readonly cryptAlgorithm: string = 'aes-256-ctr' ;
 
   private get config() {
     return {

--- a/packages/social/src/abstract-provider.service.ts
+++ b/packages/social/src/abstract-provider.service.ts
@@ -349,7 +349,7 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
 
     if (this.useAuthorizationHeaderForTokenEndpoint) {
       const auth = Buffer.from(`${this.config.clientId}:${this.config.clientSecret}`).toString('base64');
-      headers['Authorization'] = `Basic ${auth}`;
+      headers.Authorization = `Basic ${auth}`;
     }
 
     const response = await fetch(this.tokenEndpoint, {

--- a/packages/social/src/abstract-provider.service.ts
+++ b/packages/social/src/abstract-provider.service.ts
@@ -327,7 +327,7 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
     // Add code_verifier if config.useCodeChallenge is true
     if (this.useCodeChallenge) {
       const codeChallenge = ctx.request.cookies[CODE_CHALLENGE_NAME]
-      if (!codeChallenge || codeChallenge === '' ) {
+      if (!codeChallenge) {
         throw new InvalidCodeChallengeError();
       }
 

--- a/packages/social/src/abstract-provider.service.ts
+++ b/packages/social/src/abstract-provider.service.ts
@@ -197,7 +197,7 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
    * @type {boolean}
    * @memberof AbstractProvider
    */
-   protected readonly codeChallengeSecretPath: string = 'settings.social.secret.codeChallengeSecret';
+   protected readonly codeVerifierSecretPath: string = 'settings.social.secret.codeVerifierSecret';
 
   /**
    * Algorithm used for encrypt code challenge.
@@ -339,7 +339,8 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
     const response = await fetch(this.tokenEndpoint, {
       body: params,
       headers: {
-        Accept: 'application/json'
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded'
       },
       method: 'POST',
     });
@@ -374,7 +375,7 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
   }
 
   /**
-   * This function is for encrypt a string using aes-256 and codeChallengeSecret.
+   * This function is for encrypt a string using aes-256 and codeVerifierSecret.
    * Notice that init vector base64-encoded is concatenated at start of encrypted message.
    * We'll need init vector to decrypt message.
    * Init vector is 16 bytes length and it base64-encoded is 24 bytes length.
@@ -383,7 +384,7 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
    */
   private encryptString(message: string): string {
 
-    const hashedSecret = this.getCodeChallengeSecretBuffer();
+    const hashedSecret = this.getCodeVerifierSecretBuffer();
 
     // Initiate iv with random bytes
     const initVector = crypto.randomBytes(16);
@@ -399,14 +400,14 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
   }
 
   /**
-   * This function is for decrypt a string using aes-256 and codeChallengeSecret
+   * This function is for decrypt a string using aes-256 and codeVerifierSecret
    * encryptedMessage is {iv}{encrypted data}
    *
    * @param {string} encryptedMessage - String to decrypt
    */
     private decryptString(encryptedMessage: string): string {
 
-      const hashedSecret = this.getCodeChallengeSecretBuffer();
+      const hashedSecret = this.getCodeVerifierSecretBuffer();
 
       // Get init vector back from encryptedMessage
       const initVector: Buffer = Buffer.from(encryptedMessage.substring(0,24), 'base64'); // original iv is 16 bytes long, so base64 encoded is 24 bytes long
@@ -422,10 +423,10 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
       return decryptedMessage.toString()
     }
 
-    private getCodeChallengeSecretBuffer(): Buffer {
+    private getCodeVerifierSecretBuffer(): Buffer {
       // Get secret from config file or throw an error if not defined
-      const codeChallengeSecret = Config.getOrThrow(this.codeChallengeSecretPath, 'string');
+      const codeVerifierSecret = Config.getOrThrow(this.codeVerifierSecretPath, 'string');
       // We create a sha256 hash to ensure that key is 32 bytes long
-      return crypto.createHash('sha256').update(codeChallengeSecret).digest();
+      return crypto.createHash('sha256').update(codeVerifierSecret).digest();
     }
 }

--- a/packages/social/src/abstract-provider.service.ts
+++ b/packages/social/src/abstract-provider.service.ts
@@ -100,7 +100,7 @@ export class TokenError extends Error {
 }
 
 const STATE_COOKIE_NAME = 'oauth2-state';
-const CODE_VERIFIER_NAME = 'oauth2-code-verifier'
+const CODE_VERIFIER_COOKIE_NAME = 'oauth2-code-verifier'
 
 export interface ObjectType {
   [name: string]: any;
@@ -283,7 +283,7 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
     // Add Code Challenge COOKIE for token request
     if (this.usePKCE) {
       // Encrypt this code_challenge cookie for security reasons
-      redirectResponse.setCookie(CODE_VERIFIER_NAME, this.encryptString(codeVerifier), {
+      redirectResponse.setCookie(CODE_VERIFIER_COOKIE_NAME, this.encryptString(codeVerifier), {
         httpOnly: true,
         maxAge: 300,
         path: '/',
@@ -333,7 +333,7 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
     }
 
     if (this.usePKCE) {
-      const encryptedCodeVerifier = ctx.request.cookies[CODE_VERIFIER_NAME]
+      const encryptedCodeVerifier = ctx.request.cookies[CODE_VERIFIER_COOKIE_NAME]
       if (!encryptedCodeVerifier) {
         throw new CodeVerifierNotFound();
       }

--- a/packages/social/src/index.ts
+++ b/packages/social/src/index.ts
@@ -9,7 +9,7 @@ export {
   UserInfoAndTokens,
   SocialTokens,
   InvalidStateError,
-  InvalidCodeChallengeError,
+  CodeVerifierNotFound,
   TokenError,
   AuthorizationError,
   ObjectType,

--- a/packages/social/src/index.ts
+++ b/packages/social/src/index.ts
@@ -33,5 +33,9 @@ export {
   LinkedInUserInfoParams,
 } from './linkedin-provider.service';
 export {
+  TwitterProvider,
+  TwitterAuthParameter,
+} from './twitter-provider.service'
+export {
   UserInfoError,
 } from './user-info.error';

--- a/packages/social/src/index.ts
+++ b/packages/social/src/index.ts
@@ -9,6 +9,7 @@ export {
   UserInfoAndTokens,
   SocialTokens,
   InvalidStateError,
+  InvalidCodeChallengeError,
   TokenError,
   AuthorizationError,
   ObjectType,

--- a/packages/social/src/twitter-provider.service.spec.ts
+++ b/packages/social/src/twitter-provider.service.spec.ts
@@ -1,0 +1,91 @@
+// std
+import { deepStrictEqual, strictEqual } from 'assert';
+import { Server } from 'http';
+
+// 3p
+import { Config, Context, createApp, createService, Get, HttpResponseBadRequest, HttpResponseOK } from '@foal/core';
+
+// FoalTS
+import { SocialTokens } from './abstract-provider.service';
+import { TwitterProvider } from './twitter-provider.service';
+import { UserInfoError } from './user-info.error';
+
+describe('TwitterProvider', () => {
+
+  describe('has a "getUserInfoFromTokens" that', () => {
+
+    class TwitterProvider2 extends TwitterProvider {
+      userInfoEndpoint = 'http://localhost:3000/users/me';
+    }
+
+    let server: Server;
+    let provider: TwitterProvider;
+
+    beforeEach(() => {
+      provider = createService(TwitterProvider2);
+      Config.set('settings.loggerFormat', 'none');
+    });
+
+    afterEach(() => {
+      Config.remove('settings.loggerFormat');
+      if (server) {
+        server.close();
+      }
+    });
+
+    it('should send a request with the access token and return the response body.', async () => {
+      const userInfo = { email: 'john@foalts.org' };
+
+      class AppController {
+        @Get('/users/me')
+        token(ctx: Context) {
+          const { authorization } = ctx.request.headers;
+          strictEqual(authorization, 'token_type an_access_token');
+          return new HttpResponseOK(userInfo);
+        }
+      }
+
+      server = (await createApp(AppController)).listen(3000);
+
+      const tokens: SocialTokens = {
+        access_token: 'an_access_token',
+        token_type: 'token_type'
+      };
+
+      const actual = await provider.getUserInfoFromTokens(tokens);
+      deepStrictEqual(actual, userInfo);
+    });
+
+    it('should throw a UserInfoError if the user info endpoint returns an error.', async () => {
+      class AppController {
+        @Get('/users/me')
+        token() {
+          return new HttpResponseBadRequest({
+            error: 'bad request'
+          });
+        }
+      }
+
+      server = (await createApp(AppController)).listen(3000);
+
+      const tokens: SocialTokens = {
+        access_token: 'an_access_token',
+        token_type: 'token_type'
+      };
+
+      try {
+        await provider.getUserInfoFromTokens(tokens);
+        throw new Error('getUserInfoFromTokens should have thrown a TokenError.');
+      } catch (error) {
+        if (!(error instanceof UserInfoError)) {
+          throw error;
+        }
+        deepStrictEqual(error.error, {
+          error: 'bad request'
+        });
+      }
+    });
+
+  });
+
+});

--- a/packages/social/src/twitter-provider.service.ts
+++ b/packages/social/src/twitter-provider.service.ts
@@ -27,6 +27,7 @@ export class TwitterProvider extends AbstractProvider<TwitterAuthParameter, neve
 
   // Enable code flow with PKCE
   protected useCodeVerifier: boolean = true;
+  protected useAuthorizationHeaderForTokenEndpoint = true;
 
   protected defaultScopes: string[] = [ 'users.read', 'tweet.read' ];
 

--- a/packages/social/src/twitter-provider.service.ts
+++ b/packages/social/src/twitter-provider.service.ts
@@ -26,7 +26,7 @@ export class TwitterProvider extends AbstractProvider<TwitterAuthParameter, neve
   protected userInfoEndpoint = 'https://api.twitter.com/2/users/me';
 
   // Enable code flow with PKCE
-  protected useCodeChallenge = true;
+  protected useCodeVerifier: boolean = true;
 
   protected defaultScopes: string[] = [ 'users.read', 'tweet.read' ];
 

--- a/packages/social/src/twitter-provider.service.ts
+++ b/packages/social/src/twitter-provider.service.ts
@@ -25,8 +25,7 @@ export class TwitterProvider extends AbstractProvider<TwitterAuthParameter, neve
   protected tokenEndpoint = 'https://api.twitter.com/2/oauth2/token';
   protected userInfoEndpoint = 'https://api.twitter.com/2/users/me';
 
-  // Enable code flow with PKCE
-  protected useCodeVerifier: boolean = true;
+  protected usePKCE: boolean = true;
   protected useAuthorizationHeaderForTokenEndpoint = true;
 
   protected defaultScopes: string[] = [ 'users.read', 'tweet.read' ];

--- a/packages/social/src/twitter-provider.service.ts
+++ b/packages/social/src/twitter-provider.service.ts
@@ -19,13 +19,14 @@ export class TwitterProvider extends AbstractProvider<TwitterAuthParameter, neve
   protected configPaths = {
     clientId: 'settings.social.twitter.clientId',
     clientSecret: 'settings.social.twitter.clientSecret',
-    redirectUri: 'settings.social.twitter.redirectUri',
-    useCodeChallenge: 'settings.social.twitter.useCodeChallenge',
-    codeChallengeMethod: 'settings.social.twitter.codeChallengeMethod'
+    redirectUri: 'settings.social.twitter.redirectUri'
   };
   protected authEndpoint = 'https://twitter.com/i/oauth2/authorize';
   protected tokenEndpoint = 'https://api.twitter.com/2/oauth2/token';
   protected userInfoEndpoint = 'https://api.twitter.com/2/users/me';
+
+  // Enable code flow with PKCE
+  protected useCodeChallenge = true;
 
   protected defaultScopes: string[] = [ 'users.read', 'tweet.read' ];
 

--- a/packages/social/src/twitter-provider.service.ts
+++ b/packages/social/src/twitter-provider.service.ts
@@ -1,0 +1,44 @@
+// 3p
+import * as fetch from 'node-fetch';
+
+// FoalTS
+import { AbstractProvider, SocialTokens } from './abstract-provider.service';
+import { UserInfoError } from './user-info.error';
+
+export interface TwitterAuthParameter {
+}
+
+/**
+ * Twitter social provider.
+ *
+ * @export
+ * @class TwitterProvider
+ * @extends {AbstractProvider<TwitterAuthParameter, never>}
+ */
+export class TwitterProvider extends AbstractProvider<TwitterAuthParameter, never> {
+  protected configPaths = {
+    clientId: 'settings.social.twitter.clientId',
+    clientSecret: 'settings.social.twitter.clientSecret',
+    redirectUri: 'settings.social.twitter.redirectUri',
+    useCodeChallenge: 'settings.social.twitter.useCodeChallenge',
+    codeChallengeMethod: 'settings.social.twitter.codeChallengeMethod'
+  };
+  protected authEndpoint = 'https://twitter.com/i/oauth2/authorize';
+  protected tokenEndpoint = 'https://api.twitter.com/2/oauth2/token';
+  protected userInfoEndpoint = 'https://api.twitter.com/2/users/me';
+
+  protected defaultScopes: string[] = [ 'users.read', 'tweet.read' ];
+
+  async getUserInfoFromTokens(tokens: SocialTokens) {
+    const response = await fetch(this.userInfoEndpoint, {
+      headers: { Authorization: `${tokens.token_type} ${tokens.access_token}` }
+    });
+    const body = await response.json();
+
+    if (!response.ok) {
+      throw new UserInfoError(body);
+    }
+
+    return body;
+  }
+}


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue
#1014
#1047 

# Solution and steps
## Feature
Two more optional configs were added in AbstractProvider: 
- useCodeChallenge (boolean): to enable Code Flow
- codeChallengeMethodPlain (boolean): to force plain method instead SHA256

if it's enable then redirect() set a new Cookie with code_challenge to send as code_verifier parameter when fetch token and add to authorize url path both code_challenge and code_challenge_method

With this new approach then added TwitterProvider using this new feature to interact with twitter api.

## Tests
Tests added to Abstract Provider
  -  has a "redirect" method that
     - should return an HttpResponseRedirect object
       - if code_challenge is configured as active in config
          ✓ with code_challenge_method (S256) - codeChallengeMethodPlain: false
          ✓ with code_challenge_method (plain) - codeChallengeMethodPlain: true
   - has a "getTokens" method that
      - if code_challenge is configured as active in config
        ✓ should send a request which contains a grant type, a code, a redirect URI,a client ID, a client secret and code_verifier and return the response body.
        ✓ should throw a InvalidCodeChallengeError if Code Verifier not exists or is not valid
Tests added to TwitterProvider
  - has a "getUserInfoFromTokens" that
      ✓ should send a request with the access token and return the response body.
      ✓ should throw a UserInfoError if the user info endpoint returns an error.

## Docs
Social auth was updated with this new feature

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [ ] Update/check the cli generators. (Not needed)
