### PR TITLE
[CLI] Remove use of `http` module from app bootstrap

### DIFF
--- a/docs/docs/cookbook/limit-repeated-requests.md
+++ b/docs/docs/cookbook/limit-repeated-requests.md
@@ -14,9 +14,6 @@ npm install express express-rate-limit
 
 *src/index.ts*
 ```typescript
-// std
-import * as http from 'http';
-
 // 3p
 import { Config, createApp, displayServerURL } from '@foal/core';
 import * as express from 'express';
@@ -46,10 +43,9 @@ async function main() {
   }));
     
   const app = await createApp(AppController, { expressInstance: expressApp });
-    
-  const httpServer = http.createServer(app);
+
   const port = Config.get('port', 'number', 3001);
-  httpServer.listen(port, () => displayServerURL(port));
+  app.listen(port, () => displayServerURL(port));
 }
 
 main()

--- a/docs/docs/websockets.md
+++ b/docs/docs/websockets.md
@@ -46,16 +46,17 @@ export class WebsocketController extends SocketIOController {
 ```typescript
 // ...
 
+import * as http from 'http';
+
 async function main() {
   const serviceManager = new ServiceManager();
 
   const app = await createApp(AppController, { serviceManager });
-  const httpServer = http.createServer(app);
 
+  const httpServer = http.createServer(app);
   // Instanciate, init and connect websocket controllers.
   await serviceManager.get(WebsocketController).attachHttpServer(httpServer);
-
-  // ...
+  httpServer.listen(port, () => displayServerURL(port));
 }
 
 ```

--- a/packages/acceptance-tests/src/docs/cookbook/limit-repeated-requests.spec.ts
+++ b/packages/acceptance-tests/src/docs/cookbook/limit-repeated-requests.spec.ts
@@ -1,6 +1,3 @@
-// std
-import * as http from 'http';
-
 // 3p
 import { Config, createApp, displayServerURL } from '@foal/core';
 import * as express from 'express';
@@ -33,8 +30,7 @@ it('[Docs] Cookbook > Limit Repeated Requests', () => {
 
     const app = await createApp(AppController, { expressInstance: expressApp });
 
-    const httpServer = http.createServer(app);
     const port = Config.get('port', 'number', 3001);
-    httpServer.listen(port, () => displayServerURL(port));
+    app.listen(port, () => displayServerURL(port));
   }
 });

--- a/packages/cli/src/generate/specs/app/src/index.ts
+++ b/packages/cli/src/generate/specs/app/src/index.ts
@@ -1,8 +1,5 @@
 import 'source-map-support/register';
 
-// std
-import * as http from 'http';
-
 // 3p
 import { Config, createApp, displayServerURL } from '@foal/core';
 
@@ -12,9 +9,8 @@ import { AppController } from './app/app.controller';
 async function main() {
   const app = await createApp(AppController);
 
-  const httpServer = http.createServer(app);
   const port = Config.get('port', 'number', 3001);
-  httpServer.listen(port, () => displayServerURL(port));
+  app.listen(port, () => displayServerURL(port));
 }
 
 main()

--- a/packages/cli/src/generate/templates/app/src/index.ts
+++ b/packages/cli/src/generate/templates/app/src/index.ts
@@ -1,8 +1,5 @@
 import 'source-map-support/register';
 
-// std
-import * as http from 'http';
-
 // 3p
 import { Config, createApp, displayServerURL } from '@foal/core';
 
@@ -12,9 +9,8 @@ import { AppController } from './app/app.controller';
 async function main() {
   const app = await createApp(AppController);
 
-  const httpServer = http.createServer(app);
   const port = Config.get('port', 'number', 3001);
-  httpServer.listen(port, () => displayServerURL(port));
+  app.listen(port, () => displayServerURL(port));
 }
 
 main()

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -6,9 +6,6 @@
 
 import 'source-map-support/register';
 
-// std
-import * as http from 'http';
-
 // 3p
 import { Config, createApp, displayServerURL } from '@foal/core';
 import { createConnection } from '@foal/typeorm/node_modules/typeorm';
@@ -21,9 +18,8 @@ async function main() {
 
   const app = await createApp(AppController);
 
-  const httpServer = http.createServer(app);
   const port = Config.get('port', 'number', 3001);
-  httpServer.listen(port, () => displayServerURL(port));
+  app.listen(port, () => displayServerURL(port));
 }
 
 main()


### PR DESCRIPTION
# Issue

In `src/index.ts`, we use the `http.createServer` method. This makes noise and is not necessary. This can be simplified by simply calling `app.listen`

# Solution and steps

- [x] Remove the use of the `http` module.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
