### PR TITLE
[Website] Update landing page based on FoalTS survey 2022

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   title: 'FoalTS',
-  tagline: 'Elegant and complete web framework for NodeJS',
+  tagline: 'Full-featured Node.js framework, with no complexity',
   url: 'https://foalts.org',
   baseUrl: '/',
   onBrokenLinks: 'throw',

--- a/docs/src/pages/index.jsx
+++ b/docs/src/pages/index.jsx
@@ -40,11 +40,11 @@ function Home() {
   const context = useDocusaurusContext();
   return (
     <Layout  
-      description="Elegant and complete Node.Js web framework based on TypeScript.">
+      description="Full-featured Node.js framework, with no complexity">
         <header className={styles.masthead}>
           <div className={styles.content}>
-            <h1>The elegant NodeJS framework</h1>
-            <h3>Build prototypes in hours, full applications in days.</h3>
+            <h1>Full-featured Node.js framework</h1>
+            <h3>Simple and easy to use - TypeScript-based - Well-documented</h3>
             <div>
               <Link
                 className={styles.btn}

--- a/docs/src/pages/index.jsx
+++ b/docs/src/pages/index.jsx
@@ -44,7 +44,13 @@ function Home() {
         <header className={styles.masthead}>
           <div className={styles.content}>
             <h1>Full-featured Node.js framework</h1>
-            <h3>Simple and easy to use - TypeScript-based - Well-documented</h3>
+            <h3>
+              <span>Simple and easy to use</span>
+              <span> - </span>
+              <span>TypeScript-based</span>
+              <span> - </span>
+              <span>Well-documented</span>
+            </h3>
             <div>
               <Link
                 className={styles.btn}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foal-srcs",
-  "description": "Elegant and complete Node.Js web framework based on TypeScript.",
+  "description": "Full-featured Node.js framework, with no complexity",
   "directories": {
     "doc": "docs"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@foal/core",
   "version": "2.9.0",
-  "description": "Elegant and complete Node.Js web framework based on TypeScript",
+  "description": "Full-featured Node.js framework, with no complexity",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "scripts": {


### PR DESCRIPTION
# Issue

FoalTS survey 2022 (which I am still reviewing) has highlighted some points that a majority of users like. The website should show these points at the beginning of the landing page.

# Solution and steps

- [x] Update the title and subtitle of the page.
- [x] Make it pretty on small screens.

