### PR TITLE
Simplify generated CLI files and do not make shell scripts depend on TypeORM

### DIFF
--- a/packages/cli/src/generate/specs/app/src/app/entities/user.entity.mongodb.ts
+++ b/packages/cli/src/generate/specs/app/src/app/entities/user.entity.mongodb.ts
@@ -1,20 +1,9 @@
-// import { hashPassword } from '@foal/core';
-import { /*Column, */Entity, ObjectID, ObjectIdColumn } from 'typeorm';
+import { Entity, ObjectID, ObjectIdColumn } from 'typeorm';
 
 @Entity()
 export class User {
 
   @ObjectIdColumn()
   id: ObjectID;
-
-  // @Column({ unique: true })
-  // email: string;
-
-  // @Column()
-  // password: string;
-
-  // async setPassword(password: string) {
-  //   this.password = await hashPassword(password);
-  // }
 
 }

--- a/packages/cli/src/generate/specs/app/src/app/entities/user.entity.ts
+++ b/packages/cli/src/generate/specs/app/src/app/entities/user.entity.ts
@@ -1,20 +1,9 @@
-// import { hashPassword } from '@foal/core';
-import { BaseEntity, /*Column, */Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseEntity, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
 export class User extends BaseEntity {
 
   @PrimaryGeneratedColumn()
   id: number;
-
-  // @Column({ unique: true })
-  // email: string;
-
-  // @Column()
-  // password: string;
-
-  // async setPassword(password: string) {
-  //   this.password = await hashPassword(password);
-  // }
 
 }

--- a/packages/cli/src/generate/specs/app/src/scripts/create-user.mongodb.ts
+++ b/packages/cli/src/generate/specs/app/src/scripts/create-user.mongodb.ts
@@ -1,5 +1,4 @@
 // 3p
-// import { isCommon } from '@foal/password';
 import { createConnection, getConnection, getMongoManager } from 'typeorm';
 
 // App
@@ -8,21 +7,16 @@ import { User } from '../app/entities';
 export const schema = {
   additionalProperties: false,
   properties: {
-    // email: { type: 'string', format: 'email' },
-    // password: { type: 'string' },
+
   },
-  required: [ /* 'email', 'password' */ ],
+  required: [
+
+  ],
   type: 'object',
 };
 
-export async function main(/*args*/) {
+export async function main() {
   const user = new User();
-  // user.email = args.email;
-  // if (await isCommon(args.password)) {
-  //   console.log('This password is too common. Please choose another one.');
-  //   return;
-  // }
-  // await user.setPassword(args.password);
 
   await createConnection();
 

--- a/packages/cli/src/generate/specs/app/src/scripts/create-user.ts
+++ b/packages/cli/src/generate/specs/app/src/scripts/create-user.ts
@@ -1,5 +1,4 @@
 // 3p
-// import { hashPassword } from '@foal/core';
 import { createConnection } from 'typeorm';
 
 // App
@@ -8,20 +7,19 @@ import { User } from '../app/entities';
 export const schema = {
   additionalProperties: false,
   properties: {
-    // email: { type: 'string', format: 'email' },
-    // password: { type: 'string' },
+
   },
-  required: [ /* 'email', 'password' */ ],
+  required: [
+
+  ],
   type: 'object',
 };
 
-export async function main(/*args*/) {
+export async function main() {
   const connection = await createConnection();
 
   try {
     const user = new User();
-    // user.email = args.email;
-    // user.password = await hashPassword(args.password);
 
     console.log(await user.save());
   } catch (error: any) {

--- a/packages/cli/src/generate/specs/script/test-foo-bar.ts
+++ b/packages/cli/src/generate/specs/script/test-foo-bar.ts
@@ -1,24 +1,14 @@
-// 3p
-import { createConnection } from 'typeorm';
-
 export const schema = {
   additionalProperties: false,
   properties: {
-    /* To complete */
+
   },
-  required: [ /* To complete */ ],
+  required: [
+
+  ],
   type: 'object',
 };
 
-export async function main(args: any) {
-  const connection = await createConnection();
+export async function main() {
 
-  try {
-    // Do something.
-
-  } catch (error: any) {
-    console.error(error);
-  } finally {
-    await connection.close();
-  }
 }

--- a/packages/cli/src/generate/templates/app/src/app/entities/user.entity.mongodb.ts
+++ b/packages/cli/src/generate/templates/app/src/app/entities/user.entity.mongodb.ts
@@ -1,20 +1,9 @@
-// import { hashPassword } from '@foal/core';
-import { /*Column, */Entity, ObjectID, ObjectIdColumn } from 'typeorm';
+import { Entity, ObjectID, ObjectIdColumn } from 'typeorm';
 
 @Entity()
 export class User {
 
   @ObjectIdColumn()
   id: ObjectID;
-
-  // @Column({ unique: true })
-  // email: string;
-
-  // @Column()
-  // password: string;
-
-  // async setPassword(password: string) {
-  //   this.password = await hashPassword(password);
-  // }
 
 }

--- a/packages/cli/src/generate/templates/app/src/app/entities/user.entity.ts
+++ b/packages/cli/src/generate/templates/app/src/app/entities/user.entity.ts
@@ -1,20 +1,9 @@
-// import { hashPassword } from '@foal/core';
-import { BaseEntity, /*Column, */Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseEntity, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
 export class User extends BaseEntity {
 
   @PrimaryGeneratedColumn()
   id: number;
-
-  // @Column({ unique: true })
-  // email: string;
-
-  // @Column()
-  // password: string;
-
-  // async setPassword(password: string) {
-  //   this.password = await hashPassword(password);
-  // }
 
 }

--- a/packages/cli/src/generate/templates/app/src/scripts/create-user.mongodb.ts
+++ b/packages/cli/src/generate/templates/app/src/scripts/create-user.mongodb.ts
@@ -1,5 +1,4 @@
 // 3p
-// import { isCommon } from '@foal/password';
 import { createConnection, getConnection, getMongoManager } from 'typeorm';
 
 // App
@@ -8,21 +7,16 @@ import { User } from '../app/entities';
 export const schema = {
   additionalProperties: false,
   properties: {
-    // email: { type: 'string', format: 'email' },
-    // password: { type: 'string' },
+
   },
-  required: [ /* 'email', 'password' */ ],
+  required: [
+
+  ],
   type: 'object',
 };
 
-export async function main(/*args*/) {
+export async function main() {
   const user = new User();
-  // user.email = args.email;
-  // if (await isCommon(args.password)) {
-  //   console.log('This password is too common. Please choose another one.');
-  //   return;
-  // }
-  // await user.setPassword(args.password);
 
   await createConnection();
 

--- a/packages/cli/src/generate/templates/app/src/scripts/create-user.ts
+++ b/packages/cli/src/generate/templates/app/src/scripts/create-user.ts
@@ -1,5 +1,4 @@
 // 3p
-// import { hashPassword } from '@foal/core';
 import { createConnection } from 'typeorm';
 
 // App
@@ -8,20 +7,19 @@ import { User } from '../app/entities';
 export const schema = {
   additionalProperties: false,
   properties: {
-    // email: { type: 'string', format: 'email' },
-    // password: { type: 'string' },
+
   },
-  required: [ /* 'email', 'password' */ ],
+  required: [
+
+  ],
   type: 'object',
 };
 
-export async function main(/*args*/) {
+export async function main() {
   const connection = await createConnection();
 
   try {
     const user = new User();
-    // user.email = args.email;
-    // user.password = await hashPassword(args.password);
 
     console.log(await user.save());
   } catch (error: any) {

--- a/packages/cli/src/generate/templates/script/script.ts
+++ b/packages/cli/src/generate/templates/script/script.ts
@@ -1,24 +1,14 @@
-// 3p
-import { createConnection } from 'typeorm';
-
 export const schema = {
   additionalProperties: false,
   properties: {
-    /* To complete */
+
   },
-  required: [ /* To complete */ ],
+  required: [
+
+  ],
   type: 'object',
 };
 
-export async function main(args: any) {
-  const connection = await createConnection();
+export async function main() {
 
-  try {
-    // Do something.
-
-  } catch (error: any) {
-    console.error(error);
-  } finally {
-    await connection.close();
-  }
 }


### PR DESCRIPTION
# Issue

- Generated files are often coupled with TypeORM.
- There are a lot of comments that go against the "simplicity" value of the framework.

# Solution and steps

- [x] Remove TypeORM from the generated shell scripts.
- [x] Remove comments.

# Changes

See solutions and steps.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
