### PR TITLE
[CLI] Fix installation with yarn on node 10

### DIFF
--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -163,7 +163,8 @@ export async function createApp({ name, autoInstall, initRepo, mongodb = false, 
     log();
     const spinner = log(`%s 📦 Installing dependencies (${packageManager})...`, true);
 
-    const args = [ 'install' ];
+    // TODO: in version 3, remove the hack "--ignore-engines"
+    const args = [ 'install', '--ignore-engines' ];
     const options: SpawnOptions = {
       cwd: names.kebabName,
       shell: true,


### PR DESCRIPTION
# Issue

The creation of a new project (i.e. `createapp`) on Node 10 with yarn is failing: https://github.com/FoalTS/foal/actions/runs/2107640821.

Underlying reason: a sub-dependency of a direct dependency requires at least Node v12.

Issue: v2 of Foal still officially supports Node 10 (which is not maintained anymore), so the unique option here is not to check this value in the package.json (which is not great but ok for the situation).

For future major versions of Foal: the minimum version of NodeJS required should always be recent (at least v14 for Foal v3).

# Solution

Do no check the `engine` in yarn installation .

Similar commit: https://github.com/FoalTS/foal/commit/91414f1fd497040595e13d38479f584c1d8360f1

