### PR TITLE
Adds @foal/cli to package.json templates

### DIFF
--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -35,6 +35,7 @@
     "typeorm": "0.2.26"
   },
   "devDependencies": {
+    "@foal/cli": "^2.9.0",
     "@types/mocha": "7.0.2",
     "@types/node": "10.17.24",
     "concurrently": "~5.3.0",

--- a/packages/cli/src/generate/specs/app/package.mongodb.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.json
@@ -30,6 +30,7 @@
     "typeorm": "0.2.26"
   },
   "devDependencies": {
+    "@foal/cli": "^2.9.0",
     "@types/mocha": "7.0.2",
     "@types/node": "10.17.24",
     "concurrently": "~5.3.0",

--- a/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
@@ -31,6 +31,7 @@
     "yamljs": "~0.3.0"
   },
   "devDependencies": {
+    "@foal/cli": "^2.9.0",
     "@types/mocha": "7.0.2",
     "@types/node": "10.17.24",
     "concurrently": "~5.3.0",

--- a/packages/cli/src/generate/specs/app/package.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.yaml.json
@@ -36,6 +36,7 @@
     "yamljs": "~0.3.0"
   },
   "devDependencies": {
+    "@foal/cli": "^2.9.0",
     "@types/mocha": "7.0.2",
     "@types/node": "10.17.24",
     "concurrently": "~5.3.0",

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -35,6 +35,7 @@
     "typeorm": "0.2.26"
   },
   "devDependencies": {
+    "@foal/cli": "^2.9.0",
     "@types/mocha": "7.0.2",
     "@types/node": "10.17.24",
     "concurrently": "~5.3.0",

--- a/packages/cli/src/generate/templates/app/package.mongodb.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.json
@@ -30,6 +30,7 @@
     "typeorm": "0.2.26"
   },
   "devDependencies": {
+    "@foal/cli": "^2.9.0",
     "@types/mocha": "7.0.2",
     "@types/node": "10.17.24",
     "concurrently": "~5.3.0",

--- a/packages/cli/src/generate/templates/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.yaml.json
@@ -31,6 +31,7 @@
     "yamljs": "~0.3.0"
   },
   "devDependencies": {
+    "@foal/cli": "^2.9.0",
     "@types/mocha": "7.0.2",
     "@types/node": "10.17.24",
     "concurrently": "~5.3.0",

--- a/packages/cli/src/generate/templates/app/package.yaml.json
+++ b/packages/cli/src/generate/templates/app/package.yaml.json
@@ -36,6 +36,7 @@
     "yamljs": "~0.3.0"
   },
   "devDependencies": {
+    "@foal/cli": "^2.9.0",
     "@types/mocha": "7.0.2",
     "@types/node": "10.17.24",
     "concurrently": "~5.3.0",


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

- When running the npm run build command locally, the foal binary is found because we have previously installed it globally using npm install -g @foal/cli . So the command works.

- But when deploying to a PaaS provider (such a Heroku), the command fails because the CLI has not been installed globally. Only dependencies specified in package.json are installed.


# Solution and steps
Added the @foal/cli of version 2.9.0 to the package.json templates in the folders:
- <ROOT>\packages\cli\src\generate\templates\app
- <ROOT>\packages\cli\src\generate\specs\app

To test this, set up the environment as stated in the Contributing Guidelines. You don't have to setup the Database, so skip the docker-start command.

1. After setup, go to the folder "packages\cli\lib"
2. run the following command:
`node index.js createapp -G -I testApp`
3. go into the new folder "testApp":
`cd ./testApp`
4. Check the generated package.json. There now is the @foal/cli

# Checklist

- [?] Add/update/check docs (code comments and docs/ folder).
No need to update the docs.
- [x] Add/update/check tests.
Test ran successfully
- [x] Update/check the cli generators.
Generation checked using the index.js file inside the "packages\cli\lib" folder.
