### PR TITLE
[Docs] correct grammar `administrators-and-roles` doc

### DIFF
--- a/docs/docs/authentication-and-access-control/administrators-and-roles.md
+++ b/docs/docs/authentication-and-access-control/administrators-and-roles.md
@@ -63,7 +63,7 @@ export class ApiController {
 
 ### Static Roles
 
-If it exists more than two categories and/or a user can belong to several categories then defining a `roles` property can also be a solution.
+If there exists more than two categories and/or a user can belong to several categories then defining a `roles` property can also be a solution.
 
 *entities/user.entity.ts*
 ```typescript


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue
grammar was incorrect and created slight confusion

# Solution and steps
corrected the grammar

# Checklist

- [ *] Add/update/check docs (code comments and docs/ folder).
- [ *] Add/update/check tests.
- [ *] Update/check the cli generators.
