### PR TITLE
Improve `Context` class interface

### DIFF
--- a/docs/docs/architecture/controllers.md
+++ b/docs/docs/architecture/controllers.md
@@ -101,8 +101,8 @@ It has four properties:
 | --- | --- | --- |
 | `request` | `Request` | Gives information about the HTTP request. |
 | `state` | object | Object which can be used to forward data accross several hooks (see [Hooks](./hooks.md)). |
-| `user` | `any\|undefined` | The current user (see [Authentication](../authentication-and-access-control/quick-start.md)). | 
-| `session`| `Session\|undefined` | The session object if you use sessions. |
+| `user` | `any\|null` | The current user (see [Authentication](../authentication-and-access-control/quick-start.md)). | 
+| `session`| `Session\|null` | The session object if you use sessions. |
 
 
 ### HTTP Requests

--- a/docs/docs/architecture/controllers.md
+++ b/docs/docs/architecture/controllers.md
@@ -100,8 +100,8 @@ It has four properties:
 | Name | Type | Description |
 | --- | --- | --- |
 | `request` | `Request` | Gives information about the HTTP request. |
-| `state` | object | Object which can be used to forward data accross several hooks (see [Hooks](./hooks.md)). |
-| `user` | `any\|null` | The current user (see [Authentication](../authentication-and-access-control/quick-start.md)). | 
+| `state` | `{ [key: string]: any }` | Object which can be used to forward data accross several hooks (see [Hooks](./hooks.md)). |
+| `user` | `{ [key: string]: any }\|null` | The current user (see [Authentication](../authentication-and-access-control/quick-start.md)). | 
 | `session`| `Session\|null` | The session object if you use sessions. |
 
 

--- a/docs/docs/architecture/hooks.md
+++ b/docs/docs/architecture/hooks.md
@@ -494,7 +494,7 @@ interface State {
 
 export class ApiController {
   // ...
-  readOrgName(ctx: Context<any, any, State>) {
+  readOrgName(ctx: Context<any, State>) {
     // ...
   }
 }

--- a/docs/docs/architecture/hooks.md
+++ b/docs/docs/architecture/hooks.md
@@ -395,7 +395,7 @@ export class UserService {
   };
 
   getUser(key: string) {
-    return this.users[key];
+    return this.users[key] ?? null;
   }
 }
 

--- a/docs/docs/authentication-and-access-control/administrators-and-roles.md
+++ b/docs/docs/authentication-and-access-control/administrators-and-roles.md
@@ -33,7 +33,7 @@ import { Context, Hook, HttpResponseForbidden, HttpResponseUnauthorized } from '
 import { User } from '../entities';
 
 export function AdminRequired() {
-  return Hook((ctx: Context<User>) => {
+  return Hook((ctx: Context<User|null>) => {
     if (!ctx.user) {
       return new HttpResponseUnauthorized();
     }
@@ -88,7 +88,7 @@ import { Context, Hook, HttpResponseForbidden, HttpResponseUnauthorized } from '
 import { User } from '../entities';
 
 export function RoleRequired(role: string) {
-  return Hook((ctx: Context<User>) => {
+  return Hook((ctx: Context<User|null>) => {
     if (!ctx.user) {
       return new HttpResponseUnauthorized();
     }

--- a/docs/docs/authentication-and-access-control/groups-and-permissions.md
+++ b/docs/docs/authentication-and-access-control/groups-and-permissions.md
@@ -340,7 +340,7 @@ export class ProductController {
 
 | Context | Response |
 | --- | --- |
-| `ctx.user` is undefined | 401 - UNAUTHORIZED |
+| `ctx.user` is null | 401 - UNAUTHORIZED |
 | `ctx.user.hasPerm('perm')` is false | 403 - FORBIDDEN |
 
 ```typescript
@@ -349,7 +349,7 @@ export class ProductController {
 
 | Context | Response |
 | --- | --- |
-| `ctx.user` is undefined | Redirects to `/login` (302 - FOUND) |
+| `ctx.user` is null | Redirects to `/login` (302 - FOUND) |
 | `ctx.user.hasPerm('perm')` is false | 403 - FORBIDDEN |
 
 *Example*

--- a/docs/docs/authentication-and-access-control/quick-start.md
+++ b/docs/docs/authentication-and-access-control/quick-start.md
@@ -140,7 +140,7 @@ export class AppController implements IAppController {
 
 *src/app/controllers/auth.controller.ts*
 ```typescript
-import { Context, hashPassword, HttpResponseOK, HttpResponseUnauthorized, Post, Session, ValidateBody, verifyPassword } from '@foal/core';
+import { Context, hashPassword, HttpResponseOK, HttpResponseUnauthorized, Post, ValidateBody, verifyPassword } from '@foal/core';
 
 import { User } from '../entities';
 
@@ -158,21 +158,21 @@ export class AuthController {
 
   @Post('/signup')
   @ValidateBody(credentialsSchema)
-  async signup(ctx: Context<any, Session>) {
+  async signup(ctx: Context) {
     const user = new User();
     user.email = ctx.request.body.email;
     user.password = await hashPassword(ctx.request.body.password);
     await user.save();
 
-    ctx.session.setUser(user);
-    await ctx.session.regenerateID();
+    ctx.session!.setUser(user);
+    await ctx.session!.regenerateID();
 
     return new HttpResponseOK();
   }
 
   @Post('/login')
   @ValidateBody(credentialsSchema)
-  async login(ctx: Context<any, Session>) {
+  async login(ctx: Context) {
     const user = await User.findOne({ email: ctx.request.body.email });
 
     if (!user) {
@@ -183,15 +183,15 @@ export class AuthController {
       return new HttpResponseUnauthorized();
     }
 
-    ctx.session.setUser(user);
-    await ctx.session.regenerateID();
+    ctx.session!.setUser(user);
+    await ctx.session!.regenerateID();
 
     return new HttpResponseOK();
   }
 
   @Post('/logout')
-  async logout(ctx: Context<any, Session>) {
-    await ctx.session.destroy();
+  async logout(ctx: Context) {
+    await ctx.session!.destroy();
 
     return new HttpResponseOK();
   }
@@ -719,7 +719,7 @@ npm run migrations
 
 *src/app/app.controller.ts*
 ```typescript
-import { Context, controller, dependency, Get, IAppController, render, Session, Store, UserRequired, UseSessions } from '@foal/core';
+import { Context, controller, dependency, Get, IAppController, render, Store, UserRequired, UseSessions } from '@foal/core';
 import { fetchUser } from '@foal/typeorm';
 import { createConnection } from 'typeorm';
 
@@ -751,9 +751,9 @@ export class AppController implements IAppController {
   }
 
   @Get('/login')
-  login(ctx: Context<any, Session>) {
+  login(ctx: Context) {
     return render('./templates/login.html', {
-      errorMessage: ctx.session.get<string>('errorMessage', '')
+      errorMessage: ctx.session!.get<string>('errorMessage', '')
     });
   }
 
@@ -762,7 +762,7 @@ export class AppController implements IAppController {
 
 *src/app/controllers/auth.controller.ts*
 ```typescript
-import { Context, hashPassword, HttpResponseRedirect, Post, Session, ValidateBody, verifyPassword } from '@foal/core';
+import { Context, hashPassword, HttpResponseRedirect, Post, ValidateBody, verifyPassword } from '@foal/core';
 
 import { User } from '../entities';
 
@@ -780,42 +780,42 @@ export class AuthController {
 
   @Post('/signup')
   @ValidateBody(credentialsSchema)
-  async signup(ctx: Context<any, Session>) {
+  async signup(ctx: Context) {
     const user = new User();
     user.email = ctx.request.body.email;
     user.password = await hashPassword(ctx.request.body.password);
     await user.save();
 
-    ctx.session.setUser(user);
-    await ctx.session.regenerateID();
+    ctx.session!.setUser(user);
+    await ctx.session!.regenerateID();
 
     return new HttpResponseRedirect('/');
   }
 
   @Post('/login')
   @ValidateBody(credentialsSchema)
-  async login(ctx: Context<any, Session>) {
+  async login(ctx: Context) {
     const user = await User.findOne({ email: ctx.request.body.email });
 
     if (!user) {
-      ctx.session.set('errorMessage', 'Unknown email.', { flash: true });
+      ctx.session!.set('errorMessage', 'Unknown email.', { flash: true });
       return new HttpResponseRedirect('/login');
     }
 
     if (!await verifyPassword(ctx.request.body.password, user.password)) {
-      ctx.session.set('errorMessage', 'Invalid password.', { flash: true });
+      ctx.session!.set('errorMessage', 'Invalid password.', { flash: true });
       return new HttpResponseRedirect('/login');
     }
 
-    ctx.session.setUser(user);
-    await ctx.session.regenerateID();
+    ctx.session!.setUser(user);
+    await ctx.session!.regenerateID();
 
     return new HttpResponseRedirect('/');
   }
 
   @Post('/logout')
-  async logout(ctx: Context<any, Session>) {
-    await ctx.session.destroy();
+  async logout(ctx: Context) {
+    await ctx.session!.destroy();
 
     return new HttpResponseRedirect('/login');
   }

--- a/docs/docs/authentication-and-access-control/session-tokens.md
+++ b/docs/docs/authentication-and-access-control/session-tokens.md
@@ -398,9 +398,9 @@ export class ApiController {
   }
 
   @Get('/products')
-  readProducts(ctx: Context) {
+  readProducts(ctx: Context<User>) {
     // If the ctx.session is defined and the session is attached to a user
-    // then ctx.user is an instance of User. Otherwise it is undefined.
+    // then ctx.user is an instance of User. Otherwise it is null.
     return new HttpResponseOK([]);
   }
 
@@ -493,7 +493,7 @@ In the following example, the `user` cookie is empty if no user is logged in or 
 *Server-side code*
 
 ```typescript
-function userToJSON(user: User|undefined) {
+function userToJSON(user: User|null) {
   if (!user) {
     return 'null';
   }
@@ -507,13 +507,13 @@ function userToJSON(user: User|undefined) {
 @UseSessions({
   cookie: true,
   user: fetchUser(User),
-  userCookie: (ctx, services) => userToJSON(ctx.user)
+  userCookie: (ctx, services) => userToJSON(ctx.user as User|null)
 })
 export class ApiController {
 
   @Get('/products')
   @UserRequired()
-  async readProducts(ctx: Context) {
+  async readProducts(ctx: Context<User>) {
     const products = await Product.find({ owner: ctx.user });
     return new HttpResponseOK(products);
   }
@@ -899,10 +899,10 @@ interface SessionState {
 The function `fetchUser` from the package `@foal/typeorm` takes an `@Entity()` class as parameter and returns a function with this signature:
 
 ```typescript
-type FetchUser = (id: string|number, services: ServiceManager) => Promise<any>
+type FetchUser = (id: string|number, services: ServiceManager) => Promise<Context['user']>
 ```
 
-If the ID matches a user, then an instance of the class is returned. Otherwise, the function returns `undefined`.
+If the ID matches a user, then an instance of the class is returned. Otherwise, the function returns `null`.
 
 If needed you can implement your own `fetchUser` function with this exact signature.
 

--- a/docs/docs/authentication-and-access-control/session-tokens.md
+++ b/docs/docs/authentication-and-access-control/session-tokens.md
@@ -537,20 +537,20 @@ const user = JSON.parse(decodeURIComponent(/* cookie value */));
 You can access and modify the session content with the `set` and `get` methods.
 
 ```typescript
-import { Context, HttpResponseNoContent, Post, Session, UseSessions } from '@foal/core';
+import { Context, HttpResponseNoContent, Post, UseSessions } from '@foal/core';
 
 @UseSessions(/* ... */)
 export class ApiController {
 
   @Post('/subscribe')
-  subscribe(ctx: Context<any, Session>) {
-    const plan = ctx.session.get<string>('plan', 'free');
+  subscribe(ctx: Context) {
+    const plan = ctx.session!.get<string>('plan', 'free');
     // ...
   }
 
   @Post('/choose-premium-plan')
-  choosePremimumPlan(ctx: Context<any, Session>) {
-    ctx.session.set('plan', 'premium');
+  choosePremimumPlan(ctx: Context) {
+    ctx.session!.set('plan', 'premium');
     return new HttpResponseNoContent();
   }
 }

--- a/docs/docs/authentication-and-access-control/social-auth.md
+++ b/docs/docs/authentication-and-access-control/social-auth.md
@@ -194,7 +194,6 @@ import {
   dependency,
   Get,
   HttpResponseRedirect,
-  Session,
   Store,
   UseSessions,
 } from '@foal/core';
@@ -218,7 +217,7 @@ export class AuthController {
   @UseSessions({
     cookie: true,
   })
-  async handleGoogleRedirection(ctx: Context<User, Session>) {
+  async handleGoogleRedirection(ctx: Context<User>) {
     const { userInfo } = await this.google.getUserInfo<{ email: string }>(ctx);
 
     if (!userInfo.email) {
@@ -234,7 +233,7 @@ export class AuthController {
       await user.save();
     }
 
-    ctx.session.setUser(user);
+    ctx.session!.setUser(user);
 
     return new HttpResponseRedirect('/');
   }

--- a/docs/docs/databases/using-another-orm.md
+++ b/docs/docs/databases/using-another-orm.md
@@ -29,7 +29,7 @@ To do so, you will have to remove TypeORM and all its utilities and implement so
 
 If you wish to use the `user` option of `@JWTRequired` or `@UseSessions` to set the `ctx.user` property, then you will need to implement your own `fetchUser` function.
 
-This utility returns a function that takes an `id` as parameter which might be a `string` or a `number` and returns a promise. The promise value must be `undefined` is no user matches the given `id` and the *user object* otherwise.
+This utility returns a function that takes an `id` as parameter which might be a `string` or a `number` and returns a promise. The promise value must be `null` is no user matches the given `id` and the *user object* otherwise.
 
 *Example*
 ```typescript
@@ -41,9 +41,6 @@ export function fetchUser(userModel: any): FetchUser {
       throw new Error('The user ID must be a number.');
     }
     const user = await userModel.findOne({ id });
-    if (user === null) {
-      return undefined;
-    }
     return user;
   };
 }

--- a/docs/docs/security/csrf-protection.md
+++ b/docs/docs/security/csrf-protection.md
@@ -374,7 +374,6 @@ import {
   dependency,
   Get,
   render,
-  Session,
   Store,
   UseSessions,
 } from '@foal/core';
@@ -396,10 +395,10 @@ export class ViewController {
     required: true,
     redirectTo: '/login'
   })
-  async index(ctx: Context<User, Session>) {
+  async index(ctx: Context<User>) {
     return render(
       './templates/products.html',
-      { csrfToken: ctx.session.get('csrfToken') },
+      { csrfToken: ctx.session!.get('csrfToken') },
     );
   }
 }

--- a/docs/docs/security/csrf-protection.md
+++ b/docs/docs/security/csrf-protection.md
@@ -378,8 +378,6 @@ import {
   UseSessions,
 } from '@foal/core';
 
-import { User } from '../entities';
-
 export class ViewController {
   @dependency
   store: Store;
@@ -395,7 +393,7 @@ export class ViewController {
     required: true,
     redirectTo: '/login'
   })
-  async index(ctx: Context<User>) {
+  async index(ctx: Context) {
     return render(
       './templates/products.html',
       { csrfToken: ctx.session!.get('csrfToken') },

--- a/docs/docs/tutorials/real-world-example-with-react/10-auth-with-react.md
+++ b/docs/docs/tutorials/real-world-example-with-react/10-auth-with-react.md
@@ -53,7 +53,7 @@ import { Context } from '@foal/core';
 @UseSessions({
   cookie: true,
   user: fetchUser(User),
-  userCookie: (ctx: Context<User|null>) => ctx.user ? JSON.stringify({ id: ctx.user.id, name: ctx.user.name }) : '',
+  userCookie: (ctx) => ctx.user ? JSON.stringify({ id: ctx.user.id, name: ctx.user.name }) : '',
 })
 ```
 

--- a/docs/docs/tutorials/real-world-example-with-react/10-auth-with-react.md
+++ b/docs/docs/tutorials/real-world-example-with-react/10-auth-with-react.md
@@ -53,7 +53,7 @@ import { Context } from '@foal/core';
 @UseSessions({
   cookie: true,
   user: fetchUser(User),
-  userCookie: (ctx: Context<User|undefined>) => ctx.user ? JSON.stringify({ id: ctx.user.id, name: ctx.user.name }) : '',
+  userCookie: (ctx: Context<User|null>) => ctx.user ? JSON.stringify({ id: ctx.user.id, name: ctx.user.name }) : '',
 })
 ```
 

--- a/docs/docs/tutorials/real-world-example-with-react/11-sign-up.md
+++ b/docs/docs/tutorials/real-world-example-with-react/11-sign-up.md
@@ -28,7 +28,7 @@ export class AuthController {
 
   @Post('/signup')
   @ValidateBody(credentialsSchema)
-  async signup(ctx: Context<User|undefined, Session>) {
+  async signup(ctx: Context<User|null, Session>) {
     const email = ctx.request.body.email;
     const password = ctx.request.body.password;
 

--- a/docs/docs/tutorials/real-world-example-with-react/11-sign-up.md
+++ b/docs/docs/tutorials/real-world-example-with-react/11-sign-up.md
@@ -13,7 +13,7 @@ So far, only users created with the `create-user` script can log in and publish 
 Open the `auth.controller.ts` file and add a new route.
 
 ```typescript
-import { Context, hashPassword, HttpResponseNoContent, HttpResponseOK, HttpResponseUnauthorized, Post, Session, ValidateBody, verifyPassword } from '@foal/core';
+import { Context, hashPassword, HttpResponseNoContent, HttpResponseOK, HttpResponseUnauthorized, Post, ValidateBody, verifyPassword } from '@foal/core';
 import { User } from '../../entities';
 
 const credentialsSchema = {
@@ -28,7 +28,7 @@ export class AuthController {
 
   @Post('/signup')
   @ValidateBody(credentialsSchema)
-  async signup(ctx: Context<User|null, Session>) {
+  async signup(ctx: Context<User|null>) {
     const email = ctx.request.body.email;
     const password = ctx.request.body.password;
 
@@ -39,7 +39,7 @@ export class AuthController {
     user.password = await hashPassword(password);
     await user.save();
 
-    ctx.session.setUser(user);
+    ctx.session!.setUser(user);
     ctx.user = user;
 
     return new HttpResponseOK({

--- a/docs/docs/tutorials/real-world-example-with-react/12-file-upload.md
+++ b/docs/docs/tutorials/real-world-example-with-react/12-file-upload.md
@@ -59,7 +59,7 @@ export class ProfileController {
 
   @Get('/avatar')
   @ValidateQueryParam('userId', { type: 'number' }, { required: false })
-  async readProfileImage(ctx: Context<User|undefined>) {
+  async readProfileImage(ctx: Context<User|null>) {
     let user = ctx.user;
 
     const userId: number|undefined = ctx.request.query.userId;

--- a/docs/docs/tutorials/real-world-example-with-react/15-social-auth.md
+++ b/docs/docs/tutorials/real-world-example-with-react/15-social-auth.md
@@ -111,7 +111,7 @@ Open the file and add two new routes.
 | `/api/auth/google/callback` | `GET` | Handles redirection from Google once the user has approved the connection. |
 
 ```typescript
-import { Context, dependency, Get, HttpResponseRedirect, Session } from '@foal/core';
+import { Context, dependency, Get, HttpResponseRedirect } from '@foal/core';
 import { GoogleProvider } from '@foal/social';
 import { User } from '../../entities';
 import * as fetch from 'node-fetch';
@@ -136,7 +136,7 @@ export class SocialAuthController {
   }
 
   @Get('/google/callback')
-  async handleGoogleRedirection(ctx: Context<User, Session>) {
+  async handleGoogleRedirection(ctx: Context<User>) {
     const { userInfo } = await this.google.getUserInfo<GoogleUserInfo>(ctx);
 
     if (!userInfo.email) {
@@ -160,7 +160,7 @@ export class SocialAuthController {
       await user.save();
     }
 
-    ctx.session.setUser(user);
+    ctx.session!.setUser(user);
     ctx.user = user;
 
     return new HttpResponseRedirect('/');

--- a/docs/docs/tutorials/real-world-example-with-react/8-authentication.md
+++ b/docs/docs/tutorials/real-world-example-with-react/8-authentication.md
@@ -76,7 +76,7 @@ export class AuthController {
 
   @Post('/login')
   @ValidateBody(credentialsSchema)
-  async login(ctx: Context<User|undefined, Session>) {
+  async login(ctx: Context<User|null, Session>) {
     const email = ctx.request.body.email;
     const password = ctx.request.body.password;
 
@@ -99,7 +99,7 @@ export class AuthController {
   }
 
   @Post('/logout')
-  async logout(ctx: Context<User|undefined, Session>) {
+  async logout(ctx: Context<User|null, Session>) {
     await ctx.session.destroy();
     return new HttpResponseNoContent();
   }
@@ -110,5 +110,5 @@ export class AuthController {
 
 The `login` method first checks that the user exists and that the credentials provided are correct. If so, it associates the user with the current session.
 
-On subsequent requests, the *UseSessions* hook will retrieve the user's ID from the session and set the `ctx.user` property accordingly. If the user has not previously logged in, then `ctx.user` will be `undefined`. If they have, then `ctx.user` will be an instance of `User`. This is made possible by the `user` option we provided to the hook earlier. It is actually the function that takes the user ID as parameter and returns the value to assign to `ctx.user`.
+On subsequent requests, the *UseSessions* hook will retrieve the user's ID from the session and set the `ctx.user` property accordingly. If the user has not previously logged in, then `ctx.user` will be `null`. If they have, then `ctx.user` will be an instance of `User`. This is made possible by the `user` option we provided to the hook earlier. It is actually the function that takes the user ID as parameter and returns the value to assign to `ctx.user`.
 

--- a/docs/docs/tutorials/real-world-example-with-react/8-authentication.md
+++ b/docs/docs/tutorials/real-world-example-with-react/8-authentication.md
@@ -59,7 +59,7 @@ Open the new created file and add two routes.
 | `/api/auth/logout` | `POST` | Logs the user out. |
 
 ```typescript
-import { Context, hashPassword, HttpResponseNoContent, HttpResponseOK, HttpResponseUnauthorized, Post, Session, ValidateBody, verifyPassword } from '@foal/core';
+import { Context, hashPassword, HttpResponseNoContent, HttpResponseOK, HttpResponseUnauthorized, Post, ValidateBody, verifyPassword } from '@foal/core';
 import { User } from '../../entities';
 
 const credentialsSchema = {
@@ -76,7 +76,7 @@ export class AuthController {
 
   @Post('/login')
   @ValidateBody(credentialsSchema)
-  async login(ctx: Context<User|null, Session>) {
+  async login(ctx: Context<User|null>) {
     const email = ctx.request.body.email;
     const password = ctx.request.body.password;
 
@@ -89,7 +89,7 @@ export class AuthController {
       return new HttpResponseUnauthorized();
     }
 
-    ctx.session.setUser(user);
+    ctx.session!.setUser(user);
     ctx.user = user;
 
     return new HttpResponseOK({
@@ -99,8 +99,8 @@ export class AuthController {
   }
 
   @Post('/logout')
-  async logout(ctx: Context<User|null, Session>) {
-    await ctx.session.destroy();
+  async logout(ctx: Context<User|null>) {
+    await ctx.session!.destroy();
     return new HttpResponseNoContent();
   }
 

--- a/docs/docs/tutorials/real-world-example-with-react/9-authenticated-api.md
+++ b/docs/docs/tutorials/real-world-example-with-react/9-authenticated-api.md
@@ -62,6 +62,6 @@ export class StoriesController {
 }
 ```
 
-When sending a request to these endpoints, the `@UserRequired` hook will return a 401 error if `ctx.user` is not defined (i.e. if the user has not logged in first). But if it is, the controller method will be executed.
+When sending a request to these endpoints, the `@UserRequired` hook will return a 401 error if `ctx.user` is not null (i.e. if the user has not logged in first). But if it is, the controller method will be executed.
 
 Go to [http://localhost:3001/swagger](http://localhost:3001/swagger) and check that the controller is working as expected. You can, for example, first try to create a story without being connected and then log in and try again.

--- a/packages/acceptance-tests/src/additional/session.config.spec.ts
+++ b/packages/acceptance-tests/src/additional/session.config.spec.ts
@@ -8,7 +8,6 @@ import {
   HttpResponseOK,
   Post,
   ServiceManager,
-  Session,
   SessionStore,
   UseSessions,
 } from '@foal/core';
@@ -62,8 +61,8 @@ describe('The session store', () => {
 
       @Get('/products')
       @UseSessions({ required: true })
-      readProducts(ctx: Context<any, Session>) {
-        return new HttpResponseOK(ctx.session.get('products'));
+      readProducts(ctx: Context) {
+        return new HttpResponseOK(ctx.session!.get('products'));
       }
 
     }

--- a/packages/acceptance-tests/src/docs/architecture/hooks/mocking-services-in-hooks.feature.ts
+++ b/packages/acceptance-tests/src/docs/architecture/hooks/mocking-services-in-hooks.feature.ts
@@ -18,7 +18,7 @@ describe('Feature: Mocking services in hooks', () => {
       };
 
       getUser(key: string) {
-        return this.users[key];
+        return this.users[key] ?? null;
       }
     }
 

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/administrators-and-roles/controlling-access-with-administrators.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/administrators-and-roles/controlling-access-with-administrators.feature.ts
@@ -41,7 +41,7 @@ describe('Feature: Controlling access with administrators', () => {
 
     // hooks/admin-required.hook.ts
     function AdminRequired() {
-      return Hook((ctx: Context<User>) => {
+      return Hook((ctx: Context<User|null>) => {
         if (!ctx.user) {
           return new HttpResponseUnauthorized();
         }

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/administrators-and-roles/controlling-access-with-static-roles.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/administrators-and-roles/controlling-access-with-static-roles.feature.ts
@@ -41,7 +41,7 @@ describe('Feature: Controlling access with static roles', () => {
 
     // hooks/role-required.hook.ts
     function RoleRequired(role: string) {
-      return Hook((ctx: Context<User>) => {
+      return Hook((ctx: Context<User|null>) => {
         if (!ctx.user) {
           return new HttpResponseUnauthorized();
         }

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/quick-start/authenticating-users-in-a-stateful-spa-using-cookies.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/quick-start/authenticating-users-in-a-stateful-spa-using-cookies.feature.ts
@@ -15,7 +15,6 @@ import {
   HttpResponseUnauthorized,
   IAppController,
   Post,
-  Session,
   Store,
   UserRequired,
   UseSessions,
@@ -60,21 +59,21 @@ describe('Feature: Authenticating users in a stateful SPA using cookies', () => 
 
     @Post('/signup')
     @ValidateBody(credentialsSchema)
-    async signup(ctx: Context<any, Session>) {
+    async signup(ctx: Context) {
       const user = new User();
       user.email = ctx.request.body.email;
       user.password = await hashPassword(ctx.request.body.password);
       await user.save();
 
-      ctx.session.setUser(user);
-      await ctx.session.regenerateID();
+      ctx.session!.setUser(user);
+      await ctx.session!.regenerateID();
 
       return new HttpResponseOK();
     }
 
     @Post('/login')
     @ValidateBody(credentialsSchema)
-    async login(ctx: Context<any, Session>) {
+    async login(ctx: Context) {
       const user = await User.findOne({ email: ctx.request.body.email });
 
       if (!user) {
@@ -85,15 +84,15 @@ describe('Feature: Authenticating users in a stateful SPA using cookies', () => 
         return new HttpResponseUnauthorized();
       }
 
-      ctx.session.setUser(user);
-      await ctx.session.regenerateID();
+      ctx.session!.setUser(user);
+      await ctx.session!.regenerateID();
 
       return new HttpResponseOK();
     }
 
     @Post('/logout')
-    async logout(ctx: Context<any, Session>) {
-      await ctx.session.destroy();
+    async logout(ctx: Context) {
+      await ctx.session!.destroy();
 
       return new HttpResponseOK();
     }

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/quick-start/authenticating-users-in-a-stateful-ssr-app-using-cookies.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/quick-start/authenticating-users-in-a-stateful-ssr-app-using-cookies.feature.ts
@@ -19,7 +19,6 @@ import {
   IAppController,
   Post,
   render,
-  Session,
   Store,
   UserRequired,
   UseSessions,
@@ -64,42 +63,42 @@ describe('Feature: Authenticating users in a statefull SSR application using coo
 
     @Post('/signup')
     @ValidateBody(credentialsSchema)
-    async signup(ctx: Context<any, Session>) {
+    async signup(ctx: Context) {
       const user = new User();
       user.email = ctx.request.body.email;
       user.password = await hashPassword(ctx.request.body.password);
       await user.save();
 
-      ctx.session.setUser(user);
-      await ctx.session.regenerateID();
+      ctx.session!.setUser(user);
+      await ctx.session!.regenerateID();
 
       return new HttpResponseRedirect('/');
     }
 
     @Post('/login')
     @ValidateBody(credentialsSchema)
-    async login(ctx: Context<any, Session>) {
+    async login(ctx: Context) {
       const user = await User.findOne({ email: ctx.request.body.email });
 
       if (!user) {
-        ctx.session.set('errorMessage', 'Unknown email.', { flash: true });
+        ctx.session!.set('errorMessage', 'Unknown email.', { flash: true });
         return new HttpResponseRedirect('/login');
       }
 
       if (!await verifyPassword(ctx.request.body.password, user.password)) {
-        ctx.session.set('errorMessage', 'Invalid password.', { flash: true });
+        ctx.session!.set('errorMessage', 'Invalid password.', { flash: true });
         return new HttpResponseRedirect('/login');
       }
 
-      ctx.session.setUser(user);
-      await ctx.session.regenerateID();
+      ctx.session!.setUser(user);
+      await ctx.session!.regenerateID();
 
       return new HttpResponseRedirect('/');
     }
 
     @Post('/logout')
-    async logout(ctx: Context<any, Session>) {
-      await ctx.session.destroy();
+    async logout(ctx: Context) {
+      await ctx.session!.destroy();
 
       return new HttpResponseRedirect('/login');
     }
@@ -139,10 +138,10 @@ describe('Feature: Authenticating users in a statefull SSR application using coo
     }
 
     @Get('/login')
-    login(ctx: Context<any, Session>) {
+    login(ctx: Context) {
       // Not in the documentation: __dirname
       return render('./templates/login.html', {
-        errorMessage: ctx.session.get<string>('errorMessage', '')
+        errorMessage: ctx.session!.get<string>('errorMessage', '')
       }, __dirname);
     }
 

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/modifying-session-timeouts.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/modifying-session-timeouts.feature.ts
@@ -41,7 +41,7 @@ describe('Feature: Modifying session timeouts', () => {
       }
 
       @Get('/')
-      index(ctx: Context<any, Session>) {
+      index(ctx: Context) {
         return new HttpResponseOK();
       }
 

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/modifying-session-timeouts.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/modifying-session-timeouts.feature.ts
@@ -11,7 +11,6 @@ import {
   HttpResponseOK,
   IAppController,
   ServiceManager,
-  Session,
   Store,
   UseSessions
 } from '@foal/core';

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/modifying-session-timeouts.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/modifying-session-timeouts.feature.ts
@@ -41,7 +41,7 @@ describe('Feature: Modifying session timeouts', () => {
       }
 
       @Get('/')
-      index(ctx: Context<undefined, Session>) {
+      index(ctx: Context<any, Session>) {
         return new HttpResponseOK();
       }
 

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/regenerating-the-session-id.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/regenerating-the-session-id.feature.ts
@@ -14,7 +14,6 @@ import {
   Get,
   HttpResponseOK,
   IAppController,
-  Session,
   Store,
   UseSessions
 } from '@foal/core';
@@ -46,14 +45,14 @@ describe('Feature: Regenerating the session ID', () => {
       }
 
       @Get('/regenerated-id')
-      async regenerateID(ctx: Context<any, Session>) {
+      async regenerateID(ctx: Context) {
         /* ======================= DOCUMENTATION BEGIN ======================= */
 
-        await ctx.session.regenerateID();
+        await ctx.session!.regenerateID();
 
         /* ======================= DOCUMENTATION END ========================= */
 
-        return new HttpResponseOK({ token: ctx.session.getToken() });
+        return new HttpResponseOK({ token: ctx.session!.getToken() });
       }
 
       async init() {

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/saving-and-reading-content.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/saving-and-reading-content.feature.ts
@@ -104,7 +104,7 @@ describe('Feature: Saving and reading content', () => {
       }
 
       @Post('/add-flash-content')
-      addFlashContent(ctx: Context<undefined, Session>) {
+      addFlashContent(ctx: Context<any, Session>) {
         /* ======================= DOCUMENTATION BEGIN ======================= */
         ctx.session.set('error', 'Incorrect email or password', { flash: true });
         /* ======================= DOCUMENTATION END ========================= */
@@ -113,7 +113,7 @@ describe('Feature: Saving and reading content', () => {
       }
 
       @Get('/read-flash-content')
-      readFlashContent(ctx: Context<undefined, Session>) {
+      readFlashContent(ctx: Context<any, Session>) {
         return new HttpResponseOK(
           ctx.session.get<string>('error', 'No error')
         );

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/saving-and-reading-content.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/saving-and-reading-content.feature.ts
@@ -14,7 +14,6 @@ import {
   IAppController,
   Post,
   ServiceManager,
-  Session,
   Store,
   UseSessions
 } from '@foal/core';
@@ -40,16 +39,16 @@ describe('Feature: Saving and reading content', () => {
     class ApiController {
 
       @Post('/subscribe')
-      subscribe(ctx: Context<any, Session>) {
-        const plan = ctx.session.get<string>('plan', 'free');
+      subscribe(ctx: Context) {
+        const plan = ctx.session!.get<string>('plan', 'free');
         // ...
         // Not in the documentation
         return new HttpResponseOK(plan);
       }
 
       @Post('/choose-premium-plan')
-      choosePremimumPlan(ctx: Context<any, Session>) {
-        ctx.session.set('plan', 'premium');
+      choosePremimumPlan(ctx: Context) {
+        ctx.session!.set('plan', 'premium');
         return new HttpResponseNoContent();
       }
     }
@@ -104,18 +103,18 @@ describe('Feature: Saving and reading content', () => {
       }
 
       @Post('/add-flash-content')
-      addFlashContent(ctx: Context<any, Session>) {
+      addFlashContent(ctx: Context) {
         /* ======================= DOCUMENTATION BEGIN ======================= */
-        ctx.session.set('error', 'Incorrect email or password', { flash: true });
+        ctx.session!.set('error', 'Incorrect email or password', { flash: true });
         /* ======================= DOCUMENTATION END ========================= */
 
         return new HttpResponseOK();
       }
 
       @Get('/read-flash-content')
-      readFlashContent(ctx: Context<any, Session>) {
+      readFlashContent(ctx: Context) {
         return new HttpResponseOK(
-          ctx.session.get<string>('error', 'No error')
+          ctx.session!.get<string>('error', 'No error')
         );
       }
     }

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/specifying-the-store-locally.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/specifying-the-store-locally.feature.ts
@@ -39,7 +39,7 @@ describe('Feature: Specifying the store locally', () => {
 
   it('Example: Usage with Redis store', async () => {
 
-    let session: Session|undefined;
+    let session: Session|null = null;
 
     /* ======================= DOCUMENTATION BEGIN ======================= */
 
@@ -81,21 +81,21 @@ describe('Feature: Specifying the store locally', () => {
     const app = await createApp(AppController, { serviceManager: services });
     store = services.get(RedisStore);
 
-    strictEqual(session, undefined);
+    strictEqual(session, null);
 
     await request(app)
       .get('/api/products')
       .expect(200)
       .expect([]);
 
-    strictEqual(session, undefined);
+    strictEqual(session, null);
 
     const response = await request(app)
       .post('/api/login')
       .send({})
       .expect(200);
 
-    strictEqual(session, undefined);
+    strictEqual(session, null);
 
     const token: undefined|string = response.body.token;
     if (token === undefined) {
@@ -108,7 +108,7 @@ describe('Feature: Specifying the store locally', () => {
       .expect(200)
       .expect([]);
 
-    notStrictEqual(session, undefined);
+    notStrictEqual(session, null);
     strictEqual((session as unknown as Session).getToken(), token);
 
   });

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/using-cookies.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/using-cookies.feature.ts
@@ -37,7 +37,7 @@ describe('Feature: Using cookies', () => {
 
   it('Example: Simple usage with cookies', async () => {
 
-    let session: Session|undefined;
+    let session: Session|null = null;
 
     /* ======================= DOCUMENTATION BEGIN ======================= */
 
@@ -83,7 +83,7 @@ describe('Feature: Using cookies', () => {
 
     const app = await createApp(AppController);
 
-    strictEqual(session, undefined);
+    strictEqual(session, null);
 
     const response = await request(app)
       .get('/api/products')
@@ -91,7 +91,7 @@ describe('Feature: Using cookies', () => {
 
     const token = readCookie(response.get('Set-Cookie'), cookieName).value;
 
-    notStrictEqual(session, undefined);
+    notStrictEqual(session, null);
     strictEqual((session as unknown as Session).getToken(), token);
 
     const response2 = await request(app)

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/using-the-authorization-header.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/using-the-authorization-header.feature.ts
@@ -36,7 +36,7 @@ describe('Feature: Using the Authorization header', () => {
 
   it('Example: Simple usage with optional bearer tokens', async () => {
 
-    let session: Session|undefined;
+    let session: Session|null = null;
 
     /* ======================= DOCUMENTATION BEGIN ======================= */
 
@@ -85,21 +85,21 @@ describe('Feature: Using the Authorization header', () => {
 
     const app = await createApp(AppController);
 
-    strictEqual(session, undefined);
+    strictEqual(session, null);
 
     await request(app)
       .get('/api/products')
       .expect(200)
       .expect([]);
 
-    strictEqual(session, undefined);
+    strictEqual(session, null);
 
     const response = await request(app)
       .post('/api/login')
       .send({})
       .expect(200);
 
-    strictEqual(session, undefined);
+    strictEqual(session, null);
 
     const token: undefined|string = response.body.token;
     if (token === undefined) {
@@ -112,14 +112,14 @@ describe('Feature: Using the Authorization header', () => {
       .expect(200)
       .expect([]);
 
-    notStrictEqual(session, undefined);
+    notStrictEqual(session, null);
     strictEqual((session as unknown as Session).getToken(), token);
 
   });
 
   it('Example: Usage with required bearer tokens', async () => {
 
-    let session: Session|undefined;
+    let session: Session|null = null;
 
     /* ======================= DOCUMENTATION BEGIN ======================= */
 
@@ -168,7 +168,7 @@ describe('Feature: Using the Authorization header', () => {
 
     const app = await createApp(AppController);
 
-    strictEqual(session, undefined);
+    strictEqual(session, null);
 
     await request(app)
       .get('/api/products')
@@ -178,14 +178,14 @@ describe('Feature: Using the Authorization header', () => {
         description: 'Authorization header not found.'
       });
 
-    strictEqual(session, undefined);
+    strictEqual(session, null);
 
     const response = await request(app)
       .post('/api/login')
       .send({})
       .expect(200);
 
-    strictEqual(session, undefined);
+    strictEqual(session, null);
 
     const token: undefined|string = response.body.token;
     if (token === undefined) {
@@ -198,7 +198,7 @@ describe('Feature: Using the Authorization header', () => {
       .expect(200)
       .expect([]);
 
-    notStrictEqual(session, undefined);
+    notStrictEqual(session, null);
     strictEqual((session as unknown as Session).getToken(), token);
   });
 

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/social-auth/using-social-auth-with-sessions.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/social-auth/using-social-auth-with-sessions.feature.ts
@@ -62,7 +62,7 @@ describe('Feature: Using social auth with sessions', () => {
       @UseSessions({
         cookie: true,
       })
-      async handleGoogleRedirection(ctx: Context) {
+      async handleGoogleRedirection(ctx: Context<User>) {
         const { userInfo } = await this.google.getUserInfo<{ email: string }>(ctx);
 
         if (!userInfo.email) {
@@ -82,6 +82,8 @@ describe('Feature: Using social auth with sessions', () => {
 
         return new HttpResponseRedirect('/');
       }
+
+    }
 
     }
 

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/social-auth/using-social-auth-with-sessions.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/social-auth/using-social-auth-with-sessions.feature.ts
@@ -13,7 +13,6 @@ import {
   dependency,
   Get,
   HttpResponseRedirect,
-  Session,
   Store,
   UseSessions,
 } from '@foal/core';
@@ -63,7 +62,7 @@ describe('Feature: Using social auth with sessions', () => {
       @UseSessions({
         cookie: true,
       })
-      async handleGoogleRedirection(ctx: Context<User, Session>) {
+      async handleGoogleRedirection(ctx: Context) {
         const { userInfo } = await this.google.getUserInfo<{ email: string }>(ctx);
 
         if (!userInfo.email) {
@@ -79,7 +78,7 @@ describe('Feature: Using social auth with sessions', () => {
           await user.save();
         }
 
-        ctx.session.setUser(user);
+        ctx.session!.setUser(user);
 
         return new HttpResponseRedirect('/');
       }
@@ -113,7 +112,7 @@ describe('Feature: Using social auth with sessions', () => {
     });
 
     // Known user
-    const ctx = new Context<any, Session>({
+    const ctx = new Context({
       query: {
         code: 'known_user'
       }
@@ -127,7 +126,7 @@ describe('Feature: Using social auth with sessions', () => {
     deepStrictEqual(ctx.session.userId, user.id);
 
     // Unknown user
-    const ctx2 = new Context<any, Session>({
+    const ctx2 = new Context({
       query: {
         code: 'unknown_user'
       }

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/social-auth/using-social-auth-with-sessions.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/social-auth/using-social-auth-with-sessions.feature.ts
@@ -85,8 +85,6 @@ describe('Feature: Using social auth with sessions', () => {
 
     }
 
-    }
-
     /* ======================= DOCUMENTATION END ========================= */
 
     await createTestConnection([ User, DatabaseSession ]);

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/social-auth/using-social-auth-with-sessions.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/social-auth/using-social-auth-with-sessions.feature.ts
@@ -112,7 +112,7 @@ describe('Feature: Using social auth with sessions', () => {
     });
 
     // Known user
-    const ctx = new Context({
+    const ctx = new Context<User>({
       query: {
         code: 'known_user'
       }
@@ -126,7 +126,7 @@ describe('Feature: Using social auth with sessions', () => {
     deepStrictEqual(ctx.session.userId, user.id);
 
     // Unknown user
-    const ctx2 = new Context({
+    const ctx2 = new Context<User>({
       query: {
         code: 'unknown_user'
       }

--- a/packages/acceptance-tests/src/docs/databases/using-another-orm/creating-a-custom-fetch-user-function.feature.ts
+++ b/packages/acceptance-tests/src/docs/databases/using-another-orm/creating-a-custom-fetch-user-function.feature.ts
@@ -16,9 +16,6 @@ describe('Feature: Creating a custom fetch user function.', () => {
           throw new Error('The user ID must be a number.');
         }
         const user = await userModel.findOne({ id });
-        if (user === null) {
-          return undefined;
-        }
         return user;
       };
     }
@@ -41,7 +38,7 @@ describe('Feature: Creating a custom fetch user function.', () => {
       'The user ID must be a number.'
     );
     deepStrictEqual(await fetchUser(User)(1, services), { id: 1 })
-    strictEqual(await fetchUser(User)(2, services), undefined)
+    strictEqual(await fetchUser(User)(2, services), null)
 
   });
 

--- a/packages/acceptance-tests/src/docs/security/csrf/regular-web-app.stateful.spec.ts
+++ b/packages/acceptance-tests/src/docs/security/csrf/regular-web-app.stateful.spec.ts
@@ -18,7 +18,6 @@ import {
   HttpResponseRedirect,
   Post,
   render,
-  Session,
   UseSessions,
   ValidateBody,
   verifyPassword
@@ -81,8 +80,8 @@ describe('Feature: Stateful CSRF protection in a Regular Web App', () => {
       // Nothing in documentation
       store: TypeORMStore,
     })
-    async index(ctx: Context<User, Session>) {
-      return new HttpResponseOK({ csrfToken: ctx.session.get('csrfToken') });
+    async index(ctx: Context) {
+      return new HttpResponseOK({ csrfToken: ctx.session!.get('csrfToken') });
       // In documentation:
       // return render(
       //   './templates/products.html',

--- a/packages/core/src/common/hooks/user-required.hook.spec.ts
+++ b/packages/core/src/common/hooks/user-required.hook.spec.ts
@@ -29,19 +29,6 @@ describe('UserRequired', () => {
 
     beforeEach(() => hook = getHookFunction(UserRequired()));
 
-    context('given Context.user is undefined', () => {
-
-      beforeEach(() => ctx.user = undefined);
-
-      it('should return an HttpResponseUnauthorized instance.', () => {
-        const response = hook(ctx, services);
-        if (!isHttpResponseUnauthorized(response)) {
-          throw new Error('The hook should have returned an HttpResponseUnauthorized instance.');
-        }
-      });
-
-    });
-
     context('given Context.user is null', () => {
 
       beforeEach(() => ctx.user = null);
@@ -73,20 +60,6 @@ describe('UserRequired', () => {
     const path = '/foo';
 
     beforeEach(() => hook = getHookFunction(UserRequired({ redirectTo: path })));
-
-    context('given Context.user is undefined', () => {
-
-      beforeEach(() => ctx.user = undefined);
-
-      it('should return an HttpResponseRedirect instance.', () => {
-        const response = hook(ctx, services);
-        if (!isHttpResponseRedirect(response)) {
-          throw new Error('The hook should have returned an HttpResponseRedirect instance.');
-        }
-        strictEqual(response.path, path);
-      });
-
-    });
 
     context('given Context.user is null', () => {
 

--- a/packages/core/src/common/hooks/user-required.hook.ts
+++ b/packages/core/src/common/hooks/user-required.hook.ts
@@ -2,7 +2,7 @@ import { ApiResponse, Context, Hook, HookDecorator, HttpResponseRedirect, HttpRe
 
 export function UserRequired(options: { redirectTo?: string, openapi?: boolean } = {}): HookDecorator {
   function hook(ctx: Context) {
-    if (ctx.user === undefined || ctx.user === null) {
+    if (!ctx.user) {
       if (options.redirectTo) {
         return new HttpResponseRedirect(options.redirectTo);
       }

--- a/packages/core/src/core/hooks.ts
+++ b/packages/core/src/core/hooks.ts
@@ -20,7 +20,7 @@ export type HookPostFunction = (response: HttpResponse) => void | Promise<void>;
  *
  * @export
  */
-export type HookFunction = (ctx: Context, services: ServiceManager) =>
+export type HookFunction<C = Context> = (ctx: C, services: ServiceManager) =>
   void | HttpResponse | HookPostFunction | Promise <void | HttpResponse | HookPostFunction>;
 
 /**
@@ -37,12 +37,12 @@ export type HookDecorator = (target: any, propertyKey?: string) => any;
  * @param {HookFunction[]} hookFunction - The function from which the hook should be created.
  * @returns {HookDecorator} - The hook decorator.
  */
-export function Hook(
-  hookFunction: HookFunction, openApiDecorators: OpenApiDecorator[] = [], options: { openapi?: boolean } = {}
+export function Hook<C = Context>(
+  hookFunction: HookFunction<C>, openApiDecorators: OpenApiDecorator[] = [], options: { openapi?: boolean } = {}
 ): HookDecorator {
   return (target: any, propertyKey?: string) => {
     // Note that propertyKey can be undefined as it's an optional parameter in getMetadata.
-    const hooks: HookFunction[] = Reflect.getOwnMetadata('hooks', target, propertyKey as string) || [];
+    const hooks: HookFunction<C>[] = Reflect.getOwnMetadata('hooks', target, propertyKey as string) || [];
     hooks.unshift(hookFunction);
     Reflect.defineMetadata('hooks', hooks, target, propertyKey as string);
 

--- a/packages/core/src/core/http/context.spec.ts
+++ b/packages/core/src/core/http/context.spec.ts
@@ -11,7 +11,7 @@ describe('Context', () => {
     const actual = new Context(request);
     strictEqual(actual.request, request);
     deepStrictEqual(actual.state, {});
-    strictEqual(actual.user, undefined);
+    strictEqual(actual.user, null);
     strictEqual(actual.session, null);
   });
 

--- a/packages/core/src/core/http/context.spec.ts
+++ b/packages/core/src/core/http/context.spec.ts
@@ -12,7 +12,7 @@ describe('Context', () => {
     strictEqual(actual.request, request);
     deepStrictEqual(actual.state, {});
     strictEqual(actual.user, undefined);
-    strictEqual(actual.session, undefined);
+    strictEqual(actual.session, null);
   });
 
 });

--- a/packages/core/src/core/http/context.ts
+++ b/packages/core/src/core/http/context.ts
@@ -108,8 +108,8 @@ interface Request extends IncomingMessage {
  * @class Context
  * @template User
  */
-export class Context<User = any, ContextSession = Session | undefined, ContextState = any> {
-  state: ContextState = {} as ContextState;
+export class Context<User = any, ContextSession = Session | null, ContextState = { [key: string]: any }> {
+  state: ContextState;
   user: User;
   session: ContextSession;
   request: Request;
@@ -121,5 +121,7 @@ export class Context<User = any, ContextSession = Session | undefined, ContextSt
    */
   constructor(request: any) {
     this.request = request;
+    this.state = {} as any;
+    this.session = null as any;
   }
 }

--- a/packages/core/src/core/http/context.ts
+++ b/packages/core/src/core/http/context.ts
@@ -108,11 +108,12 @@ interface Request extends IncomingMessage {
  * @class Context
  * @template User
  */
-export class Context<User = any, ContextSession = Session | null, ContextState = { [key: string]: any }> {
-  state: ContextState;
+export class Context<User = { [key: string]: any } | null, ContextSession = Session | null, ContextState = { [key: string]: any }> {
+  request: Request;
+
   user: User;
   session: ContextSession;
-  request: Request;
+  state: ContextState;
 
   /**
    * Creates an instance of Context.
@@ -121,7 +122,8 @@ export class Context<User = any, ContextSession = Session | null, ContextState =
    */
   constructor(request: any) {
     this.request = request;
-    this.state = {} as any;
+    this.user = null as any;
     this.session = null as any;
+    this.state = {} as any;
   }
 }

--- a/packages/core/src/core/http/context.ts
+++ b/packages/core/src/core/http/context.ts
@@ -108,11 +108,11 @@ interface Request extends IncomingMessage {
  * @class Context
  * @template User
  */
-export class Context<User = { [key: string]: any } | null, ContextSession = Session | null, ContextState = { [key: string]: any }> {
+export class Context<User = { [key: string]: any } | null, ContextState = { [key: string]: any }> {
   request: Request;
+  session: Session | null;
 
   user: User;
-  session: ContextSession;
   state: ContextState;
 
   /**
@@ -122,8 +122,9 @@ export class Context<User = { [key: string]: any } | null, ContextSession = Sess
    */
   constructor(request: any) {
     this.request = request;
+    this.session = null;
+
     this.user = null as any;
-    this.session = null as any;
     this.state = {} as any;
   }
 }

--- a/packages/core/src/sessions/fetch-user.interface.ts
+++ b/packages/core/src/sessions/fetch-user.interface.ts
@@ -1,3 +1,3 @@
-import { ServiceManager } from '../core';
+import { Context, ServiceManager } from '../core';
 
-export type FetchUser = (id: string|number, services: ServiceManager) => Promise<any>;
+export type FetchUser = (id: string|number, services: ServiceManager) => Promise<Context['user']>;

--- a/packages/core/src/sessions/use-sessions.hook.spec.ts
+++ b/packages/core/src/sessions/use-sessions.hook.spec.ts
@@ -166,10 +166,10 @@ describe('UseSessions', () => {
 
           context('given options.create is false or undefined', async () => {
 
-            it('should let ctx.session equal undefined.', async () => {
+            it('should let ctx.session equal null.', async () => {
               await hook(ctx, services);
 
-              strictEqual(ctx.session, undefined);
+              strictEqual(ctx.session, null);
             });
 
           });
@@ -306,10 +306,10 @@ describe('UseSessions', () => {
 
             beforeEach(() => hook = getHookFunction(UseSessions({ store: Store, cookie: true, create: false })));
 
-            it('should let ctx.session equal undefined.', async () => {
+            it('should let ctx.session equal null.', async () => {
               await hook(ctx, services);
 
-              strictEqual(ctx.session, undefined);
+              strictEqual(ctx.session, null);
             });
 
           });

--- a/packages/core/src/sessions/use-sessions.hook.spec.ts
+++ b/packages/core/src/sessions/use-sessions.hook.spec.ts
@@ -158,10 +158,10 @@ describe('UseSessions', () => {
             strictEqual(isHttpResponse(response), false);
           });
 
-          it('should let ctx.user equal undefined.', async () => {
+          it('should let ctx.user equal null.', async () => {
             await hook(ctx, services);
 
-            strictEqual(ctx.user, undefined);
+            strictEqual(ctx.user, null);
           });
 
           context('given options.create is false or undefined', async () => {
@@ -284,10 +284,10 @@ describe('UseSessions', () => {
             strictEqual(isHttpResponse(response), false);
           });
 
-          it('should let ctx.user equal undefined.', async () => {
+          it('should let ctx.user equal null.', async () => {
             await hook(ctx, services);
 
-            strictEqual(ctx.user, undefined);
+            strictEqual(ctx.user, null);
           });
 
           context('given options.create is not defined', async () => {
@@ -700,11 +700,11 @@ describe('UseSessions', () => {
 
       beforeEach(() => ctx = createContext({ Authorization: `Bearer ${anonymousSessionID}`}));
 
-      it('with the undefined value.', async () => {
+      it('with the null value.', async () => {
         const response = await hook(ctx, services);
         strictEqual(isHttpResponse(response), false);
 
-        strictEqual(ctx.user, undefined);
+        strictEqual(ctx.user, null);
       });
 
     });
@@ -715,11 +715,11 @@ describe('UseSessions', () => {
 
       context('given options.user is not defined', () => {
 
-        it('with the undefined value.', async () => {
+        it('with the null value.', async () => {
           const response = await hook(ctx, services);
           strictEqual(isHttpResponse(response), false);
 
-          strictEqual(ctx.user, undefined);
+          strictEqual(ctx.user, null);
         });
 
       });
@@ -732,7 +732,7 @@ describe('UseSessions', () => {
         beforeEach(() => {
           const fetchUser: FetchUser = async (id, services) => {
             actualServices = services;
-            return id === userId ? user : undefined
+            return id === userId ? user : null
           };
           hook = getHookFunction(UseSessions({ store: Store, user: fetchUser }));
         });
@@ -750,16 +750,16 @@ describe('UseSessions', () => {
           strictEqual(ctx.user, user);
         });
 
-        context('given the function options.user returns undefined (session invalid)', () => {
+        context('given the function options.user returns null (session invalid)', () => {
 
-          const fetchUser: FetchUser = async id => undefined;
+          const fetchUser: FetchUser = async id => null;
 
           beforeEach(() => hook = getHookFunction(UseSessions({ store: Store, user: fetchUser })));
 
-          it('with the undefined value and should destroy the session.', async () => {
+          it('with the null value and should destroy the session.', async () => {
             await hook(ctx, services);
 
-            strictEqual(ctx.user, undefined);
+            strictEqual(ctx.user, null);
             // tslint:disable-next-line
             strictEqual(ctx.session?.isDestroyed, true);
           });
@@ -767,7 +767,7 @@ describe('UseSessions', () => {
           context('given options.cookie is false or not defined', () => {
 
             it(
-              'with the undefined value and should not remove a session cookie in the response '
+              'with the null value and should not remove a session cookie in the response '
               + '(it can belongs to another application).',
               async () => {
                 const response = await hook(ctx, services);
@@ -775,7 +775,7 @@ describe('UseSessions', () => {
                   throw new Error('The hook should have returned an HttpResponse instance.');
                 }
 
-                strictEqual(ctx.user, undefined);
+                strictEqual(ctx.user, null);
 
                 deepStrictEqual(response.getCookies(), {});
               }
@@ -800,13 +800,13 @@ describe('UseSessions', () => {
               }
             });
 
-            it('with the undefined value and should remove the session cookie.', async () => {
+            it('with the null value and should remove the session cookie.', async () => {
               const response = await hook(ctx, services);
               if (!isHttpResponse(response)) {
                 throw new Error('The hook should have returned an HttpResponse instance.');
               }
 
-              strictEqual(ctx.user, undefined);
+              strictEqual(ctx.user, null);
 
               const { value, options } = response.getCookie(SESSION_DEFAULT_COOKIE_NAME);
               strictEqual(value, '');
@@ -830,7 +830,7 @@ describe('UseSessions', () => {
                   throw new Error('The hook should have returned an HttpResponse instance.');
                 }
 
-                strictEqual(ctx.user, undefined);
+                strictEqual(ctx.user, null);
 
                 const { value, options } = response.getCookie(SESSION_USER_COOKIE_NAME);
                 strictEqual(value, '');
@@ -847,7 +847,7 @@ describe('UseSessions', () => {
                   throw new Error('The hook should have returned an HttpResponse instance.');
                 }
 
-                strictEqual(ctx.user, undefined);
+                strictEqual(ctx.user, null);
 
                 const { value } = response.getCookie(SESSION_USER_COOKIE_NAME);
                 strictEqual(value, undefined);
@@ -859,10 +859,10 @@ describe('UseSessions', () => {
 
           context('given options.redirectTo is not defined', () => {
 
-            it('with the undefined value and should return an HttpResponseUnauthorized object.', async () => {
+            it('with the null value and should return an HttpResponseUnauthorized object.', async () => {
               const response = await hook(ctx, services);
 
-              strictEqual(ctx.user, undefined);
+              strictEqual(ctx.user, null);
 
               if (!isHttpResponseUnauthorized(response)) {
                 throw new Error('response should be instance of HttpResponseUnauthorized');
@@ -888,7 +888,7 @@ describe('UseSessions', () => {
             it('with the null value and should return an HttpResponseRedirect object.', async () => {
               const response = await hook(ctx, services);
 
-              strictEqual(ctx.user, undefined);
+              strictEqual(ctx.user, null);
 
               if (!isHttpResponseRedirect(response)) {
                 throw new Error('response should be instance of HttpResponseRedirect');

--- a/packages/examples/src/app/app.controller.ts
+++ b/packages/examples/src/app/app.controller.ts
@@ -1,5 +1,5 @@
 import {
-  Context, controller, Get, render, Session, UseSessions
+  Context, controller, Get, render, UseSessions
 } from '@foal/core';
 import { TypeORMStore } from '@foal/typeorm';
 
@@ -17,9 +17,9 @@ export class AppController {
 
   @Get('/')
   @UseSessions({ cookie: true, store: TypeORMStore, redirectTo: '/signin' })
-  index(ctx: Context<any, Session>) {
+  index(ctx: Context) {
     return render('./templates/index.html', {
-      userInfo: JSON.stringify(ctx.session.get('userInfo'))
+      userInfo: JSON.stringify(ctx.session!.get('userInfo'))
     });
   }
 

--- a/packages/examples/src/app/controllers/auth.controller.ts
+++ b/packages/examples/src/app/controllers/auth.controller.ts
@@ -5,7 +5,6 @@ import {
   Get,
   HttpResponse,
   HttpResponseRedirect,
-  Session,
   UseSessions,
 } from '@foal/core';
 import { FacebookProvider, GithubProvider, GoogleProvider, LinkedInProvider, TwitterProvider } from '@foal/social';
@@ -37,7 +36,7 @@ export class AuthController {
   }
 
   @Get('/signin/google/cb')
-  async handleGoogleRedirection(ctx: Context<any, Session>) {
+  async handleGoogleRedirection(ctx: Context) {
     const { userInfo } = await this.google.getUserInfo(ctx);
     return this.createSessionAndSaveUserInfo(userInfo, ctx);
   }
@@ -48,7 +47,7 @@ export class AuthController {
   }
 
   @Get('/signin/facebook/cb')
-  async handleFacebookRedirection(ctx: Context<any, Session>) {
+  async handleFacebookRedirection(ctx: Context) {
     const { userInfo } = await this.facebook.getUserInfo(ctx);
     return this.createSessionAndSaveUserInfo(userInfo, ctx);
   }
@@ -59,7 +58,7 @@ export class AuthController {
   }
 
   @Get('/signin/github/cb')
-  async handleGithubRedirection(ctx: Context<any, Session>) {
+  async handleGithubRedirection(ctx: Context) {
     const { userInfo } = await this.github.getUserInfo(ctx);
     return this.createSessionAndSaveUserInfo(userInfo, ctx);
   }
@@ -70,7 +69,7 @@ export class AuthController {
   }
 
   @Get('/signin/linkedin/cb')
-  async handleLinkedInRedirection(ctx: Context<any, Session>) {
+  async handleLinkedInRedirection(ctx: Context) {
     const { userInfo } = await this.linkedin.getUserInfo(ctx);
     return this.createSessionAndSaveUserInfo(userInfo, ctx);
   }
@@ -81,14 +80,14 @@ export class AuthController {
   }
 
   @Get('/signin/twitter/cb')
-  async handleTwitterRedirection(ctx: Context<any, Session>) {
+  async handleTwitterRedirection(ctx: Context) {
     const { userInfo } = await this.twitter.getUserInfo(ctx);
     return this.createSessionAndSaveUserInfo(userInfo, ctx);
   }
 
-  private async createSessionAndSaveUserInfo(userInfo: any, ctx: Context<any, Session>): Promise<HttpResponse> {
-    ctx.session.set('userInfo', userInfo);
-    ctx.session.regenerateID();
+  private async createSessionAndSaveUserInfo(userInfo: any, ctx: Context): Promise<HttpResponse> {
+    ctx.session!.set('userInfo', userInfo);
+    ctx.session!.regenerateID();
 
     return new HttpResponseRedirect('/');
   }

--- a/packages/examples/src/app/controllers/profile.controller.ts
+++ b/packages/examples/src/app/controllers/profile.controller.ts
@@ -18,7 +18,7 @@ export class ProfileController {
   disk: Disk;
 
   @Post('/image')
-  @Hook(async ctx => { ctx.user = await getRepository(User).findOne({ email: 'john@foalts.org' }); })
+  @Hook(async ctx => { ctx.user = await getRepository(User).findOne({ email: 'john@foalts.org' }) ?? null; })
   @ValidateMultipartFormDataBody({
     files: {
       profile: { required: true, saveTo: 'images/profiles' }
@@ -41,7 +41,7 @@ export class ProfileController {
   }
 
   @Get('/image')
-  @Hook(async ctx => { ctx.user = await getRepository(User).findOne({ email: 'john@foalts.org' }); })
+  @Hook(async ctx => { ctx.user = await getRepository(User).findOne({ email: 'john@foalts.org' }) ?? null; })
   async downloadProfilePicture(ctx: Context<User>) {
     const { profile } = ctx.user;
 

--- a/packages/jwt/src/jwt.hook.spec.ts
+++ b/packages/jwt/src/jwt.hook.spec.ts
@@ -96,7 +96,7 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
   const fetchUser: FetchUser = async (id, services) => {
     actualServices = services;
-    return id === '1' ? user : undefined;
+    return id === '1' ? user : null;
   };
 
   let ctx: Context;
@@ -151,10 +151,10 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
       } else {
 
-        it('should let ctx.user equal undefined if the Authorization header does not exist.', async () => {
+        it('should let ctx.user equal null if the Authorization header does not exist.', async () => {
           const response = await hook(ctx, services);
           strictEqual(response, undefined);
-          strictEqual(ctx.user, undefined);
+          strictEqual(ctx.user, null);
         });
 
       }
@@ -195,12 +195,12 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
       } else {
 
-        it('should let ctx.user equal undefined if the cookie does not exist.', async () => {
+        it('should let ctx.user equal null if the cookie does not exist.', async () => {
           const hook = getHookFunction(JWT({ cookie: true }));
 
           const response = await hook(ctx, services);
           strictEqual(response, undefined);
-          strictEqual(ctx.user, undefined);
+          strictEqual(ctx.user, null);
         });
 
       }
@@ -765,7 +765,7 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
         await hook(ctx, services);
 
-        notStrictEqual(ctx.user, undefined);
+        notStrictEqual(ctx.user, null);
         strictEqual((ctx.user as any).foo, 'bar');
       });
 
@@ -787,7 +787,7 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
         await hook(ctx, services);
 
-        notStrictEqual(ctx.user, undefined);
+        notStrictEqual(ctx.user, null);
         strictEqual((ctx.user as any).foo, 'bar');
       });
 
@@ -802,7 +802,7 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
         await hook(ctx, services);
 
-        notStrictEqual(ctx.user, undefined);
+        notStrictEqual(ctx.user, null);
         strictEqual((ctx.user as any).foo, 'bar');
       });
 
@@ -814,7 +814,7 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
         await hook(ctx, services);
 
-        notStrictEqual(ctx.user, undefined);
+        notStrictEqual(ctx.user, null);
         strictEqual((ctx.user as any).foo, 'bar');
       });
 
@@ -828,7 +828,7 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
         await hook(ctx, services);
 
-        notStrictEqual(ctx.user, undefined);
+        notStrictEqual(ctx.user, null);
         strictEqual((ctx.user as any).foo, 'bar');
       });
 

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -23,21 +23,16 @@ export class MongoDBStore extends SessionStore {
   }
 
   async boot() {
-    console.log('[Debug CI] [MongoDBStore.boot] beginning');
     if (!this.mongoDBClient) {
       const mongoDBURI = Config.getOrThrow(
         'settings.mongodb.uri',
         'string',
         'You must provide the URI of your database when using MongoDBStore.'
       );
-      console.log('[Debug CI] [MongoDBStore.boot] before connect');
       this.mongoDBClient = await MongoClient.connect(mongoDBURI);
-      console.log('[Debug CI] [MongoDBStore.boot] after connect');
     }
-    console.log('[Debug CI] [MongoDBStore.boot] middle');
     this.collection = this.mongoDBClient.db().collection<DatabaseSession>('sessions');
     this.collection.createIndex({ sessionID: 1 }, { unique: true });
-    console.log('[Debug CI] [MongoDBStore.boot] end');
   }
 
   async save(state: SessionState, maxInactivity: number): Promise<void> {

--- a/packages/socket.io/src/architecture/websocket-context.spec.ts
+++ b/packages/socket.io/src/architecture/websocket-context.spec.ts
@@ -17,7 +17,7 @@ describe('WebsocketContext', () => {
     strictEqual(actual.payload, payload);
     strictEqual(actual.socket, socket);
     deepStrictEqual(actual.state, {});
-    strictEqual(actual.user, undefined);
+    strictEqual(actual.user, null);
     strictEqual(actual.session, null);
   });
 

--- a/packages/socket.io/src/architecture/websocket-context.spec.ts
+++ b/packages/socket.io/src/architecture/websocket-context.spec.ts
@@ -18,7 +18,7 @@ describe('WebsocketContext', () => {
     strictEqual(actual.socket, socket);
     deepStrictEqual(actual.state, {});
     strictEqual(actual.user, undefined);
-    strictEqual(actual.session, undefined);
+    strictEqual(actual.session, null);
   });
 
 });

--- a/packages/socket.io/src/architecture/websocket-context.ts
+++ b/packages/socket.io/src/architecture/websocket-context.ts
@@ -17,11 +17,13 @@ import { Session } from '@foal/core';
  * @template ContextSession
  * @template ContextState
  */
-export class WebsocketContext<User = any, ContextSession = Session | null, ContextState = { [key: string]: any }> {
-  state: ContextState;
+export class WebsocketContext<User = { [key: string]: any } | null, ContextSession = Session | null, ContextState = { [key: string]: any }> {
+  socket: Socket;
+
   user: User;
   session: ContextSession;
-  socket: Socket;
+  state: ContextState;
+
 
   /**
    * Creates an instance of WebsocketContext.
@@ -32,7 +34,9 @@ export class WebsocketContext<User = any, ContextSession = Session | null, Conte
    */
   constructor(public eventName: string, public payload: any, socket: any = {}) {
     this.socket = socket;
-    this.state = {} as any;
+
+    this.user = null as any;
     this.session = null as any;
+    this.state = {} as any;
   }
 }

--- a/packages/socket.io/src/architecture/websocket-context.ts
+++ b/packages/socket.io/src/architecture/websocket-context.ts
@@ -17,8 +17,8 @@ import { Session } from '@foal/core';
  * @template ContextSession
  * @template ContextState
  */
-export class WebsocketContext<User = any, ContextSession = Session | undefined, ContextState = any> {
-  state: ContextState = {} as ContextState;
+export class WebsocketContext<User = any, ContextSession = Session | null, ContextState = { [key: string]: any }> {
+  state: ContextState;
   user: User;
   session: ContextSession;
   socket: Socket;
@@ -32,5 +32,7 @@ export class WebsocketContext<User = any, ContextSession = Session | undefined, 
    */
   constructor(public eventName: string, public payload: any, socket: any = {}) {
     this.socket = socket;
+    this.state = {} as any;
+    this.session = null as any;
   }
 }

--- a/packages/socket.io/src/architecture/websocket-context.ts
+++ b/packages/socket.io/src/architecture/websocket-context.ts
@@ -17,11 +17,11 @@ import { Session } from '@foal/core';
  * @template ContextSession
  * @template ContextState
  */
-export class WebsocketContext<User = { [key: string]: any } | null, ContextSession = Session | null, ContextState = { [key: string]: any }> {
+export class WebsocketContext<User = { [key: string]: any } | null, ContextState = { [key: string]: any }> {
   socket: Socket;
+  session: Session | null;
 
   user: User;
-  session: ContextSession;
   state: ContextState;
 
 
@@ -34,9 +34,9 @@ export class WebsocketContext<User = { [key: string]: any } | null, ContextSessi
    */
   constructor(public eventName: string, public payload: any, socket: any = {}) {
     this.socket = socket;
+    this.session = null;
 
     this.user = null as any;
-    this.session = null as any;
     this.state = {} as any;
   }
 }

--- a/packages/socket.io/src/socketio-controller.service.spec.ts
+++ b/packages/socket.io/src/socketio-controller.service.spec.ts
@@ -106,7 +106,7 @@ describe('SocketIOController', () => {
         notStrictEqual(actualContext?.socket, undefined);
         notDeepStrictEqual(actualContext?.socket, {});
         deepStrictEqual(actualContext?.state, {});
-        strictEqual(actualContext?.user, undefined);
+        strictEqual(actualContext?.user, null);
       });
 
       it('and should emit a connection error if SocketIOController.onConnection throws or rejects an error.', async () => {
@@ -165,7 +165,7 @@ describe('SocketIOController', () => {
         notStrictEqual(actualContext?.socket, undefined);
         notDeepStrictEqual(actualContext?.socket, {});
         deepStrictEqual(actualContext?.state, {});
-        strictEqual(actualContext?.user, undefined);
+        strictEqual(actualContext?.user, null);
       });
 
       it('and should return an ok response if the controller method returns a WebsocketResponse (with no payload).', async () => {

--- a/packages/socket.io/src/socketio-controller.service.spec.ts
+++ b/packages/socket.io/src/socketio-controller.service.spec.ts
@@ -102,7 +102,7 @@ describe('SocketIOController', () => {
 
         strictEqual(actualContext?.eventName, '');
         strictEqual(actualContext?.payload, undefined);
-        strictEqual(actualContext?.session, undefined);
+        strictEqual(actualContext?.session, null);
         notStrictEqual(actualContext?.socket, undefined);
         notDeepStrictEqual(actualContext?.socket, {});
         deepStrictEqual(actualContext?.state, {});
@@ -161,7 +161,7 @@ describe('SocketIOController', () => {
         deepStrictEqual(actualContext?.payload, payload);
         deepStrictEqual(actualPayload, payload);
 
-        strictEqual(actualContext?.session, undefined);
+        strictEqual(actualContext?.session, null);
         notStrictEqual(actualContext?.socket, undefined);
         notDeepStrictEqual(actualContext?.socket, {});
         deepStrictEqual(actualContext?.state, {});

--- a/packages/typeorm/package-lock.json
+++ b/packages/typeorm/package-lock.json
@@ -317,7 +317,7 @@
 		"any-promise": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-			"integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
 			"dev": true
 		},
 		"anymatch": {

--- a/packages/typeorm/src/utils/fetch-mongodb-user.util.spec.ts
+++ b/packages/typeorm/src/utils/fetch-mongodb-user.util.spec.ts
@@ -65,19 +65,23 @@ describe('fetchMongoDBUser', () => {
 
   it('should return the user fetched from the database (id).', async () => {
     const actual = await fetchMongoDBUser(User)(user.id.toString(), new ServiceManager());
-    notStrictEqual(actual, undefined);
+    if (actual === null) {
+      throw new Error('The user should not be null.');
+    }
     strictEqual(user.id.equals(actual.id), true);
   });
 
   it('should return the user fetched from the database (_id).', async () => {
     const actual = await fetchMongoDBUser(User2)(user2._id.toString(), new ServiceManager());
-    notStrictEqual(actual, undefined);
+    if (actual === null) {
+      throw new Error('The user should not be null.');
+    }
     strictEqual(user2._id.equals(actual._id), true);
   });
 
-  it('should return undefined if no user is found in the database (string).', async () => {
+  it('should return null if no user is found in the database (string).', async () => {
     const actual = await fetchMongoDBUser(User)('5c584690ba14b143235f195d', new ServiceManager());
-    strictEqual(actual, undefined);
+    strictEqual(actual, null);
   });
 
 });

--- a/packages/typeorm/src/utils/fetch-mongodb-user.util.spec.ts
+++ b/packages/typeorm/src/utils/fetch-mongodb-user.util.spec.ts
@@ -1,6 +1,6 @@
 // std
 import { ServiceManager } from '@foal/core';
-import { notStrictEqual, strictEqual } from 'assert';
+import { strictEqual } from 'assert';
 
 // 3p
 import { Column, createConnection, Entity, getConnection, getMongoManager, ObjectID, ObjectIdColumn } from 'typeorm';

--- a/packages/typeorm/src/utils/fetch-mongodb-user.util.ts
+++ b/packages/typeorm/src/utils/fetch-mongodb-user.util.ts
@@ -18,10 +18,10 @@ import { getMongoRepository, ObjectID } from 'typeorm';
  * @returns {FetchUser} The returned function expecting an id.
  */
 export function fetchMongoDBUser(userEntityClass: Class<{ id: ObjectID }|{ _id: ObjectID }>): FetchUser {
-  return (id: number|string) => {
+  return async (id: number|string) => {
     if (typeof id === 'number') {
       throw new Error('Unexpected type for MongoDB user ID: number.');
     }
-    return getMongoRepository(userEntityClass).findOne(id);
+    return await getMongoRepository(userEntityClass).findOne(id) ?? null;
   };
 }

--- a/packages/typeorm/src/utils/fetch-user-with-permissions.util.spec.ts
+++ b/packages/typeorm/src/utils/fetch-user-with-permissions.util.spec.ts
@@ -1,6 +1,6 @@
 // std
 import { ServiceManager } from '@foal/core';
-import { notStrictEqual, ok, strictEqual } from 'assert';
+import { ok, strictEqual } from 'assert';
 
 // 3p
 import { createConnection, Entity, getConnection, getManager } from 'typeorm';

--- a/packages/typeorm/src/utils/fetch-user-with-permissions.util.spec.ts
+++ b/packages/typeorm/src/utils/fetch-user-with-permissions.util.spec.ts
@@ -82,20 +82,26 @@ function testSuite(type: 'mysql' | 'mariadb' | 'postgres' | 'sqlite' | 'better-s
 
     it('should return the user fetched from the database (id: number).', async () => {
       const actual = await fetchUserWithPermissions(User)(user.id, new ServiceManager());
-      notStrictEqual(actual, undefined);
-      strictEqual((actual as User).id, user.id);
+      if (actual === null) {
+        throw new Error('The user should not be null.');
+      }
+      strictEqual(actual.id, user.id);
     });
 
     it('should return the user fetched from the database (id: string).', async () => {
       const actual = await fetchUserWithPermissions(User)(user.id.toString(), new ServiceManager());
-      notStrictEqual(actual, undefined);
-      strictEqual((actual as User).id, user.id);
+      if (actual === null) {
+        throw new Error('The user should not be null.');
+      }
+      strictEqual(actual.id, user.id);
     });
 
     it('should return the user fetched from the database with their groups and permissions.', async () => {
       const actual = await fetchUserWithPermissions(User)(user.id, new ServiceManager());
-      notStrictEqual(actual, undefined);
-      strictEqual((actual as User).id, user.id);
+      if (actual === null) {
+        throw new Error('The user should not be null.');
+      }
+      strictEqual(actual.id, user.id);
 
       ok(Array.isArray(actual.userPermissions), 'userPermissions is not an array');
       strictEqual(actual.userPermissions.length, 1);
@@ -110,9 +116,9 @@ function testSuite(type: 'mysql' | 'mariadb' | 'postgres' | 'sqlite' | 'better-s
       strictEqual(actual.groups[0].permissions[0].codeName, 'permission1');
     });
 
-    it('should return undefined if no user is found in the database.', async () => {
+    it('should return null if no user is found in the database.', async () => {
       const actual = await fetchUserWithPermissions(User)(56, new ServiceManager());
-      strictEqual(actual, undefined);
+      strictEqual(actual, null);
     });
 
   });

--- a/packages/typeorm/src/utils/fetch-user-with-permissions.util.ts
+++ b/packages/typeorm/src/utils/fetch-user-with-permissions.util.ts
@@ -18,8 +18,8 @@ import { getRepository } from 'typeorm';
  * @returns {FetchUser} The returned function expecting an id.
  */
 export function fetchUserWithPermissions(userEntityClass: Class<{ id: number|string }>): FetchUser {
-  return (id: number|string) => getRepository(userEntityClass).findOne(
+  return async (id: number|string) => await getRepository(userEntityClass).findOne(
     { id },
     { relations: [ 'userPermissions', 'groups', 'groups.permissions' ] }
-  );
+  ) ?? null;
 }

--- a/packages/typeorm/src/utils/fetch-user.util.spec.ts
+++ b/packages/typeorm/src/utils/fetch-user.util.spec.ts
@@ -71,19 +71,23 @@ function testSuite(type: 'mysql'|'mariadb'|'postgres'|'sqlite'|'better-sqlite3')
 
     it('should return the user fetched from the database (id: number).', async () => {
       const actual = await fetchUser(User)(user.id, new ServiceManager());
-      notStrictEqual(actual, undefined);
-      strictEqual((actual as User).id, user.id);
+      if (actual === null) {
+        throw new Error('The user should not be null.');
+      }
+      strictEqual(actual.id, user.id);
     });
 
     it('should return the user fetched from the database (id: string).', async () => {
       const actual = await fetchUser(User)(user.id.toString(), new ServiceManager());
-      notStrictEqual(actual, undefined);
-      strictEqual((actual as User).id, user.id);
+      if (actual === null) {
+        throw new Error('The user should not be null.');
+      }
+      strictEqual(actual.id, user.id);
     });
 
-    it('should return undefined if no user is found in the database.', async () => {
+    it('should return null if no user is found in the database.', async () => {
       const actual = await fetchUser(User)(56, new ServiceManager());
-      strictEqual(actual, undefined);
+      strictEqual(actual, null);
     });
 
   });

--- a/packages/typeorm/src/utils/fetch-user.util.spec.ts
+++ b/packages/typeorm/src/utils/fetch-user.util.spec.ts
@@ -1,6 +1,6 @@
 // std
 import { ServiceManager } from '@foal/core';
-import { notStrictEqual, strictEqual } from 'assert';
+import { strictEqual } from 'assert';
 
 // 3p
 import { Column, createConnection, Entity, getConnection, getManager, PrimaryGeneratedColumn } from 'typeorm';

--- a/packages/typeorm/src/utils/fetch-user.util.ts
+++ b/packages/typeorm/src/utils/fetch-user.util.ts
@@ -17,5 +17,5 @@ import { getRepository } from 'typeorm';
  * @returns {FetchUser} The returned function expecting an id.
  */
 export function fetchUser(userEntityClass: Class<{ id: number|string }>): FetchUser {
-  return (id: number|string) => getRepository(userEntityClass).findOne({ id });
+  return async (id: number|string) => await getRepository(userEntityClass).findOne({ id }) ?? null;
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Aim

- [x] Reduce the number of generic parameters from 3 to 2.
- [x] Make the value of `Context.user` and `Context.session` set to `null` by default instead of `undefined`. It makes more sense (the property is defined but has no user) and it's consistent with the return values of the "`findOne`" functions of current popular ORM (TypeORM@0.3, Prisma, Mikro-ORM, Mongoose).
- [x] Change the default type of `Context.user` from `any` to `{ [key: string]: any } | null` to improve type safety.  
- [x] Change the default type of `Context.state` from `any` to `{ [key: string]: any }` to improve type safety.  
- [x] Change the return type of `FetchUser` from `Promise<any>` to `Promise<Context['user']>;` to improve type safety.  

# Solution and steps

- [x] Change `Context` definition
- [x] Change `FetchUser` definition
- [x] Change all `fetchUser` functions

# Breaking changes

```typescript
Context<User> -> Context<User>
Context<User|undefined> -> Context<User|null>
Context<User, Session> -> Context<User>
Context<any, any, State> -> Context<any, State>

// Before
let ctx: Context<any, Session>;
ctx.session.set('foo', 'bar');

// After
let ctx: Context;
ctx.session!.set('foo', 'bar');

// To update: the return value of the custom `fetchUser` functions
// All code checking if `ctx.user` or `ctx.session` if undefined.
```

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
