### PR TITLE
Finalize upgrade to TypeORM v0.3

### DIFF
--- a/benchmarks/tsconfig.json
+++ b/benchmarks/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,

--- a/docs/docs/architecture/services-and-dependency-injection.md
+++ b/docs/docs/architecture/services-and-dependency-injection.md
@@ -246,7 +246,7 @@ class ApiController {
   dataSource: DataSource;
 
   @Get('/products')
-  async readProducts() {
+  async readProducts() {
     const products = await this.dataSource.getRepository(Product).find();
     return new HttpResponseOK(products);
   }

--- a/docs/docs/authentication-and-access-control/groups-and-permissions.md
+++ b/docs/docs/authentication-and-access-control/groups-and-permissions.md
@@ -161,9 +161,7 @@ export async function main(args: { codeName: string, name: string, permissions: 
     for (const codeName of args.permissions) {
       const permission = await Permission.findOneBy({ codeName });
       if (!permission) {
-        console.log(
-          `No permission with the code name "${codeName}" was found.`
-        );
+        console.log(`No permission with the code name "${codeName}" was found.`);
         return;
       }
       group.permissions.push(permission);

--- a/docs/docs/authentication-and-access-control/groups-and-permissions.md
+++ b/docs/docs/authentication-and-access-control/groups-and-permissions.md
@@ -50,7 +50,7 @@ Replace the content of the new created file `src/scripts/create-perm.ts` with th
 import { Permission } from '@foal/typeorm';
 
 // App
-import { createDataSource } from '../db';
+import { dataSource } from '../db';
 
 export const schema = {
   additionalProperties: false,
@@ -67,7 +67,6 @@ export async function main(args: { codeName: string, name: string }) {
   permission.codeName = args.codeName;
   permission.name = args.name;
 
-  const dataSource = createDataSource();
   await dataSource.initialize();
 
   try {
@@ -135,7 +134,7 @@ Replace the content of the new created file `src/scripts/create-group.ts` with t
 import { Group, Permission } from '@foal/typeorm';
 
 // App
-import { createDataSource } from '../db';
+import { dataSource } from '../db';
 
 export const schema = {
   additionalProperties: false,
@@ -154,7 +153,6 @@ export async function main(args: { codeName: string, name: string, permissions: 
   group.codeName = args.codeName;
   group.name = args.name;
 
-  const dataSource = createDataSource();
   await dataSource.initialize();
 
   try {
@@ -230,7 +228,7 @@ import { Group, Permission } from '@foal/typeorm';
 
 // App
 import { User } from '../app/entities';
-import { createDataSource } from '../db';
+import { dataSource } from '../db';
 
 export const schema = {
   additionalProperties: false,
@@ -251,7 +249,6 @@ export async function main(args) {
   user.email = args.email;
   user.password = await hashPassword(args.password);
 
-  const dataSource = createDataSource();
   await dataSource.initialize();
 
   for (const codeName of args.userPermissions as string[]) {

--- a/docs/docs/authentication-and-access-control/session-tokens.md
+++ b/docs/docs/authentication-and-access-control/session-tokens.md
@@ -1085,7 +1085,7 @@ npm install mongodb@4
 > The `MongoDBStore` requires version 4 of the [mongodb](https://www.npmjs.com/package/mongodb) package. If you are using TypeORM with MongoDB, which requires version 3, you can have both versions coexist in your `package.json` as follows:
 > ```json
 > {
->   "mongodb": "~3.6.6",
+>   "mongodb": "~3.7.3",
 >   "mongodb4": "npm:mongodb@~4.3.1",
 > }
 > ```

--- a/docs/docs/authentication-and-access-control/user-class.md
+++ b/docs/docs/authentication-and-access-control/user-class.md
@@ -92,7 +92,43 @@ export class User {
 
 Running the `create-user` script will result in an error since we do not provide an email and a password as arguments.
 
-Go to `src/scripts/create-user.ts` and uncomment the lines mentionning the emails and passwords.
+Go to `src/scripts/create-user.ts` and replace its content with the following lines:
+
+```typescript
+// 3p
+import { hashPassword } from '@foal/core';
+
+// App
+import { User } from '../app/entities';
+import { dataSource } from '../db';
+
+export const schema = {
+  additionalProperties: false,
+  properties: {
+    email: { type: 'string', format: 'email' },
+    password: { type: 'string' },
+  },
+  required: [ 'email', 'password' ],
+  type: 'object',
+};
+
+export async function main(args) {
+  await dataSource.initialize();
+
+  try {
+    const user = new User();
+    user.email = args.email;
+    user.password = await hashPassword(args.password);
+
+    console.log(await user.save());
+  } catch (error: any) {
+    console.error(error.message);
+  } finally {
+    await dataSource.destroy();
+  }
+}
+
+```
 
 > To get it work, you will also need to install the `password` package: `npm install --save @foal/password`. The `isCommon` util helps you to detect if a password is too common (ex: 12345) and thus prevents the script from creating a new user with an unsecured password.
 

--- a/docs/docs/databases/mongodb.md
+++ b/docs/docs/databases/mongodb.md
@@ -90,7 +90,9 @@ export class User extends BaseEntity {
 
 *Example*
 ```typescript
-const user = await User.findOne('xxxx');
+import { ObjectId } from 'mongodb';
+
+const user = await User.findOneBy({ _id: new ObjectId('xxxx') });
 ```
 
 ## Authentication

--- a/docs/docs/databases/typeorm.md
+++ b/docs/docs/databases/typeorm.md
@@ -46,7 +46,7 @@ Here is a non-exhaustive list of its features:
 FoalTS supports officially the following databases:
 
 | Database | Versions | Driver |
-| --- | --- | --- | --- |
+| --- | --- | --- |
 | PostgreSQL | 9.6+ ([Version Policy](https://www.postgresql.org/support/versioning/)) | `pg@8` |
 | MySQL | 5.7+ ([Version Policy](https://en.wikipedia.org/wiki/MySQL#Release_history)) | `mysql@2` |
 | MariaDB | 10.2+ ([Version Policy](https://en.wikipedia.org/wiki/MariaDB#Versioning)) | `mysql@2` |
@@ -61,64 +61,6 @@ TypeORM is integrated by default in each new FoalTS project. This allows you to 
 
 When creating a new project, an `SQLite` database is used by default as it does not require any additional installation (the data is saved in a file). The connection configuration is stored in `default.json` located in the `config/` directory.
 
-*ormconfig.js*
-```js
-const { Config } = require('@foal/core');
-
-module.exports = {
-  type: 'better-sqlite3',
-  database: Config.get('database.database', 'string'),
-  dropSchema: Config.get('database.dropSchema', 'boolean', false),
-  entities: ['build/app/**/*.entity.js'],
-  migrations: ['build/migrations/*.js'],
-  cli: {
-    migrationsDir: 'src/migrations'
-  },
-  synchronize: Config.get('database.synchronize', 'boolean', false)
-}
-```
-
-<Tabs
-  defaultValue="yaml"
-  values={[
-    {label: 'YAML', value: 'yaml'},
-    {label: 'JSON', value: 'json'},
-    {label: 'JS', value: 'js'},
-  ]}
->
-<TabItem value="yaml">
-
-```yaml
-database:
-  database: ./db.sqlite3
-```
-
-</TabItem>
-<TabItem value="json">
-
-```json
-{
-  "database": {
-    "database": "./db.sqlite3"
-  }
-}
-```
-
-</TabItem>
-<TabItem value="js">
-
-```javascript
-module.exports = {
-  database: {
-    database: "./db.sqlite3",
-  }
-}
-```
-
-</TabItem>
-</Tabs>
-
-
 ### Packages
 
 ```
@@ -131,33 +73,13 @@ Two packages are required to use TypeORM with FoalTS:
 
 ## Database Configuration Examples
 
-This section shows how to configure **MySQL** or **PostgreSQL** with Foal.
+### PostgreSQL
 
-*ormconfig.js*
-```js
-const { Config } = require('@foal/core');
-
-module.exports = {
-  type: 'mysql', // or 'postgres'
-
-  host: Config.get('database.host', 'string'),
-  port: Config.get('database.port', 'number'),
-  username: Config.get('database.username', 'string'),
-  password: Config.get('database.password', 'string'),
-  database: Config.get('database.database', 'string'),
-
-  dropSchema: Config.get('database.dropSchema', 'boolean', false),
-  synchronize: Config.get('database.synchronize', 'boolean', false),
-  
-  entities: ["build/app/**/*.entity.js"],
-  migrations: ["build/migrations/*.js"],
-  cli: {
-    migrationsDir: "src/migrations"
-  },
-}
+```sh
+npm install pg
 ```
 
-With this configuration, database credentials can be provided in a YAML, a JSON or a `.env `configuration file or in environment variables.
+*config/default.{json|yml|js}*
 
 <Tabs
   defaultValue="yaml"
@@ -173,6 +95,76 @@ With this configuration, database credentials can be provided in a YAML, a JSON 
 # ...
 
 database:
+  type: postgres
+  host: localhost
+  port: 5432
+  username: root
+  password: password
+  database: my-db
+```
+
+</TabItem>
+<TabItem value="json">
+
+```json
+{
+  // ...
+
+  "database": {
+    "type": "postgres",
+    "host": "localhost",
+    "port": 5432,
+    "username": "root",
+    "password": "password",
+    "database": "my-db"
+  }
+}
+```
+
+</TabItem>
+<TabItem value="js">
+
+```javascript
+module.exports = {
+  // ...
+
+  database: {
+    type: "postgres",
+    host: "localhost",
+    port: 5432,
+    username: "root",
+    password: "password",
+    database: "my-db"
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+### MySQL
+
+```sh
+npm install mysql
+```
+
+*config/default.{json|yml|js}*
+
+<Tabs
+  defaultValue="yaml"
+  values={[
+    {label: 'YAML', value: 'yaml'},
+    {label: 'JSON', value: 'json'},
+    {label: 'JS', value: 'js'},
+  ]}
+>
+<TabItem value="yaml">
+
+```yaml
+# ...
+
+database:
+  type: mysql
   host: localhost
   port: 3306
   username: root
@@ -186,7 +178,9 @@ database:
 ```json
 {
   // ...
+
   "database": {
+    "type": "mysql",
     "host": "localhost",
     "port": 3306,
     "username": "root",
@@ -202,7 +196,9 @@ database:
 ```javascript
 module.exports = {
   // ...
+
   database: {
+    type: "mysql",
     host: "localhost",
     port: 3306,
     username: "root",
@@ -215,21 +211,74 @@ module.exports = {
 </TabItem>
 </Tabs>
 
-### MySQL / MariaDB
-
-Install `mysql` or `mysql3` drivers.
+### MariaDB
 
 ```sh
-npm install mysql --save # mysql2 is also supported
+npm install mysql
 ```
 
-### PostgreSQL
+*config/default.{json|yml|js}*
 
-Install `pg` driver.
+<Tabs
+  defaultValue="yaml"
+  values={[
+    {label: 'YAML', value: 'yaml'},
+    {label: 'JSON', value: 'json'},
+    {label: 'JS', value: 'js'},
+  ]}
+>
+<TabItem value="yaml">
 
-```sh
-npm install pg --save
+```yaml
+# ...
+
+database:
+  type: mariadb
+  host: localhost
+  port: 3306
+  username: root
+  password: password
+  database: my-db
 ```
+
+</TabItem>
+<TabItem value="json">
+
+```json
+{
+  // ...
+
+  "database": {
+    "type": "mariadb",
+    "host": "localhost",
+    "port": 3306,
+    "username": "root",
+    "password": "password",
+    "database": "my-db"
+  }
+}
+```
+
+</TabItem>
+<TabItem value="js">
+
+```javascript
+module.exports = {
+  // ...
+
+  database: {
+    type: "mariadb",
+    host: "localhost",
+    port: 3306,
+    username: "root",
+    password: "password",
+    database: "my-db"
+  }
+}
+```
+
+</TabItem>
+</Tabs>
 
 ## Configuration and Testing
 

--- a/docs/docs/databases/using-another-orm.md
+++ b/docs/docs/databases/using-another-orm.md
@@ -116,7 +116,15 @@ Generate the TypeScript interfaces.
 npx prisma generate
 ```
 
-Update your `src/index.ts` to create the prisma connection and pass it to the service manager.
+Update your `src/app/db.ts` to create the prisma connection:
+
+```typescript
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient();
+```
+
+Then update your `src/index.ts` to inject it into the service manager.
 
 *src/index.ts*
 ```typescript
@@ -126,12 +134,11 @@ import { PrismaClient } from '@prisma/client';
 
 // App
 import { AppController } from './app/app.controller';
-
-const prisma = new PrismaClient();
+import { prisma } from './app/db';
 
 async function main() {
-  const serviceManager = new ServiceManager();
-  serviceManager.set(PrismaClient, prisma);
+  const serviceManager = new ServiceManager()
+    .set(PrismaClient, prisma);
   const app = await createApp(AppController, { serviceManager });
 
   // ...

--- a/docs/docs/tutorials/real-world-example-with-react/9-authenticated-api.md
+++ b/docs/docs/tutorials/real-world-example-with-react/9-authenticated-api.md
@@ -48,7 +48,7 @@ export class StoriesController {
   @UserRequired()
   async deleteStory(ctx: Context<User>, { storyId }: { storyId: number }) {
     // Only retrieve stories whose author is the current user.
-    const story = await Story.findOneBy({ id: storyId, author: ctx.user });
+    const story = await Story.findOneBy({ id: storyId, author: { id: ctx.user.id } });
 
     if (!story) {
       return new HttpResponseNotFound();

--- a/packages/acceptance-tests/src/additional/authentication/do-not-save-sessions-on-error.spec.ts
+++ b/packages/acceptance-tests/src/additional/authentication/do-not-save-sessions-on-error.spec.ts
@@ -1,6 +1,6 @@
 // 3p
 import * as request from 'supertest';
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 // FoalTS
 import { Config, Context, createApp, createSession, dependency, Get, Hook, HttpResponseOK, Store, UseSessions } from '@foal/core';

--- a/packages/acceptance-tests/src/additional/authentication/isolate-sessions-from-each-other.spec.ts
+++ b/packages/acceptance-tests/src/additional/authentication/isolate-sessions-from-each-other.spec.ts
@@ -1,6 +1,6 @@
 // 3p
 import * as request from 'supertest';
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 // FoalTS
 import {

--- a/packages/acceptance-tests/src/additional/authorization/groups-and-permissions.spec.ts
+++ b/packages/acceptance-tests/src/additional/authorization/groups-and-permissions.spec.ts
@@ -1,5 +1,5 @@
 // 3p
-import { Entity, DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { Entity, DataSource } from 'typeorm';
 import * as request from 'supertest';
 
 // FoalTS

--- a/packages/acceptance-tests/src/additional/controller-inheritance.spec.ts
+++ b/packages/acceptance-tests/src/additional/controller-inheritance.spec.ts
@@ -3,7 +3,7 @@ import { deepStrictEqual } from 'assert';
 
 // 3p
 import * as request from 'supertest';
-import { BaseEntity } from '@foal/typeorm/node_modules/typeorm';
+import { BaseEntity } from 'typeorm';
 
 // FoalTs
 import {

--- a/packages/acceptance-tests/src/additional/shell-scripts/create-group.ts
+++ b/packages/acceptance-tests/src/additional/shell-scripts/create-group.ts
@@ -9,7 +9,7 @@ export const schema = {
     name: { type: 'string', maxLength: 80 },
     permissions: { type: 'array', items: { type: 'string' }, uniqueItems: true, default: [] }
   },
-  required: [ 'name', 'codeName' ],
+  required: ['name', 'codeName'],
   type: 'object',
 };
 
@@ -19,18 +19,18 @@ export async function main(args: { codeName: string, name: string, permissions: 
   group.codeName = args.codeName;
   group.name = args.name;
 
-  const dataSource = await createAndInitializeDataSource([ Permission, Group ], { dropSchema: false });
-
-  for (const codeName of args.permissions) {
-    const permission = await Permission.findOneBy({ codeName });
-    if (!permission) {
-      console.log(`No permission with the code name "${codeName}" was found.`);
-      return;
-    }
-    group.permissions.push(permission);
-  }
+  const dataSource = await createAndInitializeDataSource([Permission, Group], { dropSchema: false });
 
   try {
+    for (const codeName of args.permissions) {
+      const permission = await Permission.findOneBy({ codeName });
+      if (!permission) {
+        console.log(`No permission with the code name "${codeName}" was found.`);
+        return;
+      }
+      group.permissions.push(permission);
+    }
+
     console.log(
       await group.save()
     );

--- a/packages/acceptance-tests/src/additional/typeorm.mongodb-store.spec.ts
+++ b/packages/acceptance-tests/src/additional/typeorm.mongodb-store.spec.ts
@@ -33,7 +33,7 @@ import {
   Entity,
   ObjectID,
   ObjectIdColumn
-} from '@foal/typeorm/node_modules/typeorm';
+} from 'typeorm';
 import { createAndInitializeDataSource } from '../common';
 
 describe('[Sample] TypeORM & MongoDB Store', async () => {

--- a/packages/acceptance-tests/src/additional/typeorm.redis-store.spec.ts
+++ b/packages/acceptance-tests/src/additional/typeorm.redis-store.spec.ts
@@ -33,7 +33,7 @@ import {
   Entity,
   ObjectID,
   ObjectIdColumn
-} from '@foal/typeorm/node_modules/typeorm';
+} from 'typeorm';
 import { createAndInitializeDataSource } from '../common';
 
 describe('[Sample] MongoDB & Redis Store', async () => {

--- a/packages/acceptance-tests/src/additional/typestack.spec.ts
+++ b/packages/acceptance-tests/src/additional/typestack.spec.ts
@@ -1,6 +1,6 @@
 // 3p
 import * as request from 'supertest';
-import { BaseEntity, Column, Entity, DataSource, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { BaseEntity, Column, Entity, DataSource, PrimaryGeneratedColumn } from 'typeorm';
 
 // FoalTS
 import { Context, createApp, HttpResponseCreated, Post } from '@foal/core';

--- a/packages/acceptance-tests/src/common/create-and-initialize-data-source.ts
+++ b/packages/acceptance-tests/src/common/create-and-initialize-data-source.ts
@@ -1,5 +1,5 @@
 // 3p
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 // FoalTS
 import { Class } from '@foal/core';

--- a/packages/acceptance-tests/src/common/user.entity.ts
+++ b/packages/acceptance-tests/src/common/user.entity.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
 export class User extends BaseEntity {

--- a/packages/acceptance-tests/src/docs/architecture/services-and-dependency-injection/injecting-other-instances-as-services.feature.ts
+++ b/packages/acceptance-tests/src/docs/architecture/services-and-dependency-injection/injecting-other-instances-as-services.feature.ts
@@ -3,7 +3,7 @@ import * as request from 'supertest';
 
 // FoalTS
 import { controller, createApp, dependency, Get, HttpResponseOK, IAppController, ServiceManager } from '@foal/core';
-import { DataSource, Entity, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { createAndInitializeDataSource } from '../../../common';
 
 describe('Feature: Injecting other instances as services', () => {

--- a/packages/acceptance-tests/src/docs/architecture/services-and-dependency-injection/using-interfaces-and-generic-classes-for-services.feature.ts
+++ b/packages/acceptance-tests/src/docs/architecture/services-and-dependency-injection/using-interfaces-and-generic-classes-for-services.feature.ts
@@ -6,7 +6,7 @@ import * as request from 'supertest';
 
 // FoalTS
 import { controller, createApp, Dependency, Get, HttpResponseOK, IAppController, ServiceManager } from '@foal/core';
-import { Entity, DataSource, PrimaryGeneratedColumn, Repository } from '@foal/typeorm/node_modules/typeorm';
+import { Entity, DataSource, PrimaryGeneratedColumn, Repository } from 'typeorm';
 import { createAndInitializeDataSource } from '../../../common';
 
 describe('Feature: Using interfaces and generic classes for services', () => {

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/administrators-and-roles/controlling-access-with-administrators.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/administrators-and-roles/controlling-access-with-administrators.feature.ts
@@ -2,7 +2,7 @@
 import { strictEqual } from 'assert';
 
 // 3p
-import { BaseEntity, Column, Entity, DataSource, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { BaseEntity, Column, Entity, DataSource, PrimaryGeneratedColumn } from 'typeorm';
 import * as request from 'supertest';
 
 // FoalTS

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/administrators-and-roles/controlling-access-with-static-roles.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/administrators-and-roles/controlling-access-with-static-roles.feature.ts
@@ -2,7 +2,7 @@
 import { strictEqual } from 'assert';
 
 // 3p
-import { BaseEntity, Column, Entity, DataSource, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { BaseEntity, Column, Entity, DataSource, PrimaryGeneratedColumn } from 'typeorm';
 import * as request from 'supertest';
 
 // FoalTS

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/quick-start/authenticating-users-in-a-stateful-spa-using-cookies.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/quick-start/authenticating-users-in-a-stateful-spa-using-cookies.feature.ts
@@ -1,5 +1,5 @@
 // 3p
-import { BaseEntity, Column, DataSource, Entity, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { BaseEntity, Column, DataSource, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import * as request from 'supertest';
 
 // FoalTS

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/quick-start/authenticating-users-in-a-stateful-spa-using-header.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/quick-start/authenticating-users-in-a-stateful-spa-using-header.feature.ts
@@ -2,7 +2,7 @@
 import { notStrictEqual } from 'assert';
 
 // 3p
-import { BaseEntity, Column, DataSource, Entity, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { BaseEntity, Column, DataSource, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import * as request from 'supertest';
 
 // FoalTS

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/quick-start/authenticating-users-in-a-stateful-ssr-app-using-cookies.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/quick-start/authenticating-users-in-a-stateful-ssr-app-using-cookies.feature.ts
@@ -2,7 +2,7 @@
 import { strictEqual } from 'assert';
 
 // 3p
-import { BaseEntity, Column, DataSource, Entity, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { BaseEntity, Column, DataSource, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import * as request from 'supertest';
 
 // FoalTS

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/quick-start/authenticating-users-in-a-stateless-spa-using-cookies.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/quick-start/authenticating-users-in-a-stateless-spa-using-cookies.feature.ts
@@ -2,7 +2,7 @@
 import { promisify } from 'util';
 
 // 3p
-import { BaseEntity, Column, DataSource, Entity, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { BaseEntity, Column, DataSource, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { sign } from 'jsonwebtoken';
 import * as request from 'supertest';
 

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/quick-start/authenticating-users-in-a-stateless-spa-using-header.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/quick-start/authenticating-users-in-a-stateless-spa-using-header.feature.ts
@@ -3,7 +3,7 @@ import { notStrictEqual } from 'assert';
 import { promisify } from 'util';
 
 // 3p
-import { BaseEntity, Column, DataSource, Entity, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { BaseEntity, Column, DataSource, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { sign } from 'jsonwebtoken';
 import * as request from 'supertest';
 

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/adding-authentication-and-access-control.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/adding-authentication-and-access-control.feature.ts
@@ -2,7 +2,7 @@
 import { notStrictEqual, strictEqual } from 'assert';
 
 // 3p
-import { BaseEntity, Column, DataSource, Entity, ManyToOne, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { BaseEntity, Column, DataSource, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import * as request from 'supertest';
 
 // FoalTS

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/destroying-the-session.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/destroying-the-session.feature.ts
@@ -4,7 +4,7 @@ import { notStrictEqual, strictEqual } from 'assert';
 
 // 3p
 import * as request from 'supertest';
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 // FoalTS
 import {

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/do-not-auto-create-the-session.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/do-not-auto-create-the-session.feature.ts
@@ -3,7 +3,7 @@ import { strictEqual } from 'assert';
 
 // 3p
 import * as request from 'supertest';
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 // FoalTS
 import {

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/modifying-session-timeouts.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/modifying-session-timeouts.feature.ts
@@ -1,6 +1,6 @@
 // 3p
 import * as request from 'supertest';
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 // FoalTS
 import {

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/overriding-the-cookie-options.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/overriding-the-cookie-options.feature.ts
@@ -3,7 +3,7 @@ import { strictEqual } from 'assert';
 
 // 3p
 import * as request from 'supertest';
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 // FoalTS
 import {

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/reading-a-session-from-a-token.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/reading-a-session-from-a-token.feature.ts
@@ -2,7 +2,7 @@
 import { rejects, strictEqual } from 'assert';
 
 // 3p
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 // FoalTS
 import {

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/reading-a-session-from-a-token.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/reading-a-session-from-a-token.feature.ts
@@ -31,7 +31,7 @@ describe('Feature: Reading a session from a token', () => {
   });
 
   it('Example: Simple example.', async () => {
-    const store = await createService(Store);
+    const store = createService(Store);
 
     async function getFoo(token: string): Promise<any> {
       /* ======================= DOCUMENTATION BEGIN ======================= */

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/regenerating-the-session-id.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/regenerating-the-session-id.feature.ts
@@ -3,7 +3,7 @@ import { notStrictEqual } from 'assert';
 
 // 3p
 import * as request from 'supertest';
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 // FoalTS
 import {

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/requiring-the-session-cookie.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/requiring-the-session-cookie.feature.ts
@@ -1,6 +1,6 @@
 // 3p
 import * as request from 'supertest';
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 // FoalTS
 import {

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/revoking-sessions.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/revoking-sessions.feature.ts
@@ -2,7 +2,7 @@
 import { notStrictEqual, strictEqual } from 'assert';
 
 // 3p
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 // FoalTS
 import { Config, createService, createSession, readSession, Store } from '@foal/core';

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/saving-and-reading-content.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/saving-and-reading-content.feature.ts
@@ -1,6 +1,6 @@
 // 3p
 import * as request from 'supertest';
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 // FoalTS
 import {

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/using-cookies.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/using-cookies.feature.ts
@@ -3,7 +3,7 @@ import { notStrictEqual, strictEqual } from 'assert';
 
 // 3p
 import * as request from 'supertest';
-import { DataSource } from '@foal/typeorm/node_modules/typeorm'
+import { DataSource } from 'typeorm'
 
 // FoalTS
 import {

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/using-the-authorization-header.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/session-tokens/using-the-authorization-header.feature.ts
@@ -3,7 +3,7 @@ import { notStrictEqual, strictEqual } from 'assert';
 
 // 3p
 import * as request from 'supertest';
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 // FoalTS
 import {

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/social-auth/using-social-auth-with-jwt.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/social-auth/using-social-auth-with-jwt.feature.ts
@@ -3,7 +3,7 @@ import { promisify } from 'util';
 import { strictEqual } from 'assert';
 
 // 3p
-import { BaseEntity, Column, DataSource, Entity, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { BaseEntity, Column, DataSource, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { decode, sign } from 'jsonwebtoken';
 
 // FoalTS

--- a/packages/acceptance-tests/src/docs/authentication-and-access-control/social-auth/using-social-auth-with-sessions.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication-and-access-control/social-auth/using-social-auth-with-sessions.feature.ts
@@ -2,7 +2,7 @@
 import { deepStrictEqual, strictEqual } from 'assert';
 
 // 3p
-import { BaseEntity, Column, DataSource, Entity, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { BaseEntity, Column, DataSource, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 // FoalTS
 import {

--- a/packages/acceptance-tests/src/docs/security/csrf/disabling-csrf-protection-on-a-specific-route.feature.ts
+++ b/packages/acceptance-tests/src/docs/security/csrf/disabling-csrf-protection-on-a-specific-route.feature.ts
@@ -3,7 +3,7 @@ import { } from 'assert';
 
 // 3p
 import * as request from 'supertest';
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 // FoalTS
 import { Config, controller, createApp, Get, HttpResponseOK, Post, UseSessions } from '@foal/core';

--- a/packages/acceptance-tests/src/docs/security/csrf/regular-web-app.stateful.spec.ts
+++ b/packages/acceptance-tests/src/docs/security/csrf/regular-web-app.stateful.spec.ts
@@ -2,7 +2,7 @@
 import { strictEqual } from 'assert';
 
 // 3p
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 import * as request from 'supertest';
 
 // FoalTS

--- a/packages/acceptance-tests/src/docs/security/csrf/spa.stateful.spec.ts
+++ b/packages/acceptance-tests/src/docs/security/csrf/spa.stateful.spec.ts
@@ -2,7 +2,7 @@
 import { strictEqual } from 'assert';
 
 // 3p
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 import * as request from 'supertest';
 
 // FoalTS

--- a/packages/acceptance-tests/src/docs/security/csrf/spa.stateless.spec.ts
+++ b/packages/acceptance-tests/src/docs/security/csrf/spa.stateless.spec.ts
@@ -2,7 +2,7 @@
 import { strictEqual } from 'assert';
 
 // 3p
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 import { sign } from 'jsonwebtoken';
 import * as request from 'supertest';
 

--- a/packages/acceptance-tests/tsconfig.json
+++ b/packages/acceptance-tests/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/aws-s3/tsconfig.json
+++ b/packages/aws-s3/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/cli/src/generate/specs/app/src/scripts/create-user.ts
+++ b/packages/cli/src/generate/specs/app/src/scripts/create-user.ts
@@ -21,7 +21,7 @@ export async function main() {
 
     console.log(await user.save());
   } catch (error: any) {
-    console.log(error.message);
+    console.error(error.message);
   } finally {
     await dataSource.destroy();
   }

--- a/packages/cli/src/generate/specs/app/tsconfig.json
+++ b/packages/cli/src/generate/specs/app/tsconfig.json
@@ -8,7 +8,7 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "rootDir": "src",
     "lib": [
       "es2017",

--- a/packages/cli/src/generate/specs/rest-api/controllers/test-foo-bar.controller.auth.subdir.ts
+++ b/packages/cli/src/generate/specs/rest-api/controllers/test-foo-bar.controller.auth.subdir.ts
@@ -140,7 +140,7 @@ export class TestFooBarController {
       return new HttpResponseNotFound();
     }
 
-    await TestFooBar.delete(ctx.request.params.testFooBarId);
+    await TestFooBar.delete({ id: ctx.request.params.testFooBarId });
 
     return new HttpResponseNoContent();
   }

--- a/packages/cli/src/generate/specs/rest-api/controllers/test-foo-bar.controller.auth.ts
+++ b/packages/cli/src/generate/specs/rest-api/controllers/test-foo-bar.controller.auth.ts
@@ -140,7 +140,7 @@ export class TestFooBarController {
       return new HttpResponseNotFound();
     }
 
-    await TestFooBar.delete(ctx.request.params.testFooBarId);
+    await TestFooBar.delete({ id: ctx.request.params.testFooBarId });
 
     return new HttpResponseNoContent();
   }

--- a/packages/cli/src/generate/specs/rest-api/controllers/test-foo-bar.controller.subdir.ts
+++ b/packages/cli/src/generate/specs/rest-api/controllers/test-foo-bar.controller.subdir.ts
@@ -123,7 +123,7 @@ export class TestFooBarController {
       return new HttpResponseNotFound();
     }
 
-    await TestFooBar.delete(ctx.request.params.testFooBarId);
+    await TestFooBar.delete({ id: ctx.request.params.testFooBarId });
 
     return new HttpResponseNoContent();
   }

--- a/packages/cli/src/generate/specs/rest-api/controllers/test-foo-bar.controller.ts
+++ b/packages/cli/src/generate/specs/rest-api/controllers/test-foo-bar.controller.ts
@@ -123,7 +123,7 @@ export class TestFooBarController {
       return new HttpResponseNotFound();
     }
 
-    await TestFooBar.delete(ctx.request.params.testFooBarId);
+    await TestFooBar.delete({ id: ctx.request.params.testFooBarId });
 
     return new HttpResponseNoContent();
   }

--- a/packages/cli/src/generate/specs/script/test-foo-bar.ts
+++ b/packages/cli/src/generate/specs/script/test-foo-bar.ts
@@ -9,6 +9,6 @@ export const schema = {
   type: 'object',
 };
 
-export async function main() {
+export async function main(args: any) {
 
 }

--- a/packages/cli/src/generate/templates/app/src/scripts/create-user.ts
+++ b/packages/cli/src/generate/templates/app/src/scripts/create-user.ts
@@ -21,7 +21,7 @@ export async function main() {
 
     console.log(await user.save());
   } catch (error: any) {
-    console.log(error.message);
+    console.error(error.message);
   } finally {
     await dataSource.destroy();
   }

--- a/packages/cli/src/generate/templates/app/tsconfig.json
+++ b/packages/cli/src/generate/templates/app/tsconfig.json
@@ -8,7 +8,7 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "rootDir": "src",
     "lib": [
       "es2017",

--- a/packages/cli/src/generate/templates/rest-api/controllers/controller.auth.ts
+++ b/packages/cli/src/generate/templates/rest-api/controllers/controller.auth.ts
@@ -140,7 +140,7 @@ export class /* upperFirstCamelName */Controller {
       return new HttpResponseNotFound();
     }
 
-    await /* upperFirstCamelName */.delete(ctx.request.params./* camelName */Id);
+    await /* upperFirstCamelName */.delete({ id: ctx.request.params./* camelName */Id });
 
     return new HttpResponseNoContent();
   }

--- a/packages/cli/src/generate/templates/rest-api/controllers/controller.ts
+++ b/packages/cli/src/generate/templates/rest-api/controllers/controller.ts
@@ -123,7 +123,7 @@ export class /* upperFirstCamelName */Controller {
       return new HttpResponseNotFound();
     }
 
-    await /* upperFirstCamelName */.delete(ctx.request.params./* camelName */Id);
+    await /* upperFirstCamelName */.delete({ id: ctx.request.params./* camelName */Id });
 
     return new HttpResponseNoContent();
   }

--- a/packages/cli/src/generate/templates/script/script.ts
+++ b/packages/cli/src/generate/templates/script/script.ts
@@ -9,6 +9,6 @@ export const schema = {
   type: 'object',
 };
 
-export async function main() {
+export async function main(args: any) {
 
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/examples/src/app/entities/product.entity.ts
+++ b/packages/examples/src/app/entities/product.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
 export class Product {

--- a/packages/examples/src/app/entities/user.entity.ts
+++ b/packages/examples/src/app/entities/user.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryGeneratedColumn } from '@foal/typeorm/node_modules/typeorm';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 import { hashPassword } from '@foal/core';
 import { UserWithPermissions } from '@foal/typeorm';

--- a/packages/examples/src/db.ts
+++ b/packages/examples/src/db.ts
@@ -1,4 +1,4 @@
-import { DataSource } from '@foal/typeorm/node_modules/typeorm';
+import { DataSource } from 'typeorm';
 
 export function createDataSource(): DataSource {
   return new DataSource({

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "build",
     "sourceMap": true,
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,

--- a/packages/graphiql/tsconfig.json
+++ b/packages/graphiql/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/internal-test/tsconfig.json
+++ b/packages/internal-test/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/jwks-rsa/tsconfig.json
+++ b/packages/jwks-rsa/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/jwt/tsconfig.json
+++ b/packages/jwt/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -18,7 +18,7 @@ export class MongoDBStore extends SessionStore {
   private mongoDBClient: MongoClient;
   private collection: Collection<DatabaseSession>;
 
-  setMongoDBClient(mongoDBClient: MongoClient) {
+  setMongoDBClient(mongoDBClient: MongoClient): void {
     this.mongoDBClient = mongoDBClient;
   }
 

--- a/packages/mongodb/tsconfig.json
+++ b/packages/mongodb/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/password/tsconfig.json
+++ b/packages/password/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/redis/src/redis-store.service.ts
+++ b/packages/redis/src/redis-store.service.ts
@@ -12,7 +12,7 @@ export class RedisStore extends SessionStore {
 
   private redisClient: ReturnType<typeof createClient>;
 
-  setRedisClient(redisClient: ReturnType<typeof createClient>) {
+  setRedisClient(redisClient: ReturnType<typeof createClient>): void {
     this.redisClient = redisClient;
   }
 

--- a/packages/redis/tsconfig.json
+++ b/packages/redis/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/social/tsconfig.json
+++ b/packages/social/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/socket.io/tsconfig.json
+++ b/packages/socket.io/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/swagger/tsconfig.json
+++ b/packages/swagger/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/typeorm/tsconfig.json
+++ b/packages/typeorm/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/packages/typestack/tsconfig.json
+++ b/packages/typestack/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "./lib/",
     "baseUrl": ".",
     "module": "commonjs",
-    "target": "es2017",
+    "target": "es2021",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,


### PR DESCRIPTION
## Breaking changes (and new features)

- The framework code is now built in `es2021`. This should not be a problem considering the supported versions of Node by Foal.

## Dependencies

https://github.com/FoalTS/foal/pull/1031/commits/fffbb910d37d6484c08500c0cf96a6dc61b6ce36