### PR TITLE
Support `graphql@15`

### DIFF
--- a/docs/docs/api-section/graphql.md
+++ b/docs/docs/api-section/graphql.md
@@ -29,6 +29,8 @@ title: GraphQL
 To use GraphQL with FoalTS, you need to install the packages `graphql` and `@foal/graphql`. The first one is maintained by the GraphQL community and parses and resolves queries. The second is specific to FoalTS and allows you to configure a controller compatible with common GraphQL clients ([graphql-request](https://www.npmjs.com/package/graphql-request), [Apollo Client](https://www.apollographql.com/docs/react/), etc), load type definitions from separate files or handle errors thrown in resolvers.
 
 ```bash
+npm install graphql@15 @foal/graphql
+# OR
 npm install graphql@14 @foal/graphql
 ```
 
@@ -418,6 +420,17 @@ export class ApiController extends GraphQLController {
 ```
 
 ## Using TypeGraphQL
+
+
+:::info
+
+TypeGraphQL requires version 15 of the `graphql` package:
+
+```bash
+npm install graphql@15
+```
+
+:::
 
 > *[TypeGraphQL](https://typegraphql.com/) is a library that allows you to create GraphQL schemas and resolvers with TypeScript classes and decorators.*
 

--- a/packages/graphql/package-lock.json
+++ b/packages/graphql/package-lock.json
@@ -4,27 +4,20 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@types/events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-			"dev": true
-		},
 		"@types/glob": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
 			"dev": true,
 			"requires": {
-				"@types/events": "*",
 				"@types/minimatch": "*",
 				"@types/node": "*"
 			}
 		},
 		"@types/minimatch": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
 			"dev": true
 		},
 		"@types/mocha": {
@@ -40,15 +33,9 @@
 			"dev": true
 		},
 		"@types/semver": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.0.tgz",
-			"integrity": "sha512-1OzrNb4RuAzIT7wHSsgZRlMBlNsJl+do6UblR7JMW4oB7bbR+uBEYtUh7gEc/jM84GGilh68lSOokyM/zNUlBA==",
-			"dev": true
-		},
-		"@types/validator": {
-			"version": "10.11.3",
-			"resolved": "https://registry.npmjs.org/@types/validator/-/validator-10.11.3.tgz",
-			"integrity": "sha512-GKF2VnEkMmEeEGvoo03ocrP9ySMuX1ypKazIYMlsjfslfBMhOAtC5dmEWKdJioW4lJN7MZRS88kalTsVClyQ9w==",
+			"version": "7.3.9",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+			"integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
 			"dev": true
 		},
 		"@types/zen-observable": {
@@ -362,17 +349,6 @@
 				"readdirp": "~3.5.0"
 			}
 		},
-		"class-validator": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.11.0.tgz",
-			"integrity": "sha512-niAmmSPFku9xsnpYYrddy8NZRrCX3yyoZ/rgPKOilE5BG0Ma1eVCIxpR4X0LasL/6BzbYzsutG+mSbAXlh4zNw==",
-			"dev": true,
-			"requires": {
-				"@types/validator": "10.11.3",
-				"google-libphonenumber": "^3.1.6",
-				"validator": "12.0.0"
-			}
-		},
 		"cliui": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -570,25 +546,16 @@
 				"is-glob": "^4.0.1"
 			}
 		},
-		"google-libphonenumber": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.6.tgz",
-			"integrity": "sha512-6QCQAaKJlSd/1dUqvdQf7zzfb3uiZHsG8yhCfOdCVRfMuPZ/VDIEB47y5SYwjPQJPs7ebfW5jj6PeobB9JJ4JA==",
+		"graphql": {
+			"version": "15.8.0",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+			"integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
 			"dev": true
 		},
-		"graphql": {
-			"version": "14.6.0",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
-			"integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
-			"dev": true,
-			"requires": {
-				"iterall": "^1.2.2"
-			}
-		},
 		"graphql-query-complexity": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/graphql-query-complexity/-/graphql-query-complexity-0.3.0.tgz",
-			"integrity": "sha512-JVqHT81Eh9O17iOjs1r1qzsh5YY2upfA3zoUsQGggT4d+1hajWitk4GQQY5SZtq5eul7y6jMsM9qRUSOAKhDJQ==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/graphql-query-complexity/-/graphql-query-complexity-0.7.2.tgz",
+			"integrity": "sha512-+VgmrfxGEjHI3zuojWOR8bsz7Ycz/BZjNjxnlUieTz5DsB92WoIrYCSZdWG7UWZ3rfcA1Gb2Nf+wB80GsaZWuQ==",
 			"dev": true,
 			"requires": {
 				"lodash.get": "^4.4.2"
@@ -604,12 +571,12 @@
 			}
 		},
 		"graphql-subscriptions": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.1.0.tgz",
-			"integrity": "sha512-6WzlBFC0lWmXJbIVE8OgFgXIP4RJi3OQgTPa0DVMsDXdpRDjTsM1K9wfl5HSYX7R87QAGlvcv2Y4BIZa/ItonA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.2.1.tgz",
+			"integrity": "sha512-95yD/tKi24q8xYa7Q9rhQN16AYj5wPbrb8tmHGM3WRc9EBmWrG/0kkMl+tQG8wcEuE9ibR4zyOM31p5Sdr2v4g==",
 			"dev": true,
 			"requires": {
-				"iterall": "^1.2.1"
+				"iterall": "^1.3.0"
 			}
 		},
 		"graphql-tag": {
@@ -705,9 +672,9 @@
 			"dev": true
 		},
 		"iterall": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
-			"integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+			"integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
 			"dev": true
 		},
 		"js-yaml": {
@@ -746,6 +713,15 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0"
+			}
+		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"requires": {
+				"yallist": "^4.0.0"
 			}
 		},
 		"make-error": {
@@ -924,10 +900,13 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true
+			"version": "7.3.7",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^6.0.0"
+			}
 		},
 		"serialize-javascript": {
 			"version": "5.0.1",
@@ -1032,20 +1011,27 @@
 			"dev": true
 		},
 		"type-graphql": {
-			"version": "0.17.5",
-			"resolved": "https://registry.npmjs.org/type-graphql/-/type-graphql-0.17.5.tgz",
-			"integrity": "sha512-wscr63K0j9UKcX/nBTySamLd7nMZeYKmADk8A9sVmcPh+clNJUAw96784dg2VZn/sUdmN1y2AeKzmTjCfVB5sA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/type-graphql/-/type-graphql-1.1.1.tgz",
+			"integrity": "sha512-iOOWVn0ehCYMukmnXStbkRwFE9dcjt7/oDcBS1JyQZo9CbhlIll4lHHps54HMEk4A4c8bUPd+DjK8w1/ZrxB4A==",
 			"dev": true,
 			"requires": {
-				"@types/glob": "^7.1.1",
+				"@types/glob": "^7.1.3",
 				"@types/node": "*",
-				"@types/semver": "^6.0.1",
-				"class-validator": ">=0.9.1",
-				"glob": "^7.1.4",
-				"graphql-query-complexity": "^0.3.0",
+				"@types/semver": "^7.3.3",
+				"glob": "^7.1.6",
+				"graphql-query-complexity": "^0.7.0",
 				"graphql-subscriptions": "^1.1.0",
-				"semver": "^6.2.0",
-				"tslib": "^1.10.0"
+				"semver": "^7.3.2",
+				"tslib": "^2.0.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+					"dev": true
+				}
 			}
 		},
 		"typescript": {
@@ -1061,12 +1047,6 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
-		},
-		"validator": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/validator/-/validator-12.0.0.tgz",
-			"integrity": "sha512-r5zA1cQBEOgYlesRmSEwc9LkbfNLTtji+vWyaHzRZUxCTHdsX3bd+sdHfs5tGZ2W6ILGGsxWxCNwT/h3IY/3ng==",
-			"dev": true
 		},
 		"whatwg-fetch": {
 			"version": "2.0.4",
@@ -1152,6 +1132,12 @@
 			"version": "5.0.5",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
 			"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+			"dev": true
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
 		"yargs": {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -50,16 +50,16 @@
     "apollo-cache-inmemory": "~1.5.1",
     "apollo-client": "~2.5.1",
     "apollo-link-http": "~1.5.14",
-    "graphql": "~14.6.0",
+    "graphql": "~15.8.0",
     "graphql-request": "~1.8.2",
     "graphql-tag": "~2.10.1",
     "mocha": "~8.3.0",
     "rimraf": "~2.6.2",
     "ts-node": "~9.0.0",
-    "type-graphql": "~0.17.5",
+    "type-graphql": "~1.1.1",
     "typescript": "~4.0.2"
   },
   "peerDependencies": {
-    "graphql": "^14.3.0"
+    "graphql": ">= 14.3.0 < 16.0.0"
   }
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Resolves #1066

The `@foal/graphql` package only supports version 14 of `graphql` but recent versions of `type-graphql` requires version 15.

# Solution and steps

- [x] Check that `@foal/graphql` can work with both versions 14 and 15
- [x] Update peer dependency versions
- [x] Update TypeGraphQL test

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
