### PR TITLE
Do not let "undefined" values override other config values

### DIFF
--- a/packages/core/src/core/config/config.spec.ts
+++ b/packages/core/src/core/config/config.spec.ts
@@ -224,6 +224,13 @@ describe('Config', () => {
           strictEqual(Config.get('a.b.c'), 2);
         });
 
+        it('and explicit undefined values should not override other defined values.', () => {
+          writeFileSync('config/default.js', 'module.exports = { a: "foobar" }');
+          writeFileSync('config/development.js', 'module.exports = { a: undefined }');
+
+          strictEqual(Config.get('a'), 'foobar');
+        })
+
       });
 
       it('should not delete configuration values (deep merge).', () => {

--- a/packages/core/src/core/config/config.ts
+++ b/packages/core/src/core/config/config.ts
@@ -216,7 +216,7 @@ export class Config {
     for (const key in source) {
       if (isObject(target[key]) && isObject(source[key])) {
         this.mergeDeep(target[key], source[key]);
-      } else {
+      } else if (source[key] !== undefined) {
         target[key] = source[key];
       }
     }


### PR DESCRIPTION
# Issue

Resolves #1071

# Solution and steps

- [x] Add an `undefined` check.

# Breaking changes

`undefined` values do not override other defined config values anymore.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
