### PR TITLE
Add `User.findOneWithPermissionsBy`

### DIFF
--- a/packages/typeorm/src/entities/user-with-permissions.entity.ts
+++ b/packages/typeorm/src/entities/user-with-permissions.entity.ts
@@ -50,6 +50,22 @@ export abstract class UserWithPermissions extends BaseEntity {
       .getMany();
   }
 
+  static async findOneWithPermissionsBy<T extends UserWithPermissions>(this: (new () => T) & typeof BaseEntity, { id }: { id: number }): Promise<T|null> {
+    return (await this
+      .getRepository<UserWithPermissions>()
+      .findOne(
+        {
+          where: { id },
+          relations: {
+            userPermissions: true,
+            groups: {
+              permissions: true,
+            }
+          }
+        }
+      )) as T|null;
+  }
+
   @PrimaryGeneratedColumn()
   id: number;
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

The `fetchUserWithPermissions` function will be removed. We need a quick function to replace it.

# Solution and steps

- [x] Add `User.findOneWithPermissionsBy`

# New features

- `User.findOneWithPermissionsBy` has been added.

# Checklist

- [ ] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
