### PR TITLE
Rename "npm run develop" to "npm run dev"

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ First install [Node.Js and npm](https://nodejs.org/en/download/).
 $ npm install -g @foal/cli
 $ foal createapp my-app
 $ cd my-app
-$ npm run develop
+$ npm run dev
 ```
 
 The development server is started! Go to `http://localhost:3001` and find our welcoming page!

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -43,7 +43,7 @@ Great attention is paid to the stability of the product. You can find out more b
 > npm install -g @foal/cli
 > foal createapp my-app
 > cd my-app
-> npm run develop
+> npm run dev
 ```
 
 The development server is started! Go to `http://localhost:3001` and find our welcoming page!

--- a/docs/docs/api-section/gRPC.md
+++ b/docs/docs/api-section/gRPC.md
@@ -20,7 +20,7 @@ Then update your `package.json` so that your build scripts will correctly copy y
 ```json
 {
   "build": "foal rmdir build && cpx \"src/**/*.proto\" build && tsc -p tsconfig.app.json",
-  "develop": "npm run build && concurrently \"cpx \\\"src/**/*.proto\\\" build -w\" \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml,proto --no-restart-on error ./build/index.js\"",
+  "dev": "npm run build && concurrently \"cpx \\\"src/**/*.proto\\\" build -w\" \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml,proto --no-restart-on error ./build/index.js\"",
   "build:test": "foal rmdir build && cpx \"src/**/*.proto\" build && tsc -p tsconfig.test.json",
   "test": "npm run build:test && concurrently \"cpx \\\"src/**/*.proto\\\" build -w\" \"tsc -p tsconfig.test.json -w\" \"mocha --file ./build/test.js -w --watch-files build \\\"./build/**/*.spec.js\\\"\"",
   "build:e2e": "foal rmdir build && cpx \"src/**/*.proto\" build && tsc -p tsconfig.e2e.json",

--- a/docs/docs/api-section/graphql.md
+++ b/docs/docs/api-section/graphql.md
@@ -171,7 +171,7 @@ npm install cpx2  --save-dev
 {
   "scripts": {
     "build": "foal rmdir build && cpx \"src/**/*.graphql\" build && tsc -p tsconfig.app.json",
-    "develop": "npm run build && concurrently \"cpx \\\"src/**/*.graphql\\\" build -w\" \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml,graphql --no-restart-on error ./build/index.js\"",
+    "dev": "npm run build && concurrently \"cpx \\\"src/**/*.graphql\\\" build -w\" \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml,graphql --no-restart-on error ./build/index.js\"",
     "build:test": "foal rmdir build && cpx \"src/**/*.graphql\" build && tsc -p tsconfig.test.json",
     "test": "npm run build:test && concurrently \"cpx \\\"src/**/*.graphql\\\" build -w\" \"tsc -p tsconfig.test.json -w\" \"mocha --file ./build/test.js -w --watch-files build \\\"./build/**/*.spec.js\\\"\"",
     "build:e2e": "foal rmdir build && cpx \"src/**/*.graphql\" build && tsc -p tsconfig.e2e.json",

--- a/docs/docs/development-environment/build-and-start-the-app.md
+++ b/docs/docs/development-environment/build-and-start-the-app.md
@@ -8,6 +8,6 @@ FoalTS provides several commands to help you build and develop your app.
 
 | Command | Description |
 | --- | --- |
-| `npm run develop` | Build the source code and start the server. If a file changes then the code is rebuilt and the server reloads. This is usually **the only command that you need during development** |
+| `npm run dev` | Build the source code and start the server. If a file changes then the code is rebuilt and the server reloads. This is usually **the only command that you need during development** |
 | `npm run build` | Build the app code located in the `src/` directory (test files are ignored). |
 | `npm run start` | Start the server from the built files. |

--- a/docs/docs/development-environment/create-and-run-scripts.md
+++ b/docs/docs/development-environment/create-and-run-scripts.md
@@ -61,4 +61,4 @@ foal run my-script # or foal run-script my-script
 
 > You can also provide additionnal arguments to your script (for example: `foal run my-script foo=1 bar='[ 3, 4 ]'`). The default template in the generated scripts shows you how to handle such behavior.
 
-> If you want your script to recompile each time you save the file, you can run `npm run develop` in a separate terminal.
+> If you want your script to recompile each time you save the file, you can run `npm run dev` in a separate terminal.

--- a/docs/docs/tutorials/real-world-example-with-react/1-introduction.md
+++ b/docs/docs/tutorials/real-world-example-with-react/1-introduction.md
@@ -55,7 +55,7 @@ Then start the development server.
 
 ```bash
 cd backend-app
-npm run develop
+npm run dev
 ```
 
 Go to [http://localhost:3001](http://localhost:3001) in your browser. You should see the *Welcome on board* message.

--- a/docs/docs/tutorials/real-world-example-with-react/14-production-build.md
+++ b/docs/docs/tutorials/real-world-example-with-react/14-production-build.md
@@ -61,7 +61,7 @@ If you return to [http://localhost:3001/login](http://localhost:3001/login) and 
 
 ## Building the Foal app
 
-Now, if you want to build the backend application so that you don't use the `npm run develop` option, you can run this command:
+Now, if you want to build the backend application so that you don't use the `npm run dev` option, you can run this command:
 
 ```bash
 npm run build

--- a/docs/docs/tutorials/simple-todo-list/1-installation.md
+++ b/docs/docs/tutorials/simple-todo-list/1-installation.md
@@ -68,7 +68,7 @@ Let's verify that the FoalTS project works. Run the following commands:
 
 ```
 cd my-app
-npm run develop
+npm run dev
 ```
 
 You've started the development server.

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -211,7 +211,7 @@ export async function createApp({ name, autoInstall, initRepo, mongodb = false, 
   if (!autoInstall) {
     logCommand('npm install');
   }
-  logCommand('npm run develop');
+  logCommand('npm run dev');
 
   log();
 }

--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "foal rmdir build && tsc -p tsconfig.app.json",
     "start": "node ./build/index.js",
-    "develop": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
+    "dev": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
     "build:test": "foal rmdir build && tsc -p tsconfig.test.json",
     "start:test": "mocha --file ./build/test.js \"./build/**/*.spec.js\"",
     "test": "npm run build:test && concurrently -r \"tsc -p tsconfig.test.json -w\" \"mocha --file ./build/test.js -w \\\"./build/**/*.spec.js\\\"\"",

--- a/packages/cli/src/generate/specs/app/package.mongodb.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "foal rmdir build && tsc -p tsconfig.app.json",
     "start": "node ./build/index.js",
-    "develop": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
+    "dev": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
     "build:test": "foal rmdir build && tsc -p tsconfig.test.json",
     "start:test": "mocha --file ./build/test.js \"./build/**/*.spec.js\"",
     "test": "npm run build:test && concurrently -r \"tsc -p tsconfig.test.json -w\" \"mocha --file ./build/test.js -w \\\"./build/**/*.spec.js\\\"\"",

--- a/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "foal rmdir build && tsc -p tsconfig.app.json",
     "start": "node ./build/index.js",
-    "develop": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
+    "dev": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
     "build:test": "foal rmdir build && tsc -p tsconfig.test.json",
     "start:test": "mocha --file ./build/test.js \"./build/**/*.spec.js\"",
     "test": "npm run build:test && concurrently -r \"tsc -p tsconfig.test.json -w\" \"mocha --file ./build/test.js -w \\\"./build/**/*.spec.js\\\"\"",

--- a/packages/cli/src/generate/specs/app/package.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.yaml.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "foal rmdir build && tsc -p tsconfig.app.json",
     "start": "node ./build/index.js",
-    "develop": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
+    "dev": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
     "build:test": "foal rmdir build && tsc -p tsconfig.test.json",
     "start:test": "mocha --file ./build/test.js \"./build/**/*.spec.js\"",
     "test": "npm run build:test && concurrently -r \"tsc -p tsconfig.test.json -w\" \"mocha --file ./build/test.js -w \\\"./build/**/*.spec.js\\\"\"",

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "foal rmdir build && tsc -p tsconfig.app.json",
     "start": "node ./build/index.js",
-    "develop": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
+    "dev": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
     "build:test": "foal rmdir build && tsc -p tsconfig.test.json",
     "start:test": "mocha --file ./build/test.js \"./build/**/*.spec.js\"",
     "test": "npm run build:test && concurrently -r \"tsc -p tsconfig.test.json -w\" \"mocha --file ./build/test.js -w \\\"./build/**/*.spec.js\\\"\"",

--- a/packages/cli/src/generate/templates/app/package.mongodb.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "foal rmdir build && tsc -p tsconfig.app.json",
     "start": "node ./build/index.js",
-    "develop": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
+    "dev": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
     "build:test": "foal rmdir build && tsc -p tsconfig.test.json",
     "start:test": "mocha --file ./build/test.js \"./build/**/*.spec.js\"",
     "test": "npm run build:test && concurrently -r \"tsc -p tsconfig.test.json -w\" \"mocha --file ./build/test.js -w \\\"./build/**/*.spec.js\\\"\"",

--- a/packages/cli/src/generate/templates/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.yaml.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "foal rmdir build && tsc -p tsconfig.app.json",
     "start": "node ./build/index.js",
-    "develop": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
+    "dev": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
     "build:test": "foal rmdir build && tsc -p tsconfig.test.json",
     "start:test": "mocha --file ./build/test.js \"./build/**/*.spec.js\"",
     "test": "npm run build:test && concurrently -r \"tsc -p tsconfig.test.json -w\" \"mocha --file ./build/test.js -w \\\"./build/**/*.spec.js\\\"\"",

--- a/packages/cli/src/generate/templates/app/package.yaml.json
+++ b/packages/cli/src/generate/templates/app/package.yaml.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "foal rmdir build && tsc -p tsconfig.app.json",
     "start": "node ./build/index.js",
-    "develop": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
+    "dev": "npm run build && concurrently -r \"tsc -p tsconfig.app.json -w\" \"supervisor -w ./build,./config -e js,json,yml --no-restart-on error ./build/index.js\"",
     "build:test": "foal rmdir build && tsc -p tsconfig.test.json",
     "start:test": "mocha --file ./build/test.js \"./build/**/*.spec.js\"",
     "test": "npm run build:test && concurrently -r \"tsc -p tsconfig.test.json -w\" \"mocha --file ./build/test.js -w \\\"./build/**/*.spec.js\\\"\"",

--- a/packages/cli/src/run-script/run-script.spec.ts
+++ b/packages/cli/src/run-script/run-script.spec.ts
@@ -43,7 +43,7 @@ describe('runScript', () => {
     strictEqual(
       msg,
       'The script "my-script" does not exist in build/scripts/. But it exists in src/scripts/.'
-        + ' Please build your script by running the command "npm run build" or using "npm run develop".'
+        + ' Please build your script by running the command "npm run build" or using "npm run dev".'
     );
   });
 

--- a/packages/cli/src/run-script/run-script.ts
+++ b/packages/cli/src/run-script/run-script.ts
@@ -13,7 +13,7 @@ export async function runScript({ name }: { name: string }, argv: string[], log 
     if (existsSync(`src/scripts/${name}.ts`)) {
       log(
         `The script "${name}" does not exist in build/scripts/. But it exists in src/scripts/.`
-          + ' Please build your script by running the command "npm run build" or using "npm run develop".'
+          + ' Please build your script by running the command "npm run build" or using "npm run dev".'
       );
     } else {
       log(`The script "${name}" does not exist. You can create it by running the command "foal g script ${name}".`);

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -8,7 +8,7 @@
     "build:w": "tsc -w",
     "start": "node ./build/index.js",
     "start:w": "supervisor -w ./build --no-restart-on error ./build/index.js",
-    "develop": "npm run build && concurrently \"npm run build:w\" \"npm run start:w\"",
+    "dev": "npm run build && concurrently \"npm run build:w\" \"npm run start:w\"",
     "build:test": "tsc && copy-cli \"src/**/*.html\" build",
     "build:test:w": "tsc -w",
     "start:test": "mocha \"./build/**/*.spec.js\"",


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Small improvement whose goals are:
- smaller command
- be consistent with the command of other frameworks

# Solution and steps

- [x] Update all occurrences of `develop` to `dev`

# Breaking changes

The command `npm run develop` has been renamed to `npm run dev`
 
# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
