### PR TITLE
[Cleanup] Move http request read from `@JWT` and `@UseSessions` into separate functions

### DIFF
--- a/packages/core/src/sessions/http/get-session-id-from-request.spec.ts
+++ b/packages/core/src/sessions/http/get-session-id-from-request.spec.ts
@@ -1,0 +1,136 @@
+import { strictEqual, throws } from 'assert';
+import { Config, Context } from '../../core';
+import { SESSION_DEFAULT_COOKIE_NAME } from '../constants';
+import { getSessionIdFromRequest, RequestValidationError } from './get-session-id-from-request';
+
+function createEmptyRequest(): Context['request'] {
+  return {
+    get(headerName: string): string|undefined {
+      return;
+    },
+    cookies: {},
+  } as Context['request'];
+}
+
+function createRequestWithHeader(name: string, value: string): Context['request'] {
+  return {
+    ...createEmptyRequest(),
+    get(headerName: string): string|undefined {
+      if (headerName === name) {
+        return value;
+      }
+    }
+  } as Context['request'];
+}
+
+function createRequestWithCookie(name: string, value: string): Context['request'] {
+  return {
+    ...createEmptyRequest(),
+    cookies: {
+      [name]: value
+    }
+  } as Context['request'];
+}
+
+describe('getSessionIdFromRequest', () => {
+  context('given the location is "token-in-header"', () => {
+    context('given the "required" option is false', () => {
+      it('should return undefined if the request has no "Authorization" header.', () => {
+        const request = createEmptyRequest();
+        const sessionId = getSessionIdFromRequest(request, 'token-in-header', false);
+
+        strictEqual(sessionId, undefined);
+      });
+      it('should throw a RequestValidationError if the request has an "Authorization" header but does NOT use the bearer scheme.', () => {
+        const request = createRequestWithHeader('Authorization', 'Basic 123');
+        const error = () => getSessionIdFromRequest(request, 'token-in-header', false);
+
+        throws(error, new RequestValidationError('Expected a bearer token. Scheme is Authorization: Bearer <token>.'));
+      });
+      it('should return the session ID if it is provided in an "Authorization" header with a bearer scheme.', () => {
+        const request = createRequestWithHeader('Authorization', 'Bearer 123');
+        const sessionId = getSessionIdFromRequest(request, 'token-in-header', false);
+
+        strictEqual(sessionId, '123');
+      });
+    });
+    context('given the "required" option is true', () => {
+      it('should throw a RequestValidationError if the request has no "Authorization" header.', () => {
+        const request = createEmptyRequest();
+        const error = () => getSessionIdFromRequest(request, 'token-in-header', true);
+
+        throws(error, new RequestValidationError('Authorization header not found.'));
+      });
+      it('should throw a RequestValidationError if the request has an "Authorization" header but does NOT use the bearer scheme.', () => {
+        const request = createRequestWithHeader('Authorization', 'Basic 123');
+        const error = () => getSessionIdFromRequest(request, 'token-in-header', true);
+
+        throws(error, new RequestValidationError('Expected a bearer token. Scheme is Authorization: Bearer <token>.'));
+      });
+      it('should return the session ID if it is provided in an "Authorization" header with a bearer scheme.', () => {
+        const request = createRequestWithHeader('Authorization', 'Bearer 123');
+        const sessionId = getSessionIdFromRequest(request, 'token-in-header', true);
+
+        strictEqual(sessionId, '123');
+      });
+    });
+  });
+  context('given the location is "token-in-cookie"', () => {
+    afterEach(() => {
+      Config.remove('settings.session.cookie.name');
+    });
+
+    context('given the "required" option is false', () => {
+      it('should return undefined if the request has no session cookie.', () => {
+        const request = createEmptyRequest();
+        const sessionId = getSessionIdFromRequest(request, 'token-in-cookie', false);
+
+        strictEqual(sessionId, undefined);
+      });
+      it('should return the session ID if it is provided in a session cookie (default cookie name).', () => {
+        const request = createRequestWithCookie(SESSION_DEFAULT_COOKIE_NAME, '123');
+        const sessionId = getSessionIdFromRequest(request, 'token-in-cookie', false);
+
+        strictEqual(sessionId, '123');
+      });
+      it('should return the session ID if it is provided in a session cookie (custom cookie name).', () => {
+        Config.set('settings.session.cookie.name', 'custom-cookie-name');
+
+        const request = createRequestWithCookie('custom-cookie-name', '123');
+        const sessionId = getSessionIdFromRequest(request, 'token-in-cookie', false);
+
+        strictEqual(sessionId, '123');
+      });
+    });
+    context('given the "required" option is true', () => {
+      it('should throw a RequestValidationError if the request has no session cookie.', () => {
+        const request = createEmptyRequest();
+        const error = () => getSessionIdFromRequest(request, 'token-in-cookie', true);
+
+        throws(error, new RequestValidationError('Session cookie not found.'));
+      });
+      it('should return the session ID if it is provided in a session cookie (default cookie name).', () => {
+        const request = createRequestWithCookie(SESSION_DEFAULT_COOKIE_NAME, '123');
+        const sessionId = getSessionIdFromRequest(request, 'token-in-cookie', true);
+
+        strictEqual(sessionId, '123');
+      });
+      it('should return the session ID if it is provided in a session cookie (custom cookie name).', () => {
+        Config.set('settings.session.cookie.name', 'custom-cookie-name');
+
+        const request = createRequestWithCookie('custom-cookie-name', '123');
+        const sessionId = getSessionIdFromRequest(request, 'token-in-cookie', true);
+
+        strictEqual(sessionId, '123');
+      });
+    });
+  });
+  context('given the location is invalid', () => {
+    it('should throw an Error.', () => {
+      const request = createEmptyRequest();
+      const error = () => getSessionIdFromRequest(request, 'invalid' as any, false);
+
+      throws(error, new Error('Invalid location.'));
+    });
+  });
+});

--- a/packages/core/src/sessions/http/get-session-id-from-request.ts
+++ b/packages/core/src/sessions/http/get-session-id-from-request.ts
@@ -1,0 +1,33 @@
+import { Config, Context } from '../../core';
+import { SESSION_DEFAULT_COOKIE_NAME } from '../constants';
+
+export class RequestValidationError extends Error {}
+
+export function getSessionIdFromRequest(request: Context['request'], location: 'token-in-header'|'token-in-cookie', required: boolean): string|undefined {
+  let token: string|undefined;
+
+  switch (location) {
+    case 'token-in-header':
+        const headerContent = request.get('Authorization');
+        if (!headerContent) {
+          if (required) {
+            throw new RequestValidationError('Authorization header not found.');
+          }
+          return;
+        }
+        token = headerContent?.split('Bearer ')[1] as string|undefined;
+        if (!token) {
+          throw new RequestValidationError('Expected a bearer token. Scheme is Authorization: Bearer <token>.');
+        }
+        return token;
+    case 'token-in-cookie':
+      const cookieName = Config.get('settings.session.cookie.name', 'string', SESSION_DEFAULT_COOKIE_NAME);
+      token = request.cookies[cookieName];
+      if (!token && required) {
+        throw new RequestValidationError('Session cookie not found.');
+      }
+      return token;
+    default:
+      throw new Error('Invalid location.');
+  }
+}

--- a/packages/jwt/src/http/get-jwt-from-request.spec.ts
+++ b/packages/jwt/src/http/get-jwt-from-request.spec.ts
@@ -1,0 +1,136 @@
+import { strictEqual, throws } from 'assert';
+import { Config, Context } from '@foal/core';
+import { JWT_DEFAULT_COOKIE_NAME } from '../constants';
+import { getJwtFromRequest, RequestValidationError } from './get-jwt-from-request';
+
+function createEmptyRequest(): Context['request'] {
+  return {
+    get(headerName: string): string|undefined {
+      return;
+    },
+    cookies: {},
+  } as Context['request'];
+}
+
+function createRequestWithHeader(name: string, value: string): Context['request'] {
+  return {
+    ...createEmptyRequest(),
+    get(headerName: string): string|undefined {
+      if (headerName === name) {
+        return value;
+      }
+    }
+  } as Context['request'];
+}
+
+function createRequestWithCookie(name: string, value: string): Context['request'] {
+  return {
+    ...createEmptyRequest(),
+    cookies: {
+      [name]: value
+    }
+  } as Context['request'];
+}
+
+describe('getJwtFromRequest', () => {
+  context('given the location is "token-in-header"', () => {
+    context('given the "required" option is false', () => {
+      it('should return undefined if the request has no "Authorization" header.', () => {
+        const request = createEmptyRequest();
+        const jwt = getJwtFromRequest(request, 'token-in-header', false);
+
+        strictEqual(jwt, undefined);
+      });
+      it('should throw a RequestValidationError if the request has an "Authorization" header but does NOT use the bearer scheme.', () => {
+        const request = createRequestWithHeader('Authorization', 'Basic 123');
+        const error = () => getJwtFromRequest(request, 'token-in-header', false);
+
+        throws(error, new RequestValidationError('Expected a bearer token. Scheme is Authorization: Bearer <token>.'));
+      });
+      it('should return the JWT if it is provided in an "Authorization" header with a bearer scheme.', () => {
+        const request = createRequestWithHeader('Authorization', 'Bearer 123');
+        const jwt = getJwtFromRequest(request, 'token-in-header', false);
+
+        strictEqual(jwt, '123');
+      });
+    });
+    context('given the "required" option is true', () => {
+      it('should throw a RequestValidationError if the request has no "Authorization" header.', () => {
+        const request = createEmptyRequest();
+        const error = () => getJwtFromRequest(request, 'token-in-header', true);
+
+        throws(error, new RequestValidationError('Authorization header not found.'));
+      });
+      it('should throw a RequestValidationError if the request has an "Authorization" header but does NOT use the bearer scheme.', () => {
+        const request = createRequestWithHeader('Authorization', 'Basic 123');
+        const error = () => getJwtFromRequest(request, 'token-in-header', true);
+
+        throws(error, new RequestValidationError('Expected a bearer token. Scheme is Authorization: Bearer <token>.'));
+      });
+      it('should return the JWT if it is provided in an "Authorization" header with a bearer scheme.', () => {
+        const request = createRequestWithHeader('Authorization', 'Bearer 123');
+        const jwt = getJwtFromRequest(request, 'token-in-header', true);
+
+        strictEqual(jwt, '123');
+      });
+    });
+  });
+  context('given the location is "token-in-cookie"', () => {
+    afterEach(() => {
+      Config.remove('settings.jwt.cookie.name');
+    });
+
+    context('given the "required" option is false', () => {
+      it('should return undefined if the request has no session cookie.', () => {
+        const request = createEmptyRequest();
+        const jwt = getJwtFromRequest(request, 'token-in-cookie', false);
+
+        strictEqual(jwt, undefined);
+      });
+      it('should return the JWT if it is provided in a session cookie (default cookie name).', () => {
+        const request = createRequestWithCookie(JWT_DEFAULT_COOKIE_NAME, '123');
+        const jwt = getJwtFromRequest(request, 'token-in-cookie', false);
+
+        strictEqual(jwt, '123');
+      });
+      it('should return the JWT if it is provided in a session cookie (custom cookie name).', () => {
+        Config.set('settings.jwt.cookie.name', 'custom-cookie-name');
+
+        const request = createRequestWithCookie('custom-cookie-name', '123');
+        const jwt = getJwtFromRequest(request, 'token-in-cookie', false);
+
+        strictEqual(jwt, '123');
+      });
+    });
+    context('given the "required" option is true', () => {
+      it('should throw a RequestValidationError if the request has no session cookie.', () => {
+        const request = createEmptyRequest();
+        const error = () => getJwtFromRequest(request, 'token-in-cookie', true);
+
+        throws(error, new RequestValidationError('Auth cookie not found.'));
+      });
+      it('should return the JWT if it is provided in a session cookie (default cookie name).', () => {
+        const request = createRequestWithCookie(JWT_DEFAULT_COOKIE_NAME, '123');
+        const jwt = getJwtFromRequest(request, 'token-in-cookie', true);
+
+        strictEqual(jwt, '123');
+      });
+      it('should return the JWT if it is provided in a session cookie (custom cookie name).', () => {
+        Config.set('settings.jwt.cookie.name', 'custom-cookie-name');
+
+        const request = createRequestWithCookie('custom-cookie-name', '123');
+        const jwt = getJwtFromRequest(request, 'token-in-cookie', true);
+
+        strictEqual(jwt, '123');
+      });
+    });
+  });
+  context('given the location is invalid', () => {
+    it('should throw an Error.', () => {
+      const request = createEmptyRequest();
+      const error = () => getJwtFromRequest(request, 'invalid' as any, false);
+
+      throws(error, new Error('Invalid location.'));
+    });
+  });
+});

--- a/packages/jwt/src/http/get-jwt-from-request.ts
+++ b/packages/jwt/src/http/get-jwt-from-request.ts
@@ -1,0 +1,34 @@
+import { Config, Context } from '@foal/core';
+
+import { JWT_DEFAULT_COOKIE_NAME } from '../constants';
+
+export class RequestValidationError extends Error {}
+
+export function getJwtFromRequest(request: Context['request'], location: 'token-in-header'|'token-in-cookie', required: boolean): string|undefined {
+  let token: string|undefined;
+
+  switch (location) {
+    case 'token-in-header':
+        const headerContent = request.get('Authorization');
+        if (!headerContent) {
+          if (required) {
+            throw new RequestValidationError('Authorization header not found.');
+          }
+          return;
+        }
+        token = headerContent?.split('Bearer ')[1] as string|undefined;
+        if (!token) {
+          throw new RequestValidationError('Expected a bearer token. Scheme is Authorization: Bearer <token>.');
+        }
+        return token;
+    case 'token-in-cookie':
+      const cookieName = Config.get('settings.jwt.cookie.name', 'string', JWT_DEFAULT_COOKIE_NAME);
+      token = request.cookies[cookieName];
+      if (!token && required) {
+        throw new RequestValidationError('Auth cookie not found.');
+      }
+      return token;
+    default:
+      throw new Error('Invalid location.');
+  }
+}

--- a/packages/jwt/src/jwt.hook.ts
+++ b/packages/jwt/src/jwt.hook.ts
@@ -20,6 +20,7 @@ import { decode, verify } from 'jsonwebtoken';
 // FoalTS
 import { JWT_DEFAULT_COOKIE_NAME, JWT_DEFAULT_CSRF_COOKIE_NAME } from './constants';
 import { getSecretOrPublicKey } from './get-secret-or-public-key.util';
+import { getJwtFromRequest, RequestValidationError } from './http/get-jwt-from-request';
 import { isInvalidTokenError } from './invalid-token.error';
 
 class InvalidTokenResponse extends HttpResponseUnauthorized {
@@ -88,35 +89,20 @@ export interface VerifyOptions {
  */
 export function JWT(required: boolean, options: JWTOptions, verifyOptions: VerifyOptions): HookDecorator {
   async function hook(ctx: Context, services: ServiceManager) {
-    let token: string;
-    if (options.cookie) {
-      const cookieName = Config.get('settings.jwt.cookie.name', 'string', JWT_DEFAULT_COOKIE_NAME);
-      const content = ctx.request.cookies[cookieName] as string|undefined;
+    let token: string|undefined;
 
-      if (!content) {
-        if (!required) {
-          return;
-        }
-        return new InvalidRequestResponse('Auth cookie not found.');
+    try {
+      token = getJwtFromRequest(ctx.request, options.cookie ? 'token-in-cookie' : 'token-in-header', required);
+    } catch (error) {
+      if (error instanceof RequestValidationError) {
+        return new InvalidRequestResponse(error.message);
       }
+      // TODO: test this.
+      throw error;
+    }
 
-      token = content;
-    } else {
-      const authorizationHeader = ctx.request.get('Authorization') || '';
-
-      if (!authorizationHeader) {
-        if (!required) {
-          return;
-        }
-        return new InvalidRequestResponse('Authorization header not found.');
-      }
-
-      const content = authorizationHeader.split('Bearer ')[1] as string|undefined;
-      if (!content) {
-        return new InvalidRequestResponse('Expected a bearer token. Scheme is Authorization: Bearer <token>.');
-      }
-
-      token = content;
+    if (!token) {
+      return;
     }
 
     if (options.blackList && await options.blackList(token)) {


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

`@JWT` and `@UseSessions` are big functions with a lot of tests. It is hard to add new features to them without providing a lot of work.

# Solution and steps

- [x] Move http request read from `@JWT` and `@UseSessions` into separate functions

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
