### PR TITLE
[Docs] Syntax error fix

### DIFF
--- a/docs/docs/authentication-and-access-control/groups-and-permissions.md
+++ b/docs/docs/authentication-and-access-control/groups-and-permissions.md
@@ -69,7 +69,7 @@ export async function main(args: { codeName: string, name: string }) {
 
   try {
     console.log(
-      await permission.save();
+      await permission.save()
     );
   } catch (error) {
     console.log(error.message);


### PR DESCRIPTION
# Issue
Syntax error in docs for auth and access control.

# Solution and steps
Removed semi colon, see file change.
