### PR TITLE
Add default `Content-Type` header in `Disk.createHttpResponse` responses

### DIFF
--- a/packages/storage/src/disk.service.spec.ts
+++ b/packages/storage/src/disk.service.spec.ts
@@ -121,12 +121,14 @@ describe('AbstractDisk', () => {
       });
 
       it('should have a correct Content-Type header based on the file extension.', async () => {
-        let response = await disk.createHttpResponse(path);
+        const response = await disk.createHttpResponse(path);
         strictEqual(response.getHeader('Content-Type'), 'image/png');
-
-        response = await disk.createHttpResponse('test-file');
-        strictEqual(response.getHeader('Content-Type'), undefined);
       });
+
+      it('should have a Content-Type header equal to "application/octet-stream" when the file extension cannot be computed.', async () => {
+        const response = await disk.createHttpResponse('test-file');
+        strictEqual(response.getHeader('Content-Type'), 'application/octet-stream');
+      })
 
       it('should have a correct Content-Length header based on the file size.', async () => {
         const httpResponse = await disk.createHttpResponse(path);

--- a/packages/storage/src/disk.service.ts
+++ b/packages/storage/src/disk.service.ts
@@ -140,16 +140,14 @@ export abstract class Disk {
     const { file, size } = await this.read(path, 'stream');
     const response = new HttpResponseOK(file, { stream: true });
 
-    const mimeType = getType(path);
-    if (mimeType) {
-      response.setHeader('Content-Type', mimeType);
-    }
-
     if (options.cache) {
       response.setHeader('Cache-Control', options.cache);
     }
 
+    const mimeType = getType(path) || 'application/octet-stream';
+
     return response
+      .setHeader('Content-Type', mimeType)
       .setHeader('Content-Length', size.toString())
       .setHeader(
         'Content-Disposition',

--- a/packages/storage/src/local-disk.service.ts
+++ b/packages/storage/src/local-disk.service.ts
@@ -35,7 +35,7 @@ export class LocalDisk extends Disk {
     if (content instanceof Buffer) {
       await promisify(writeFile)(this.getPath(path), content);
     } else {
-      await new Promise((resolve, reject) => {
+      await new Promise<void>((resolve, reject) => {
         pipeline(content, createWriteStream(this.getPath(path)), err => {
           // Note: error streams are unlikely to occur (most "createWriteStream" errors are simply thrown).
           // TODO: test the error case.


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

When downloading a file, some navigators (might) need to always have the `Content-Type` header defined.

# Solution and steps

- Add `application/octet-stream` as default `Content-Type` header.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
