### PR TITLE
Replace `node-fetch` with `axios`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16]
+        node-version: [14, '16.14.0']
 
     env:
       SETTINGS_AWS_ACCESS_KEY_ID: ${{ secrets.SETTINGS_AWS_ACCESS_KEY_ID }}

--- a/packages/aws-s3/src/s3-disk.service.spec.ts
+++ b/packages/aws-s3/src/s3-disk.service.spec.ts
@@ -11,7 +11,7 @@ import { S3 } from '@aws-sdk/client-s3';
 import { S3Disk } from './s3-disk.service';
 
 // Isolate each job with a different S3 bucket.
-const bucketName = `foal-test-${process.env.NODE_VERSION || 10}`;
+const bucketName = `foal-test-${process.env.NODE_VERSION?.slice(0,2) || 14}`;
 
 async function rmObjectsIfExist(s3: S3) {
   const response = await s3.listObjects({

--- a/packages/jwks-rsa/package-lock.json
+++ b/packages/jwks-rsa/package-lock.json
@@ -19,9 +19,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "17.0.23",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-					"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+					"version": "17.0.24",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.24.tgz",
+					"integrity": "sha512-aveCYRQbgTH9Pssp1voEP7HiuWlD2jW2BO56w+bVrJn04i61yh6mRfoKO6hEYQD9vF+W8Chkwc6j1M36uPkx4g=="
 				}
 			}
 		},
@@ -34,9 +34,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "17.0.23",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-					"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+					"version": "17.0.24",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.24.tgz",
+					"integrity": "sha512-aveCYRQbgTH9Pssp1voEP7HiuWlD2jW2BO56w+bVrJn04i61yh6mRfoKO6hEYQD9vF+W8Chkwc6j1M36uPkx4g=="
 				}
 			}
 		},
@@ -71,9 +71,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "17.0.23",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-					"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+					"version": "17.0.24",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.24.tgz",
+					"integrity": "sha512-aveCYRQbgTH9Pssp1voEP7HiuWlD2jW2BO56w+bVrJn04i61yh6mRfoKO6hEYQD9vF+W8Chkwc6j1M36uPkx4g=="
 				}
 			}
 		},
@@ -122,9 +122,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "17.0.23",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-					"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+					"version": "17.0.24",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.24.tgz",
+					"integrity": "sha512-aveCYRQbgTH9Pssp1voEP7HiuWlD2jW2BO56w+bVrJn04i61yh6mRfoKO6hEYQD9vF+W8Chkwc6j1M36uPkx4g=="
 				}
 			}
 		},

--- a/packages/jwks-rsa/package-lock.json
+++ b/packages/jwks-rsa/package-lock.json
@@ -16,6 +16,13 @@
 			"requires": {
 				"@types/connect": "*",
 				"@types/node": "*"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "17.0.23",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+					"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+				}
 			}
 		},
 		"@types/connect": {
@@ -24,6 +31,13 @@
 			"integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
 			"requires": {
 				"@types/node": "*"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "17.0.23",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+					"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+				}
 			}
 		},
 		"@types/express": {
@@ -54,12 +68,19 @@
 				"@types/node": "*",
 				"@types/qs": "*",
 				"@types/range-parser": "*"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "17.0.23",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+					"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+				}
 			}
 		},
 		"@types/express-unless": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.2.tgz",
-			"integrity": "sha512-Q74UyYRX/zIgl1HSp9tUX2PlG8glkVm+59r7aK4KGKzC5jqKIOX6rrVLRQrzpZUQ84VukHtRoeAuon2nIssHPQ==",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.3.tgz",
+			"integrity": "sha512-TyPLQaF6w8UlWdv4gj8i46B+INBVzURBNRahCozCSXfsK2VTlL1wNyTlMKw817VHygBtlcl5jfnPadlydr06Yw==",
 			"requires": {
 				"@types/express": "*"
 			}
@@ -78,7 +99,8 @@
 		"@types/node": {
 			"version": "10.17.24",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-			"integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
+			"integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA==",
+			"dev": true
 		},
 		"@types/qs": {
 			"version": "6.9.7",
@@ -97,6 +119,13 @@
 			"requires": {
 				"@types/mime": "^1",
 				"@types/node": "*"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "17.0.23",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+					"integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+				}
 			}
 		},
 		"@ungap/promise-all-settled": {
@@ -112,9 +141,9 @@
 			"dev": true
 		},
 		"ansi-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+			"integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
 			"dev": true
 		},
 		"ansi-styles": {
@@ -301,18 +330,11 @@
 			"dev": true
 		},
 		"debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"requires": {
 				"ms": "2.1.2"
-			},
-			"dependencies": {
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
 			}
 		},
 		"decamelize": {
@@ -633,14 +655,19 @@
 							"dev": true
 						}
 					}
+				},
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+					"dev": true
 				}
 			}
 		},
 		"ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"nanoid": {
 			"version": "3.1.20",
@@ -833,9 +860,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-			"integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
 			"dev": true
 		},
 		"which": {

--- a/packages/social/package-lock.json
+++ b/packages/social/package-lock.json
@@ -38,9 +38,9 @@
 			}
 		},
 		"ansi-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+			"integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
 			"dev": true
 		},
 		"ansi-styles": {
@@ -552,9 +552,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.9",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-			"integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
 			"dev": true
 		},
 		"growl": {
@@ -944,27 +944,27 @@
 			}
 		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
 		},
 		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
 			"dev": true,
 			"requires": {
-				"minimist": "^1.2.5"
+				"minimist": "^1.2.6"
 			}
 		},
 		"mocha": {
@@ -1012,6 +1012,15 @@
 						"minimatch": "^3.0.4",
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"which": {
@@ -1402,9 +1411,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-			"integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+			"version": "4.5.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+			"integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
 			"dev": true
 		},
 		"unc-path-regex": {

--- a/packages/social/package-lock.json
+++ b/packages/social/package-lock.json
@@ -98,6 +98,14 @@
 			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
 			"dev": true
 		},
+		"axios": {
+			"version": "0.26.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+			"requires": {
+				"follow-redirects": "^1.14.8"
+			}
+		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -467,6 +475,11 @@
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
 			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
 			"dev": true
+		},
+		"follow-redirects": {
+			"version": "1.14.9",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+			"integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
 		},
 		"fs-exists-sync": {
 			"version": "0.1.0",
@@ -1024,14 +1037,6 @@
 			"integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
 			"dev": true
 		},
-		"node-fetch": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-			"requires": {
-				"whatwg-url": "^5.0.0"
-			}
-		},
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1375,11 +1380,6 @@
 				"is-number": "^7.0.0"
 			}
 		},
-		"tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-		},
 		"ts-node": {
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.0.0.tgz",
@@ -1428,20 +1428,6 @@
 				"clone": "^1.0.0",
 				"clone-stats": "^0.0.1",
 				"replace-ext": "0.0.1"
-			}
-		},
-		"webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-		},
-		"whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-			"requires": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"which": {

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@foal/core": "^2.8.1",
-    "node-fetch": "~2.6.7"
+    "axios": "0.26.1"
   },
   "devDependencies": {
     "@types/mocha": "7.0.2",

--- a/packages/social/src/abstract-provider.service.ts
+++ b/packages/social/src/abstract-provider.service.ts
@@ -3,7 +3,7 @@ import { URL, URLSearchParams } from 'url';
 
 // 3p
 import { Config, Context, generateToken, HttpResponseRedirect } from '@foal/core';
-import * as fetch from 'node-fetch';
+import axios from 'axios';
 
 /**
  * Tokens returned by an OAuth2 authorization server.
@@ -246,20 +246,16 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
     params.set('client_id', this.config.clientId);
     params.set('client_secret', this.config.clientSecret);
 
-    const response = await fetch(this.tokenEndpoint, {
-      body: params,
-      headers: {
-        Accept: 'application/json'
-      },
-      method: 'POST',
-    });
-    const body = await response.json();
-
-    if (!response.ok) {
-      throw new TokenError(body);
+    try {
+      const response = await axios.post(this.tokenEndpoint, params, {
+        headers: {
+          Accept: 'application/json'
+        },
+      });
+      return response.data;
+    } catch (error: any) {
+      throw new TokenError(error.response.data);
     }
-
-    return body;
   }
 
   /**

--- a/packages/social/src/facebook-provider.service.ts
+++ b/packages/social/src/facebook-provider.service.ts
@@ -2,7 +2,7 @@
 import { URL } from 'url';
 
 // 3p
-import * as fetch from 'node-fetch';
+import axios from 'axios';
 
 // FoalTS
 import { AbstractProvider, SocialTokens } from './abstract-provider.service';
@@ -44,14 +44,12 @@ export class FacebookProvider extends AbstractProvider<FacebookAuthParams, Faceb
     const fields = params && params.fields ? params.fields : this.fields;
     url.searchParams.set('fields', fields.join(','));
 
-    const response = await fetch(url.href);
-    const body = await response.json();
-
-    if (!response.ok) {
-      throw new UserInfoError(body);
+    try {
+      const response = await axios.get(url.href);
+      return response.data;
+    } catch (error: any) {
+      throw new UserInfoError(error.response.data);
     }
-
-    return body;
   }
 
 }

--- a/packages/social/src/github-provider.service.ts
+++ b/packages/social/src/github-provider.service.ts
@@ -1,5 +1,5 @@
 // 3p
-import * as fetch from 'node-fetch';
+import axios from 'axios';
 
 // FoalTS
 import { AbstractProvider, SocialTokens } from './abstract-provider.service';
@@ -28,16 +28,14 @@ export class GithubProvider extends AbstractProvider<GithubAuthParams, never> {
   protected userInfoEndpoint = 'https://api.github.com/user';
 
   async getUserInfoFromTokens(tokens: SocialTokens) {
-    const response = await fetch(this.userInfoEndpoint, {
-      headers: { Authorization: `token ${tokens.access_token}` }
-    });
-    const body = await response.json();
-
-    if (!response.ok) {
-      throw new UserInfoError(body);
+    try {
+      const response = await axios.get(this.userInfoEndpoint, {
+        headers: { Authorization: `token ${tokens.access_token}` }
+      });
+      return response.data;
+    } catch (error: any) {
+      throw new UserInfoError(error.response.data);
     }
-
-    return body;
   }
 
 }

--- a/packages/social/src/linkedin-provider.service.ts
+++ b/packages/social/src/linkedin-provider.service.ts
@@ -2,7 +2,7 @@
 import { URL } from 'url';
 
 // 3p
-import * as fetch from 'node-fetch';
+import axios from 'axios';
 
 // FoalTS
 import { AbstractProvider, SocialTokens } from './abstract-provider.service';
@@ -43,16 +43,14 @@ export class LinkedInProvider extends AbstractProvider<never, LinkedInUserInfoPa
       url.searchParams.set('fields', params.fields.join(','));
     }
 
-    const response = await fetch(url.href, {
-      headers: { Authorization: `Bearer ${tokens.access_token}` }
-    });
-    const body = await response.json();
-
-    if (!response.ok) {
-      throw new UserInfoError(body);
+    try {
+      const response = await axios.get(url.href, {
+        headers: { Authorization: `Bearer ${tokens.access_token}` }
+      });
+      return response.data;
+    } catch (error: any) {
+      throw new UserInfoError(error.response.data);
     }
-
-    return body;
   }
 
 }

--- a/packages/social/typings/node-fetch/index.d.ts
+++ b/packages/social/typings/node-fetch/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'node-fetch';


### PR DESCRIPTION
# Issue

We cannot upgrade the `node-fetch` dependency to `node-fetch@3` because it requires ESM enabled. For this reason, we had to remove the dependency to use another one (building, testing and maintaining a http client was requiring too much work). I chose `axios`.

Pros: it is widely used and has only one dependency.
Cons: it is still in `0.x.y`.

# Solution and steps

- [x] Uninstall `node-fetch` and install `axios`

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
