### PR TITLE
[Docs] Do not index v1 documentation on Google

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -127,7 +127,8 @@ module.exports = {
               "label": require('../lerna.json').version + ' (latest)',
             },
             '1.x': {
-              'label': '1.x'
+              'label': '1.x',
+              noIndex: true
             }
           }
         },

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,9 +8,9 @@
       "name": "docs",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "~2.0.1",
-        "@docusaurus/plugin-google-analytics": "~2.0.1",
-        "@docusaurus/preset-classic": "~2.0.1",
+        "@docusaurus/core": "~2.1.0",
+        "@docusaurus/plugin-google-analytics": "~2.1.0",
+        "@docusaurus/preset-classic": "~2.1.0",
         "@mdx-js/react": "~1.6.22",
         "docusaurus-plugin-sass": "0.2.2",
         "react": "~17.0.2",
@@ -1948,30 +1948,41 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.1.1.tgz",
-      "integrity": "sha512-utLgg7E1agqQeqCJn05DWC7XXMk4tMUUnL7MZupcknRu2OzGN13qwey2qA/0NAKkVBGugiWtON0+rlU0QIPojg=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
+      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.1.1.tgz",
-      "integrity": "sha512-cfoql4qvtsVRqBMYxhlGNpvyy/KlCoPqjIsJSZYqYf9AplZncKjLBTcwBu6RXFMVCe30cIFljniI4OjqAU67pQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
+      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
       "dependencies": {
         "@algolia/autocomplete-core": "1.7.1",
         "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.1.1",
+        "@docsearch/css": "3.2.1",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 19.0.0",
         "react": ">= 16.8.0 < 19.0.0",
         "react-dom": ">= 16.8.0 < 19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
       "dependencies": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -1983,13 +1994,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/cssnano-preset": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -2057,9 +2068,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
-      "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
+      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -2071,9 +2082,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.1.tgz",
-      "integrity": "sha512-wIWseCKko1w/WARcDjO3N/XoJ0q/VE42AthP0eNAfEazDjJ94NXbaI6wuUsuY/bMg6hTKGVIpphjj2LoX3g6dA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
+      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
@@ -2083,14 +2094,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.1.tgz",
-      "integrity": "sha512-tdNeljdilXCmhbaEND3SAgsqaw/oh7v9onT5yrIrL26OSk2AFwd+MIi4R8jt8vq33M0R4rz2wpknm0fQIkDdvQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
+      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
       "dependencies": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2114,12 +2125,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.1.tgz",
-      "integrity": "sha512-f888ylnxHAM/3T8p1lx08+lTc6/g7AweSRfRuZvrVhHXj3Tz/nTTxaP6gPTGkJK7WLqTagpar/IGP6/74IBbkg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
+      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.0.1",
+        "@docusaurus/types": "2.1.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2133,17 +2144,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.1.tgz",
-      "integrity": "sha512-/4ua3iFYcpwgpeYgHnhVGROB/ybnauLH2+rICb4vz/+Gn1hjAmGXVYq1fk8g49zGs3uxx5nc0H5bL9P0g977IQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
+      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -2163,17 +2174,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.1.tgz",
-      "integrity": "sha512-2qeBWRy1EjgnXdwAO6/csDIS1UVNmhmtk/bQ2s9jqjpwM8YVgZ8QVdkxFAMWXgZWDQdwWwdP1rnmoEelE4HknQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
+      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/module-type-aliases": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/module-type-aliases": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -2193,15 +2204,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.1.tgz",
-      "integrity": "sha512-6apSVeJENnNecAH5cm5VnRqR103M6qSI6IuiP7tVfD5H4AWrfDNkvJQV2+R2PIq3bGrwmX4fcXl1x4g0oo7iwA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
+      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -2215,13 +2226,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.1.tgz",
-      "integrity": "sha512-jpZBT5HK7SWx1LRQyv9d14i44vSsKXGZsSPA2ndth5HykHJsiAj9Fwl1AtzmtGYuBmI+iXQyOd4MAMHd4ZZ1tg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
+      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -2235,13 +2246,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.1.tgz",
-      "integrity": "sha512-d5qb+ZeQcg1Czoxc+RacETjLdp2sN/TAd7PGN/GrvtijCdgNmvVAtZ9QgajBTG0YbJFVPTeZ39ad2bpoOexX0w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
+      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2253,13 +2264,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.1.tgz",
-      "integrity": "sha512-qiRufJe2FvIyzICbkjm4VbVCI1hyEju/CebfDKkKh2ZtV4q6DM1WZG7D6VoQSXL8MrMFB895gipOM4BwdM8VsQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
+      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2271,16 +2282,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.1.tgz",
-      "integrity": "sha512-KcYuIUIp2JPzUf+Xa7W2BSsjLgN1/0h+VAz7D/C3RYjAgC5ApPX8wO+TECmGfunl/m7WKGUmLabfOon/as64kQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
+      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
@@ -2294,22 +2305,22 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.1.tgz",
-      "integrity": "sha512-nOoniTg46My1qdDlLWeFs55uEmxOJ+9WMF8KKG8KMCu5LAvpemMi7rQd4x8Tw+xiPHZ/sQzH9JmPTMPRE4QGPw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
+      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/plugin-content-blog": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/plugin-content-pages": "2.0.1",
-        "@docusaurus/plugin-debug": "2.0.1",
-        "@docusaurus/plugin-google-analytics": "2.0.1",
-        "@docusaurus/plugin-google-gtag": "2.0.1",
-        "@docusaurus/plugin-sitemap": "2.0.1",
-        "@docusaurus/theme-classic": "2.0.1",
-        "@docusaurus/theme-common": "2.0.1",
-        "@docusaurus/theme-search-algolia": "2.0.1",
-        "@docusaurus/types": "2.0.1"
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/plugin-content-blog": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/plugin-content-pages": "2.1.0",
+        "@docusaurus/plugin-debug": "2.1.0",
+        "@docusaurus/plugin-google-analytics": "2.1.0",
+        "@docusaurus/plugin-google-gtag": "2.1.0",
+        "@docusaurus/plugin-sitemap": "2.1.0",
+        "@docusaurus/theme-classic": "2.1.0",
+        "@docusaurus/theme-common": "2.1.0",
+        "@docusaurus/theme-search-algolia": "2.1.0",
+        "@docusaurus/types": "2.1.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -2332,22 +2343,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.1.tgz",
-      "integrity": "sha512-0jfigiqkUwIuKOw7Me5tqUM9BBvoQX7qqeevx7v4tkYQexPhk3VYSZo7aRuoJ9oyW5makCTPX551PMJzmq7+sw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
+      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/module-type-aliases": "2.0.1",
-        "@docusaurus/plugin-content-blog": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/plugin-content-pages": "2.0.1",
-        "@docusaurus/theme-common": "2.0.1",
-        "@docusaurus/theme-translations": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/module-type-aliases": "2.1.0",
+        "@docusaurus/plugin-content-blog": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/plugin-content-pages": "2.1.0",
+        "@docusaurus/theme-common": "2.1.0",
+        "@docusaurus/theme-translations": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -2371,16 +2382,16 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.1.tgz",
-      "integrity": "sha512-I3b6e/ryiTQMsbES40cP0DRGnfr0E2qghVq+XecyMKjBPejISoSFEDn0MsnbW8Q26k1Dh/0qDH8QKDqaZZgLhA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
+      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/module-type-aliases": "2.0.1",
-        "@docusaurus/plugin-content-blog": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/plugin-content-pages": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/module-type-aliases": "2.1.0",
+        "@docusaurus/plugin-content-blog": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/plugin-content-pages": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2399,18 +2410,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.1.tgz",
-      "integrity": "sha512-cw3NaOSKbYlsY6uNj4PgO+5mwyQ3aEWre5RlmvjStaz2cbD15Nr69VG8Rd/F6Q5VsCT8BvSdkPDdDG5d/ACexg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
+      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
       "dependencies": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/theme-common": "2.0.1",
-        "@docusaurus/theme-translations": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/theme-common": "2.1.0",
+        "@docusaurus/theme-translations": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -2429,9 +2440,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.1.tgz",
-      "integrity": "sha512-v1MYYlbsdX+rtKnXFcIAn9ar0Z6K0yjqnCYS0p/KLCLrfJwfJ8A3oRJw2HiaIb8jQfk1WMY2h5Qi1p4vHOekQw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
+      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
       "dependencies": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
@@ -2441,9 +2452,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.1.tgz",
-      "integrity": "sha512-o+4hAFWkj3sBszVnRTAnNqtAIuIW0bNaYyDwQhQ6bdz3RAPEq9cDKZxMpajsj4z2nRty8XjzhyufAAjxFTyrfg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -2460,11 +2471,11 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.1.tgz",
-      "integrity": "sha512-u2Vdl/eoVwMfUjDCkg7FjxoiwFs/XhVVtNxQEw8cvB+qaw6QWyT73m96VZzWtUb1fDOefHoZ+bZ0ObFeKk9lMQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
+      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
       "dependencies": {
-        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/logger": "2.1.0",
         "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
@@ -2493,9 +2504,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.1.tgz",
-      "integrity": "sha512-kajCCDCXRd1HFH5EUW31MPaQcsyNlGakpkDoTBtBvpa4EIPvWaSKy7TIqYKHrZjX4tnJ0YbEJvaXfjjgdq5xSg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
+      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2512,12 +2523,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.1.tgz",
-      "integrity": "sha512-f14AnwFBy4/1A19zWthK+Ii80YDz+4qt8oPpK3julywXsheSxPBqgsND3LVBBvB2p3rJHvbo2m3HyB9Tco1JRw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
+      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
       "dependencies": {
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -3616,9 +3627,9 @@
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.10.0.tgz",
-      "integrity": "sha512-4E4od8qWWDMVvQ3jaRX6Oks/k35ywD011wAA4LbYMMjOtaZV6VWaTjRr4iN2bdaXP2o1BP7SLFMBf3wvnHmd8Q==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.0.tgz",
+      "integrity": "sha512-TLl/MSjtQ98mgkd8hngWkzSjE+dAWldZ1NpJtv2mT+ZoFJ2P2zDE85oF9WafJOXWN9FbVRmyxpO5H+qXcNaFng==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -5477,9 +5488,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
       "engines": {
         "node": ">=0.12"
       },
@@ -8262,11 +8273,11 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "node_modules/parse5": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
-      "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.0.tgz",
+      "integrity": "sha512-jo4pIv8LVI1IO2QxismoCv/+qZC6V3VSxOHqEQIpm5kDSzJNLNIVUwdStdUnezexjwdZXgYkxP5nanlZgfcCHg==",
       "dependencies": {
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -9027,9 +9038,9 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
-      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
       "engines": {
         "node": ">=6"
       }
@@ -13780,25 +13791,25 @@
       "optional": true
     },
     "@docsearch/css": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.1.1.tgz",
-      "integrity": "sha512-utLgg7E1agqQeqCJn05DWC7XXMk4tMUUnL7MZupcknRu2OzGN13qwey2qA/0NAKkVBGugiWtON0+rlU0QIPojg=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
+      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
     },
     "@docsearch/react": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.1.1.tgz",
-      "integrity": "sha512-cfoql4qvtsVRqBMYxhlGNpvyy/KlCoPqjIsJSZYqYf9AplZncKjLBTcwBu6RXFMVCe30cIFljniI4OjqAU67pQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
+      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
       "requires": {
         "@algolia/autocomplete-core": "1.7.1",
         "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.1.1",
+        "@docsearch/css": "3.2.1",
         "algoliasearch": "^4.0.0"
       }
     },
     "@docusaurus/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
       "requires": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -13810,13 +13821,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/cssnano-preset": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -13874,9 +13885,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
-      "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
+      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -13885,23 +13896,23 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.1.tgz",
-      "integrity": "sha512-wIWseCKko1w/WARcDjO3N/XoJ0q/VE42AthP0eNAfEazDjJ94NXbaI6wuUsuY/bMg6hTKGVIpphjj2LoX3g6dA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
+      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.1.tgz",
-      "integrity": "sha512-tdNeljdilXCmhbaEND3SAgsqaw/oh7v9onT5yrIrL26OSk2AFwd+MIi4R8jt8vq33M0R4rz2wpknm0fQIkDdvQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
+      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
       "requires": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -13918,12 +13929,12 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.1.tgz",
-      "integrity": "sha512-f888ylnxHAM/3T8p1lx08+lTc6/g7AweSRfRuZvrVhHXj3Tz/nTTxaP6gPTGkJK7WLqTagpar/IGP6/74IBbkg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
+      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.0.1",
+        "@docusaurus/types": "2.1.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -13933,17 +13944,17 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.1.tgz",
-      "integrity": "sha512-/4ua3iFYcpwgpeYgHnhVGROB/ybnauLH2+rICb4vz/+Gn1hjAmGXVYq1fk8g49zGs3uxx5nc0H5bL9P0g977IQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
+      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -13956,17 +13967,17 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.1.tgz",
-      "integrity": "sha512-2qeBWRy1EjgnXdwAO6/csDIS1UVNmhmtk/bQ2s9jqjpwM8YVgZ8QVdkxFAMWXgZWDQdwWwdP1rnmoEelE4HknQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
+      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/module-type-aliases": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/module-type-aliases": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -13979,88 +13990,88 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.1.tgz",
-      "integrity": "sha512-6apSVeJENnNecAH5cm5VnRqR103M6qSI6IuiP7tVfD5H4AWrfDNkvJQV2+R2PIq3bGrwmX4fcXl1x4g0oo7iwA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
+      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.1.tgz",
-      "integrity": "sha512-jpZBT5HK7SWx1LRQyv9d14i44vSsKXGZsSPA2ndth5HykHJsiAj9Fwl1AtzmtGYuBmI+iXQyOd4MAMHd4ZZ1tg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
+      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.1.tgz",
-      "integrity": "sha512-d5qb+ZeQcg1Czoxc+RacETjLdp2sN/TAd7PGN/GrvtijCdgNmvVAtZ9QgajBTG0YbJFVPTeZ39ad2bpoOexX0w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
+      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.1.tgz",
-      "integrity": "sha512-qiRufJe2FvIyzICbkjm4VbVCI1hyEju/CebfDKkKh2ZtV4q6DM1WZG7D6VoQSXL8MrMFB895gipOM4BwdM8VsQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
+      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.1.tgz",
-      "integrity": "sha512-KcYuIUIp2JPzUf+Xa7W2BSsjLgN1/0h+VAz7D/C3RYjAgC5ApPX8wO+TECmGfunl/m7WKGUmLabfOon/as64kQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
+      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.1.tgz",
-      "integrity": "sha512-nOoniTg46My1qdDlLWeFs55uEmxOJ+9WMF8KKG8KMCu5LAvpemMi7rQd4x8Tw+xiPHZ/sQzH9JmPTMPRE4QGPw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
+      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/plugin-content-blog": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/plugin-content-pages": "2.0.1",
-        "@docusaurus/plugin-debug": "2.0.1",
-        "@docusaurus/plugin-google-analytics": "2.0.1",
-        "@docusaurus/plugin-google-gtag": "2.0.1",
-        "@docusaurus/plugin-sitemap": "2.0.1",
-        "@docusaurus/theme-classic": "2.0.1",
-        "@docusaurus/theme-common": "2.0.1",
-        "@docusaurus/theme-search-algolia": "2.0.1",
-        "@docusaurus/types": "2.0.1"
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/plugin-content-blog": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/plugin-content-pages": "2.1.0",
+        "@docusaurus/plugin-debug": "2.1.0",
+        "@docusaurus/plugin-google-analytics": "2.1.0",
+        "@docusaurus/plugin-google-gtag": "2.1.0",
+        "@docusaurus/plugin-sitemap": "2.1.0",
+        "@docusaurus/theme-classic": "2.1.0",
+        "@docusaurus/theme-common": "2.1.0",
+        "@docusaurus/theme-search-algolia": "2.1.0",
+        "@docusaurus/types": "2.1.0"
       }
     },
     "@docusaurus/react-loadable": {
@@ -14073,22 +14084,22 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.1.tgz",
-      "integrity": "sha512-0jfigiqkUwIuKOw7Me5tqUM9BBvoQX7qqeevx7v4tkYQexPhk3VYSZo7aRuoJ9oyW5makCTPX551PMJzmq7+sw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
+      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/module-type-aliases": "2.0.1",
-        "@docusaurus/plugin-content-blog": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/plugin-content-pages": "2.0.1",
-        "@docusaurus/theme-common": "2.0.1",
-        "@docusaurus/theme-translations": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/module-type-aliases": "2.1.0",
+        "@docusaurus/plugin-content-blog": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/plugin-content-pages": "2.1.0",
+        "@docusaurus/theme-common": "2.1.0",
+        "@docusaurus/theme-translations": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -14105,16 +14116,16 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.1.tgz",
-      "integrity": "sha512-I3b6e/ryiTQMsbES40cP0DRGnfr0E2qghVq+XecyMKjBPejISoSFEDn0MsnbW8Q26k1Dh/0qDH8QKDqaZZgLhA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
+      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
       "requires": {
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/module-type-aliases": "2.0.1",
-        "@docusaurus/plugin-content-blog": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/plugin-content-pages": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/module-type-aliases": "2.1.0",
+        "@docusaurus/plugin-content-blog": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/plugin-content-pages": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -14126,18 +14137,18 @@
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.1.tgz",
-      "integrity": "sha512-cw3NaOSKbYlsY6uNj4PgO+5mwyQ3aEWre5RlmvjStaz2cbD15Nr69VG8Rd/F6Q5VsCT8BvSdkPDdDG5d/ACexg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
+      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
       "requires": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/theme-common": "2.0.1",
-        "@docusaurus/theme-translations": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/theme-common": "2.1.0",
+        "@docusaurus/theme-translations": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -14149,18 +14160,18 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.1.tgz",
-      "integrity": "sha512-v1MYYlbsdX+rtKnXFcIAn9ar0Z6K0yjqnCYS0p/KLCLrfJwfJ8A3oRJw2HiaIb8jQfk1WMY2h5Qi1p4vHOekQw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
+      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
       "requires": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.1.tgz",
-      "integrity": "sha512-o+4hAFWkj3sBszVnRTAnNqtAIuIW0bNaYyDwQhQ6bdz3RAPEq9cDKZxMpajsj4z2nRty8XjzhyufAAjxFTyrfg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -14173,11 +14184,11 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.1.tgz",
-      "integrity": "sha512-u2Vdl/eoVwMfUjDCkg7FjxoiwFs/XhVVtNxQEw8cvB+qaw6QWyT73m96VZzWtUb1fDOefHoZ+bZ0ObFeKk9lMQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
+      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
       "requires": {
-        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/logger": "2.1.0",
         "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
@@ -14195,20 +14206,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.1.tgz",
-      "integrity": "sha512-kajCCDCXRd1HFH5EUW31MPaQcsyNlGakpkDoTBtBvpa4EIPvWaSKy7TIqYKHrZjX4tnJ0YbEJvaXfjjgdq5xSg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
+      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.1.tgz",
-      "integrity": "sha512-f14AnwFBy4/1A19zWthK+Ii80YDz+4qt8oPpK3julywXsheSxPBqgsND3LVBBvB2p3rJHvbo2m3HyB9Tco1JRw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
+      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
       "requires": {
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -15078,9 +15089,9 @@
       }
     },
     "algoliasearch-helper": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.10.0.tgz",
-      "integrity": "sha512-4E4od8qWWDMVvQ3jaRX6Oks/k35ywD011wAA4LbYMMjOtaZV6VWaTjRr4iN2bdaXP2o1BP7SLFMBf3wvnHmd8Q==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.0.tgz",
+      "integrity": "sha512-TLl/MSjtQ98mgkd8hngWkzSjE+dAWldZ1NpJtv2mT+ZoFJ2P2zDE85oF9WafJOXWN9FbVRmyxpO5H+qXcNaFng==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -16411,9 +16422,9 @@
       }
     },
     "entities": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -18407,11 +18418,11 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "parse5": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
-      "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.0.tgz",
+      "integrity": "sha512-jo4pIv8LVI1IO2QxismoCv/+qZC6V3VSxOHqEQIpm5kDSzJNLNIVUwdStdUnezexjwdZXgYkxP5nanlZgfcCHg==",
       "requires": {
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       }
     },
     "parse5-htmlparser2-tree-adapter": {
@@ -18888,9 +18899,9 @@
       "requires": {}
     },
     "prismjs": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
-      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw=="
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,9 +8,9 @@
       "name": "docs",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "~2.1.0",
-        "@docusaurus/plugin-google-analytics": "~2.1.0",
-        "@docusaurus/preset-classic": "~2.1.0",
+        "@docusaurus/core": "~2.0.1",
+        "@docusaurus/plugin-google-analytics": "~2.0.1",
+        "@docusaurus/preset-classic": "~2.0.1",
         "@mdx-js/react": "~1.6.22",
         "docusaurus-plugin-sass": "0.2.2",
         "react": "~17.0.2",
@@ -1948,41 +1948,30 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.1.1.tgz",
+      "integrity": "sha512-utLgg7E1agqQeqCJn05DWC7XXMk4tMUUnL7MZupcknRu2OzGN13qwey2qA/0NAKkVBGugiWtON0+rlU0QIPojg=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.1.1.tgz",
+      "integrity": "sha512-cfoql4qvtsVRqBMYxhlGNpvyy/KlCoPqjIsJSZYqYf9AplZncKjLBTcwBu6RXFMVCe30cIFljniI4OjqAU67pQ==",
       "dependencies": {
         "@algolia/autocomplete-core": "1.7.1",
         "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
+        "@docsearch/css": "3.1.1",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 19.0.0",
         "react": ">= 16.8.0 < 19.0.0",
         "react-dom": ">= 16.8.0 < 19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
       "dependencies": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -1994,13 +1983,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/cssnano-preset": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -2068,9 +2057,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
+      "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -2082,9 +2071,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
-      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.1.tgz",
+      "integrity": "sha512-wIWseCKko1w/WARcDjO3N/XoJ0q/VE42AthP0eNAfEazDjJ94NXbaI6wuUsuY/bMg6hTKGVIpphjj2LoX3g6dA==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
@@ -2094,14 +2083,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
-      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.1.tgz",
+      "integrity": "sha512-tdNeljdilXCmhbaEND3SAgsqaw/oh7v9onT5yrIrL26OSk2AFwd+MIi4R8jt8vq33M0R4rz2wpknm0fQIkDdvQ==",
       "dependencies": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2125,12 +2114,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.1.tgz",
+      "integrity": "sha512-f888ylnxHAM/3T8p1lx08+lTc6/g7AweSRfRuZvrVhHXj3Tz/nTTxaP6gPTGkJK7WLqTagpar/IGP6/74IBbkg==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.1.0",
+        "@docusaurus/types": "2.0.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2144,17 +2133,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
-      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.1.tgz",
+      "integrity": "sha512-/4ua3iFYcpwgpeYgHnhVGROB/ybnauLH2+rICb4vz/+Gn1hjAmGXVYq1fk8g49zGs3uxx5nc0H5bL9P0g977IQ==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -2174,17 +2163,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
-      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.1.tgz",
+      "integrity": "sha512-2qeBWRy1EjgnXdwAO6/csDIS1UVNmhmtk/bQ2s9jqjpwM8YVgZ8QVdkxFAMWXgZWDQdwWwdP1rnmoEelE4HknQ==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/module-type-aliases": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -2204,15 +2193,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
-      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.1.tgz",
+      "integrity": "sha512-6apSVeJENnNecAH5cm5VnRqR103M6qSI6IuiP7tVfD5H4AWrfDNkvJQV2+R2PIq3bGrwmX4fcXl1x4g0oo7iwA==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -2226,13 +2215,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
-      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.1.tgz",
+      "integrity": "sha512-jpZBT5HK7SWx1LRQyv9d14i44vSsKXGZsSPA2ndth5HykHJsiAj9Fwl1AtzmtGYuBmI+iXQyOd4MAMHd4ZZ1tg==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -2246,13 +2235,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
-      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.1.tgz",
+      "integrity": "sha512-d5qb+ZeQcg1Czoxc+RacETjLdp2sN/TAd7PGN/GrvtijCdgNmvVAtZ9QgajBTG0YbJFVPTeZ39ad2bpoOexX0w==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2264,13 +2253,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
-      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.1.tgz",
+      "integrity": "sha512-qiRufJe2FvIyzICbkjm4VbVCI1hyEju/CebfDKkKh2ZtV4q6DM1WZG7D6VoQSXL8MrMFB895gipOM4BwdM8VsQ==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2282,16 +2271,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
-      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.1.tgz",
+      "integrity": "sha512-KcYuIUIp2JPzUf+Xa7W2BSsjLgN1/0h+VAz7D/C3RYjAgC5ApPX8wO+TECmGfunl/m7WKGUmLabfOon/as64kQ==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
@@ -2305,22 +2294,22 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
-      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.1.tgz",
+      "integrity": "sha512-nOoniTg46My1qdDlLWeFs55uEmxOJ+9WMF8KKG8KMCu5LAvpemMi7rQd4x8Tw+xiPHZ/sQzH9JmPTMPRE4QGPw==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/plugin-debug": "2.1.0",
-        "@docusaurus/plugin-google-analytics": "2.1.0",
-        "@docusaurus/plugin-google-gtag": "2.1.0",
-        "@docusaurus/plugin-sitemap": "2.1.0",
-        "@docusaurus/theme-classic": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-search-algolia": "2.1.0",
-        "@docusaurus/types": "2.1.0"
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/plugin-content-blog": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/plugin-content-pages": "2.0.1",
+        "@docusaurus/plugin-debug": "2.0.1",
+        "@docusaurus/plugin-google-analytics": "2.0.1",
+        "@docusaurus/plugin-google-gtag": "2.0.1",
+        "@docusaurus/plugin-sitemap": "2.0.1",
+        "@docusaurus/theme-classic": "2.0.1",
+        "@docusaurus/theme-common": "2.0.1",
+        "@docusaurus/theme-search-algolia": "2.0.1",
+        "@docusaurus/types": "2.0.1"
       },
       "engines": {
         "node": ">=16.14"
@@ -2343,22 +2332,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
-      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.1.tgz",
+      "integrity": "sha512-0jfigiqkUwIuKOw7Me5tqUM9BBvoQX7qqeevx7v4tkYQexPhk3VYSZo7aRuoJ9oyW5makCTPX551PMJzmq7+sw==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/module-type-aliases": "2.0.1",
+        "@docusaurus/plugin-content-blog": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/plugin-content-pages": "2.0.1",
+        "@docusaurus/theme-common": "2.0.1",
+        "@docusaurus/theme-translations": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -2382,16 +2371,16 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
-      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.1.tgz",
+      "integrity": "sha512-I3b6e/ryiTQMsbES40cP0DRGnfr0E2qghVq+XecyMKjBPejISoSFEDn0MsnbW8Q26k1Dh/0qDH8QKDqaZZgLhA==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/module-type-aliases": "2.0.1",
+        "@docusaurus/plugin-content-blog": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/plugin-content-pages": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2410,18 +2399,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
-      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.1.tgz",
+      "integrity": "sha512-cw3NaOSKbYlsY6uNj4PgO+5mwyQ3aEWre5RlmvjStaz2cbD15Nr69VG8Rd/F6Q5VsCT8BvSdkPDdDG5d/ACexg==",
       "dependencies": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/theme-common": "2.0.1",
+        "@docusaurus/theme-translations": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -2440,9 +2429,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
-      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.1.tgz",
+      "integrity": "sha512-v1MYYlbsdX+rtKnXFcIAn9ar0Z6K0yjqnCYS0p/KLCLrfJwfJ8A3oRJw2HiaIb8jQfk1WMY2h5Qi1p4vHOekQw==",
       "dependencies": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
@@ -2452,9 +2441,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-o+4hAFWkj3sBszVnRTAnNqtAIuIW0bNaYyDwQhQ6bdz3RAPEq9cDKZxMpajsj4z2nRty8XjzhyufAAjxFTyrfg==",
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -2471,11 +2460,11 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
-      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.1.tgz",
+      "integrity": "sha512-u2Vdl/eoVwMfUjDCkg7FjxoiwFs/XhVVtNxQEw8cvB+qaw6QWyT73m96VZzWtUb1fDOefHoZ+bZ0ObFeKk9lMQ==",
       "dependencies": {
-        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/logger": "2.0.1",
         "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
@@ -2504,9 +2493,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
-      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.1.tgz",
+      "integrity": "sha512-kajCCDCXRd1HFH5EUW31MPaQcsyNlGakpkDoTBtBvpa4EIPvWaSKy7TIqYKHrZjX4tnJ0YbEJvaXfjjgdq5xSg==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2523,12 +2512,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
-      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.1.tgz",
+      "integrity": "sha512-f14AnwFBy4/1A19zWthK+Ii80YDz+4qt8oPpK3julywXsheSxPBqgsND3LVBBvB2p3rJHvbo2m3HyB9Tco1JRw==",
       "dependencies": {
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -3627,9 +3616,9 @@
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.0.tgz",
-      "integrity": "sha512-TLl/MSjtQ98mgkd8hngWkzSjE+dAWldZ1NpJtv2mT+ZoFJ2P2zDE85oF9WafJOXWN9FbVRmyxpO5H+qXcNaFng==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.10.0.tgz",
+      "integrity": "sha512-4E4od8qWWDMVvQ3jaRX6Oks/k35ywD011wAA4LbYMMjOtaZV6VWaTjRr4iN2bdaXP2o1BP7SLFMBf3wvnHmd8Q==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -5488,9 +5477,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
       "engines": {
         "node": ">=0.12"
       },
@@ -8273,11 +8262,11 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "node_modules/parse5": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.0.tgz",
-      "integrity": "sha512-jo4pIv8LVI1IO2QxismoCv/+qZC6V3VSxOHqEQIpm5kDSzJNLNIVUwdStdUnezexjwdZXgYkxP5nanlZgfcCHg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+      "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
       "dependencies": {
-        "entities": "^4.4.0"
+        "entities": "^4.3.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -9038,9 +9027,9 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
       "engines": {
         "node": ">=6"
       }
@@ -13791,25 +13780,25 @@
       "optional": true
     },
     "@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.1.1.tgz",
+      "integrity": "sha512-utLgg7E1agqQeqCJn05DWC7XXMk4tMUUnL7MZupcknRu2OzGN13qwey2qA/0NAKkVBGugiWtON0+rlU0QIPojg=="
     },
     "@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.1.1.tgz",
+      "integrity": "sha512-cfoql4qvtsVRqBMYxhlGNpvyy/KlCoPqjIsJSZYqYf9AplZncKjLBTcwBu6RXFMVCe30cIFljniI4OjqAU67pQ==",
       "requires": {
         "@algolia/autocomplete-core": "1.7.1",
         "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
+        "@docsearch/css": "3.1.1",
         "algoliasearch": "^4.0.0"
       }
     },
     "@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
+      "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
       "requires": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -13821,13 +13810,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/cssnano-preset": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -13885,9 +13874,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
+      "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -13896,23 +13885,23 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
-      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.1.tgz",
+      "integrity": "sha512-wIWseCKko1w/WARcDjO3N/XoJ0q/VE42AthP0eNAfEazDjJ94NXbaI6wuUsuY/bMg6hTKGVIpphjj2LoX3g6dA==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
-      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.1.tgz",
+      "integrity": "sha512-tdNeljdilXCmhbaEND3SAgsqaw/oh7v9onT5yrIrL26OSk2AFwd+MIi4R8jt8vq33M0R4rz2wpknm0fQIkDdvQ==",
       "requires": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -13929,12 +13918,12 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.1.tgz",
+      "integrity": "sha512-f888ylnxHAM/3T8p1lx08+lTc6/g7AweSRfRuZvrVhHXj3Tz/nTTxaP6gPTGkJK7WLqTagpar/IGP6/74IBbkg==",
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.1.0",
+        "@docusaurus/types": "2.0.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -13944,17 +13933,17 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
-      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.1.tgz",
+      "integrity": "sha512-/4ua3iFYcpwgpeYgHnhVGROB/ybnauLH2+rICb4vz/+Gn1hjAmGXVYq1fk8g49zGs3uxx5nc0H5bL9P0g977IQ==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -13967,17 +13956,17 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
-      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.1.tgz",
+      "integrity": "sha512-2qeBWRy1EjgnXdwAO6/csDIS1UVNmhmtk/bQ2s9jqjpwM8YVgZ8QVdkxFAMWXgZWDQdwWwdP1rnmoEelE4HknQ==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/module-type-aliases": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -13990,88 +13979,88 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
-      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.1.tgz",
+      "integrity": "sha512-6apSVeJENnNecAH5cm5VnRqR103M6qSI6IuiP7tVfD5H4AWrfDNkvJQV2+R2PIq3bGrwmX4fcXl1x4g0oo7iwA==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
-      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.1.tgz",
+      "integrity": "sha512-jpZBT5HK7SWx1LRQyv9d14i44vSsKXGZsSPA2ndth5HykHJsiAj9Fwl1AtzmtGYuBmI+iXQyOd4MAMHd4ZZ1tg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
-      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.1.tgz",
+      "integrity": "sha512-d5qb+ZeQcg1Czoxc+RacETjLdp2sN/TAd7PGN/GrvtijCdgNmvVAtZ9QgajBTG0YbJFVPTeZ39ad2bpoOexX0w==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
-      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.1.tgz",
+      "integrity": "sha512-qiRufJe2FvIyzICbkjm4VbVCI1hyEju/CebfDKkKh2ZtV4q6DM1WZG7D6VoQSXL8MrMFB895gipOM4BwdM8VsQ==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
-      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.1.tgz",
+      "integrity": "sha512-KcYuIUIp2JPzUf+Xa7W2BSsjLgN1/0h+VAz7D/C3RYjAgC5ApPX8wO+TECmGfunl/m7WKGUmLabfOon/as64kQ==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
-      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.1.tgz",
+      "integrity": "sha512-nOoniTg46My1qdDlLWeFs55uEmxOJ+9WMF8KKG8KMCu5LAvpemMi7rQd4x8Tw+xiPHZ/sQzH9JmPTMPRE4QGPw==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/plugin-debug": "2.1.0",
-        "@docusaurus/plugin-google-analytics": "2.1.0",
-        "@docusaurus/plugin-google-gtag": "2.1.0",
-        "@docusaurus/plugin-sitemap": "2.1.0",
-        "@docusaurus/theme-classic": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-search-algolia": "2.1.0",
-        "@docusaurus/types": "2.1.0"
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/plugin-content-blog": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/plugin-content-pages": "2.0.1",
+        "@docusaurus/plugin-debug": "2.0.1",
+        "@docusaurus/plugin-google-analytics": "2.0.1",
+        "@docusaurus/plugin-google-gtag": "2.0.1",
+        "@docusaurus/plugin-sitemap": "2.0.1",
+        "@docusaurus/theme-classic": "2.0.1",
+        "@docusaurus/theme-common": "2.0.1",
+        "@docusaurus/theme-search-algolia": "2.0.1",
+        "@docusaurus/types": "2.0.1"
       }
     },
     "@docusaurus/react-loadable": {
@@ -14084,22 +14073,22 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
-      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.1.tgz",
+      "integrity": "sha512-0jfigiqkUwIuKOw7Me5tqUM9BBvoQX7qqeevx7v4tkYQexPhk3VYSZo7aRuoJ9oyW5makCTPX551PMJzmq7+sw==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/module-type-aliases": "2.0.1",
+        "@docusaurus/plugin-content-blog": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/plugin-content-pages": "2.0.1",
+        "@docusaurus/theme-common": "2.0.1",
+        "@docusaurus/theme-translations": "2.0.1",
+        "@docusaurus/types": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-common": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -14116,16 +14105,16 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
-      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.1.tgz",
+      "integrity": "sha512-I3b6e/ryiTQMsbES40cP0DRGnfr0E2qghVq+XecyMKjBPejISoSFEDn0MsnbW8Q26k1Dh/0qDH8QKDqaZZgLhA==",
       "requires": {
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/module-type-aliases": "2.0.1",
+        "@docusaurus/plugin-content-blog": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/plugin-content-pages": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -14137,18 +14126,18 @@
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
-      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.1.tgz",
+      "integrity": "sha512-cw3NaOSKbYlsY6uNj4PgO+5mwyQ3aEWre5RlmvjStaz2cbD15Nr69VG8Rd/F6Q5VsCT8BvSdkPDdDG5d/ACexg==",
       "requires": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.0.1",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/plugin-content-docs": "2.0.1",
+        "@docusaurus/theme-common": "2.0.1",
+        "@docusaurus/theme-translations": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/utils-validation": "2.0.1",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -14160,18 +14149,18 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
-      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.1.tgz",
+      "integrity": "sha512-v1MYYlbsdX+rtKnXFcIAn9ar0Z6K0yjqnCYS0p/KLCLrfJwfJ8A3oRJw2HiaIb8jQfk1WMY2h5Qi1p4vHOekQw==",
       "requires": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.1.tgz",
+      "integrity": "sha512-o+4hAFWkj3sBszVnRTAnNqtAIuIW0bNaYyDwQhQ6bdz3RAPEq9cDKZxMpajsj4z2nRty8XjzhyufAAjxFTyrfg==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -14184,11 +14173,11 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
-      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.1.tgz",
+      "integrity": "sha512-u2Vdl/eoVwMfUjDCkg7FjxoiwFs/XhVVtNxQEw8cvB+qaw6QWyT73m96VZzWtUb1fDOefHoZ+bZ0ObFeKk9lMQ==",
       "requires": {
-        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/logger": "2.0.1",
         "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
@@ -14206,20 +14195,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
-      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.1.tgz",
+      "integrity": "sha512-kajCCDCXRd1HFH5EUW31MPaQcsyNlGakpkDoTBtBvpa4EIPvWaSKy7TIqYKHrZjX4tnJ0YbEJvaXfjjgdq5xSg==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
-      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.1.tgz",
+      "integrity": "sha512-f14AnwFBy4/1A19zWthK+Ii80YDz+4qt8oPpK3julywXsheSxPBqgsND3LVBBvB2p3rJHvbo2m3HyB9Tco1JRw==",
       "requires": {
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/utils": "2.0.1",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -15089,9 +15078,9 @@
       }
     },
     "algoliasearch-helper": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.0.tgz",
-      "integrity": "sha512-TLl/MSjtQ98mgkd8hngWkzSjE+dAWldZ1NpJtv2mT+ZoFJ2P2zDE85oF9WafJOXWN9FbVRmyxpO5H+qXcNaFng==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.10.0.tgz",
+      "integrity": "sha512-4E4od8qWWDMVvQ3jaRX6Oks/k35ywD011wAA4LbYMMjOtaZV6VWaTjRr4iN2bdaXP2o1BP7SLFMBf3wvnHmd8Q==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -16422,9 +16411,9 @@
       }
     },
     "entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -18418,11 +18407,11 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "parse5": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.0.tgz",
-      "integrity": "sha512-jo4pIv8LVI1IO2QxismoCv/+qZC6V3VSxOHqEQIpm5kDSzJNLNIVUwdStdUnezexjwdZXgYkxP5nanlZgfcCHg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+      "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
       "requires": {
-        "entities": "^4.4.0"
+        "entities": "^4.3.0"
       }
     },
     "parse5-htmlparser2-tree-adapter": {
@@ -18899,9 +18888,9 @@
       "requires": {}
     },
     "prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw=="
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,9 +8,9 @@
       "name": "docs",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "~2.0.1",
-        "@docusaurus/plugin-google-analytics": "~2.0.1",
-        "@docusaurus/preset-classic": "~2.0.1",
+        "@docusaurus/core": "~2.1.0",
+        "@docusaurus/plugin-google-analytics": "~2.1.0",
+        "@docusaurus/preset-classic": "~2.1.0",
         "@mdx-js/react": "~1.6.22",
         "docusaurus-plugin-sass": "0.2.2",
         "react": "~17.0.2",
@@ -1948,30 +1948,41 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.1.1.tgz",
-      "integrity": "sha512-utLgg7E1agqQeqCJn05DWC7XXMk4tMUUnL7MZupcknRu2OzGN13qwey2qA/0NAKkVBGugiWtON0+rlU0QIPojg=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
+      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.1.1.tgz",
-      "integrity": "sha512-cfoql4qvtsVRqBMYxhlGNpvyy/KlCoPqjIsJSZYqYf9AplZncKjLBTcwBu6RXFMVCe30cIFljniI4OjqAU67pQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
+      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
       "dependencies": {
         "@algolia/autocomplete-core": "1.7.1",
         "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.1.1",
+        "@docsearch/css": "3.2.1",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 19.0.0",
         "react": ">= 16.8.0 < 19.0.0",
         "react-dom": ">= 16.8.0 < 19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
       "dependencies": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -1983,13 +1994,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/cssnano-preset": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -2057,9 +2068,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
-      "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
+      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -2071,9 +2082,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.1.tgz",
-      "integrity": "sha512-wIWseCKko1w/WARcDjO3N/XoJ0q/VE42AthP0eNAfEazDjJ94NXbaI6wuUsuY/bMg6hTKGVIpphjj2LoX3g6dA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
+      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
@@ -2083,14 +2094,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.1.tgz",
-      "integrity": "sha512-tdNeljdilXCmhbaEND3SAgsqaw/oh7v9onT5yrIrL26OSk2AFwd+MIi4R8jt8vq33M0R4rz2wpknm0fQIkDdvQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
+      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
       "dependencies": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2114,12 +2125,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.1.tgz",
-      "integrity": "sha512-f888ylnxHAM/3T8p1lx08+lTc6/g7AweSRfRuZvrVhHXj3Tz/nTTxaP6gPTGkJK7WLqTagpar/IGP6/74IBbkg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
+      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.0.1",
+        "@docusaurus/types": "2.1.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2133,17 +2144,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.1.tgz",
-      "integrity": "sha512-/4ua3iFYcpwgpeYgHnhVGROB/ybnauLH2+rICb4vz/+Gn1hjAmGXVYq1fk8g49zGs3uxx5nc0H5bL9P0g977IQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
+      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -2163,17 +2174,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.1.tgz",
-      "integrity": "sha512-2qeBWRy1EjgnXdwAO6/csDIS1UVNmhmtk/bQ2s9jqjpwM8YVgZ8QVdkxFAMWXgZWDQdwWwdP1rnmoEelE4HknQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
+      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/module-type-aliases": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/module-type-aliases": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -2193,15 +2204,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.1.tgz",
-      "integrity": "sha512-6apSVeJENnNecAH5cm5VnRqR103M6qSI6IuiP7tVfD5H4AWrfDNkvJQV2+R2PIq3bGrwmX4fcXl1x4g0oo7iwA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
+      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -2215,13 +2226,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.1.tgz",
-      "integrity": "sha512-jpZBT5HK7SWx1LRQyv9d14i44vSsKXGZsSPA2ndth5HykHJsiAj9Fwl1AtzmtGYuBmI+iXQyOd4MAMHd4ZZ1tg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
+      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -2235,13 +2246,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.1.tgz",
-      "integrity": "sha512-d5qb+ZeQcg1Czoxc+RacETjLdp2sN/TAd7PGN/GrvtijCdgNmvVAtZ9QgajBTG0YbJFVPTeZ39ad2bpoOexX0w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
+      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2253,13 +2264,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.1.tgz",
-      "integrity": "sha512-qiRufJe2FvIyzICbkjm4VbVCI1hyEju/CebfDKkKh2ZtV4q6DM1WZG7D6VoQSXL8MrMFB895gipOM4BwdM8VsQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
+      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2271,16 +2282,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.1.tgz",
-      "integrity": "sha512-KcYuIUIp2JPzUf+Xa7W2BSsjLgN1/0h+VAz7D/C3RYjAgC5ApPX8wO+TECmGfunl/m7WKGUmLabfOon/as64kQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
+      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
@@ -2294,22 +2305,22 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.1.tgz",
-      "integrity": "sha512-nOoniTg46My1qdDlLWeFs55uEmxOJ+9WMF8KKG8KMCu5LAvpemMi7rQd4x8Tw+xiPHZ/sQzH9JmPTMPRE4QGPw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
+      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/plugin-content-blog": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/plugin-content-pages": "2.0.1",
-        "@docusaurus/plugin-debug": "2.0.1",
-        "@docusaurus/plugin-google-analytics": "2.0.1",
-        "@docusaurus/plugin-google-gtag": "2.0.1",
-        "@docusaurus/plugin-sitemap": "2.0.1",
-        "@docusaurus/theme-classic": "2.0.1",
-        "@docusaurus/theme-common": "2.0.1",
-        "@docusaurus/theme-search-algolia": "2.0.1",
-        "@docusaurus/types": "2.0.1"
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/plugin-content-blog": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/plugin-content-pages": "2.1.0",
+        "@docusaurus/plugin-debug": "2.1.0",
+        "@docusaurus/plugin-google-analytics": "2.1.0",
+        "@docusaurus/plugin-google-gtag": "2.1.0",
+        "@docusaurus/plugin-sitemap": "2.1.0",
+        "@docusaurus/theme-classic": "2.1.0",
+        "@docusaurus/theme-common": "2.1.0",
+        "@docusaurus/theme-search-algolia": "2.1.0",
+        "@docusaurus/types": "2.1.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -2332,22 +2343,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.1.tgz",
-      "integrity": "sha512-0jfigiqkUwIuKOw7Me5tqUM9BBvoQX7qqeevx7v4tkYQexPhk3VYSZo7aRuoJ9oyW5makCTPX551PMJzmq7+sw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
+      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
       "dependencies": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/module-type-aliases": "2.0.1",
-        "@docusaurus/plugin-content-blog": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/plugin-content-pages": "2.0.1",
-        "@docusaurus/theme-common": "2.0.1",
-        "@docusaurus/theme-translations": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/module-type-aliases": "2.1.0",
+        "@docusaurus/plugin-content-blog": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/plugin-content-pages": "2.1.0",
+        "@docusaurus/theme-common": "2.1.0",
+        "@docusaurus/theme-translations": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -2371,16 +2382,16 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.1.tgz",
-      "integrity": "sha512-I3b6e/ryiTQMsbES40cP0DRGnfr0E2qghVq+XecyMKjBPejISoSFEDn0MsnbW8Q26k1Dh/0qDH8QKDqaZZgLhA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
+      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/module-type-aliases": "2.0.1",
-        "@docusaurus/plugin-content-blog": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/plugin-content-pages": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/module-type-aliases": "2.1.0",
+        "@docusaurus/plugin-content-blog": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/plugin-content-pages": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2399,18 +2410,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.1.tgz",
-      "integrity": "sha512-cw3NaOSKbYlsY6uNj4PgO+5mwyQ3aEWre5RlmvjStaz2cbD15Nr69VG8Rd/F6Q5VsCT8BvSdkPDdDG5d/ACexg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
+      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
       "dependencies": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/theme-common": "2.0.1",
-        "@docusaurus/theme-translations": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/theme-common": "2.1.0",
+        "@docusaurus/theme-translations": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -2429,9 +2440,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.1.tgz",
-      "integrity": "sha512-v1MYYlbsdX+rtKnXFcIAn9ar0Z6K0yjqnCYS0p/KLCLrfJwfJ8A3oRJw2HiaIb8jQfk1WMY2h5Qi1p4vHOekQw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
+      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
       "dependencies": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
@@ -2441,9 +2452,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.1.tgz",
-      "integrity": "sha512-o+4hAFWkj3sBszVnRTAnNqtAIuIW0bNaYyDwQhQ6bdz3RAPEq9cDKZxMpajsj4z2nRty8XjzhyufAAjxFTyrfg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -2460,11 +2471,11 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.1.tgz",
-      "integrity": "sha512-u2Vdl/eoVwMfUjDCkg7FjxoiwFs/XhVVtNxQEw8cvB+qaw6QWyT73m96VZzWtUb1fDOefHoZ+bZ0ObFeKk9lMQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
+      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
       "dependencies": {
-        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/logger": "2.1.0",
         "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
@@ -2493,9 +2504,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.1.tgz",
-      "integrity": "sha512-kajCCDCXRd1HFH5EUW31MPaQcsyNlGakpkDoTBtBvpa4EIPvWaSKy7TIqYKHrZjX4tnJ0YbEJvaXfjjgdq5xSg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
+      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2512,12 +2523,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.1.tgz",
-      "integrity": "sha512-f14AnwFBy4/1A19zWthK+Ii80YDz+4qt8oPpK3julywXsheSxPBqgsND3LVBBvB2p3rJHvbo2m3HyB9Tco1JRw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
+      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
       "dependencies": {
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -3616,9 +3627,9 @@
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.10.0.tgz",
-      "integrity": "sha512-4E4od8qWWDMVvQ3jaRX6Oks/k35ywD011wAA4LbYMMjOtaZV6VWaTjRr4iN2bdaXP2o1BP7SLFMBf3wvnHmd8Q==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.0.tgz",
+      "integrity": "sha512-TLl/MSjtQ98mgkd8hngWkzSjE+dAWldZ1NpJtv2mT+ZoFJ2P2zDE85oF9WafJOXWN9FbVRmyxpO5H+qXcNaFng==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -5477,9 +5488,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
       "engines": {
         "node": ">=0.12"
       },
@@ -8262,11 +8273,11 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "node_modules/parse5": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
-      "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
+      "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
       "dependencies": {
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -9027,9 +9038,9 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
-      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
       "engines": {
         "node": ">=6"
       }
@@ -13780,25 +13791,25 @@
       "optional": true
     },
     "@docsearch/css": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.1.1.tgz",
-      "integrity": "sha512-utLgg7E1agqQeqCJn05DWC7XXMk4tMUUnL7MZupcknRu2OzGN13qwey2qA/0NAKkVBGugiWtON0+rlU0QIPojg=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
+      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
     },
     "@docsearch/react": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.1.1.tgz",
-      "integrity": "sha512-cfoql4qvtsVRqBMYxhlGNpvyy/KlCoPqjIsJSZYqYf9AplZncKjLBTcwBu6RXFMVCe30cIFljniI4OjqAU67pQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
+      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
       "requires": {
         "@algolia/autocomplete-core": "1.7.1",
         "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.1.1",
+        "@docsearch/css": "3.2.1",
         "algoliasearch": "^4.0.0"
       }
     },
     "@docusaurus/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
       "requires": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -13810,13 +13821,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
+        "@docusaurus/cssnano-preset": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -13874,9 +13885,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz",
-      "integrity": "sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
+      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -13885,23 +13896,23 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.0.1.tgz",
-      "integrity": "sha512-wIWseCKko1w/WARcDjO3N/XoJ0q/VE42AthP0eNAfEazDjJ94NXbaI6wuUsuY/bMg6hTKGVIpphjj2LoX3g6dA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
+      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.1.tgz",
-      "integrity": "sha512-tdNeljdilXCmhbaEND3SAgsqaw/oh7v9onT5yrIrL26OSk2AFwd+MIi4R8jt8vq33M0R4rz2wpknm0fQIkDdvQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
+      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
       "requires": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -13918,12 +13929,12 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.1.tgz",
-      "integrity": "sha512-f888ylnxHAM/3T8p1lx08+lTc6/g7AweSRfRuZvrVhHXj3Tz/nTTxaP6gPTGkJK7WLqTagpar/IGP6/74IBbkg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
+      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.0.1",
+        "@docusaurus/types": "2.1.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -13933,17 +13944,17 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.1.tgz",
-      "integrity": "sha512-/4ua3iFYcpwgpeYgHnhVGROB/ybnauLH2+rICb4vz/+Gn1hjAmGXVYq1fk8g49zGs3uxx5nc0H5bL9P0g977IQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
+      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -13956,17 +13967,17 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.1.tgz",
-      "integrity": "sha512-2qeBWRy1EjgnXdwAO6/csDIS1UVNmhmtk/bQ2s9jqjpwM8YVgZ8QVdkxFAMWXgZWDQdwWwdP1rnmoEelE4HknQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
+      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/module-type-aliases": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/module-type-aliases": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -13979,88 +13990,88 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.1.tgz",
-      "integrity": "sha512-6apSVeJENnNecAH5cm5VnRqR103M6qSI6IuiP7tVfD5H4AWrfDNkvJQV2+R2PIq3bGrwmX4fcXl1x4g0oo7iwA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
+      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.1.tgz",
-      "integrity": "sha512-jpZBT5HK7SWx1LRQyv9d14i44vSsKXGZsSPA2ndth5HykHJsiAj9Fwl1AtzmtGYuBmI+iXQyOd4MAMHd4ZZ1tg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
+      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.1.tgz",
-      "integrity": "sha512-d5qb+ZeQcg1Czoxc+RacETjLdp2sN/TAd7PGN/GrvtijCdgNmvVAtZ9QgajBTG0YbJFVPTeZ39ad2bpoOexX0w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
+      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.1.tgz",
-      "integrity": "sha512-qiRufJe2FvIyzICbkjm4VbVCI1hyEju/CebfDKkKh2ZtV4q6DM1WZG7D6VoQSXL8MrMFB895gipOM4BwdM8VsQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
+      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.1.tgz",
-      "integrity": "sha512-KcYuIUIp2JPzUf+Xa7W2BSsjLgN1/0h+VAz7D/C3RYjAgC5ApPX8wO+TECmGfunl/m7WKGUmLabfOon/as64kQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
+      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.1.tgz",
-      "integrity": "sha512-nOoniTg46My1qdDlLWeFs55uEmxOJ+9WMF8KKG8KMCu5LAvpemMi7rQd4x8Tw+xiPHZ/sQzH9JmPTMPRE4QGPw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
+      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/plugin-content-blog": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/plugin-content-pages": "2.0.1",
-        "@docusaurus/plugin-debug": "2.0.1",
-        "@docusaurus/plugin-google-analytics": "2.0.1",
-        "@docusaurus/plugin-google-gtag": "2.0.1",
-        "@docusaurus/plugin-sitemap": "2.0.1",
-        "@docusaurus/theme-classic": "2.0.1",
-        "@docusaurus/theme-common": "2.0.1",
-        "@docusaurus/theme-search-algolia": "2.0.1",
-        "@docusaurus/types": "2.0.1"
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/plugin-content-blog": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/plugin-content-pages": "2.1.0",
+        "@docusaurus/plugin-debug": "2.1.0",
+        "@docusaurus/plugin-google-analytics": "2.1.0",
+        "@docusaurus/plugin-google-gtag": "2.1.0",
+        "@docusaurus/plugin-sitemap": "2.1.0",
+        "@docusaurus/theme-classic": "2.1.0",
+        "@docusaurus/theme-common": "2.1.0",
+        "@docusaurus/theme-search-algolia": "2.1.0",
+        "@docusaurus/types": "2.1.0"
       }
     },
     "@docusaurus/react-loadable": {
@@ -14073,22 +14084,22 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.1.tgz",
-      "integrity": "sha512-0jfigiqkUwIuKOw7Me5tqUM9BBvoQX7qqeevx7v4tkYQexPhk3VYSZo7aRuoJ9oyW5makCTPX551PMJzmq7+sw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
+      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
       "requires": {
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/module-type-aliases": "2.0.1",
-        "@docusaurus/plugin-content-blog": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/plugin-content-pages": "2.0.1",
-        "@docusaurus/theme-common": "2.0.1",
-        "@docusaurus/theme-translations": "2.0.1",
-        "@docusaurus/types": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-common": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/module-type-aliases": "2.1.0",
+        "@docusaurus/plugin-content-blog": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/plugin-content-pages": "2.1.0",
+        "@docusaurus/theme-common": "2.1.0",
+        "@docusaurus/theme-translations": "2.1.0",
+        "@docusaurus/types": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-common": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -14105,16 +14116,16 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.1.tgz",
-      "integrity": "sha512-I3b6e/ryiTQMsbES40cP0DRGnfr0E2qghVq+XecyMKjBPejISoSFEDn0MsnbW8Q26k1Dh/0qDH8QKDqaZZgLhA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
+      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
       "requires": {
-        "@docusaurus/mdx-loader": "2.0.1",
-        "@docusaurus/module-type-aliases": "2.0.1",
-        "@docusaurus/plugin-content-blog": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/plugin-content-pages": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/module-type-aliases": "2.1.0",
+        "@docusaurus/plugin-content-blog": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/plugin-content-pages": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -14126,18 +14137,18 @@
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.1.tgz",
-      "integrity": "sha512-cw3NaOSKbYlsY6uNj4PgO+5mwyQ3aEWre5RlmvjStaz2cbD15Nr69VG8Rd/F6Q5VsCT8BvSdkPDdDG5d/ACexg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
+      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
       "requires": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.0.1",
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/plugin-content-docs": "2.0.1",
-        "@docusaurus/theme-common": "2.0.1",
-        "@docusaurus/theme-translations": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
-        "@docusaurus/utils-validation": "2.0.1",
+        "@docusaurus/core": "2.1.0",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/plugin-content-docs": "2.1.0",
+        "@docusaurus/theme-common": "2.1.0",
+        "@docusaurus/theme-translations": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/utils-validation": "2.1.0",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -14149,18 +14160,18 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.0.1.tgz",
-      "integrity": "sha512-v1MYYlbsdX+rtKnXFcIAn9ar0Z6K0yjqnCYS0p/KLCLrfJwfJ8A3oRJw2HiaIb8jQfk1WMY2h5Qi1p4vHOekQw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
+      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
       "requires": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.1.tgz",
-      "integrity": "sha512-o+4hAFWkj3sBszVnRTAnNqtAIuIW0bNaYyDwQhQ6bdz3RAPEq9cDKZxMpajsj4z2nRty8XjzhyufAAjxFTyrfg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
+      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -14173,11 +14184,11 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.1.tgz",
-      "integrity": "sha512-u2Vdl/eoVwMfUjDCkg7FjxoiwFs/XhVVtNxQEw8cvB+qaw6QWyT73m96VZzWtUb1fDOefHoZ+bZ0ObFeKk9lMQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
+      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
       "requires": {
-        "@docusaurus/logger": "2.0.1",
+        "@docusaurus/logger": "2.1.0",
         "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
@@ -14195,20 +14206,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.1.tgz",
-      "integrity": "sha512-kajCCDCXRd1HFH5EUW31MPaQcsyNlGakpkDoTBtBvpa4EIPvWaSKy7TIqYKHrZjX4tnJ0YbEJvaXfjjgdq5xSg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
+      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.1.tgz",
-      "integrity": "sha512-f14AnwFBy4/1A19zWthK+Ii80YDz+4qt8oPpK3julywXsheSxPBqgsND3LVBBvB2p3rJHvbo2m3HyB9Tco1JRw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
+      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
       "requires": {
-        "@docusaurus/logger": "2.0.1",
-        "@docusaurus/utils": "2.0.1",
+        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/utils": "2.1.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -15078,9 +15089,9 @@
       }
     },
     "algoliasearch-helper": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.10.0.tgz",
-      "integrity": "sha512-4E4od8qWWDMVvQ3jaRX6Oks/k35ywD011wAA4LbYMMjOtaZV6VWaTjRr4iN2bdaXP2o1BP7SLFMBf3wvnHmd8Q==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.0.tgz",
+      "integrity": "sha512-TLl/MSjtQ98mgkd8hngWkzSjE+dAWldZ1NpJtv2mT+ZoFJ2P2zDE85oF9WafJOXWN9FbVRmyxpO5H+qXcNaFng==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -16411,9 +16422,9 @@
       }
     },
     "entities": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -18407,11 +18418,11 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "parse5": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
-      "integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
+      "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
       "requires": {
-        "entities": "^4.3.0"
+        "entities": "^4.4.0"
       }
     },
     "parse5-htmlparser2-tree-adapter": {
@@ -18888,9 +18899,9 @@
       "requires": {}
     },
     "prismjs": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
-      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw=="
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,9 +13,9 @@
     "write-translations": "docusaurus write-translations"
   },
   "dependencies": {
-    "@docusaurus/core": "~2.0.1",
-    "@docusaurus/plugin-google-analytics": "~2.0.1",
-    "@docusaurus/preset-classic": "~2.0.1",
+    "@docusaurus/core": "~2.1.0",
+    "@docusaurus/plugin-google-analytics": "~2.1.0",
+    "@docusaurus/preset-classic": "~2.1.0",
     "@mdx-js/react": "~1.6.22",
     "docusaurus-plugin-sass": "0.2.2",
     "react": "~17.0.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,9 +13,9 @@
     "write-translations": "docusaurus write-translations"
   },
   "dependencies": {
-    "@docusaurus/core": "~2.1.0",
-    "@docusaurus/plugin-google-analytics": "~2.1.0",
-    "@docusaurus/preset-classic": "~2.1.0",
+    "@docusaurus/core": "~2.0.1",
+    "@docusaurus/plugin-google-analytics": "~2.0.1",
+    "@docusaurus/preset-classic": "~2.0.1",
     "@mdx-js/react": "~1.6.22",
     "docusaurus-plugin-sass": "0.2.2",
     "react": "~17.0.2",


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Some searches on Google redirect users to the version 1 of the documentation which is deprecated. Only v2 pages should be indexed on Google.

# Solution and steps

- [x] Add the option `noIndex:true` not to index v1 documentation (see https://github.com/facebook/docusaurus/pull/7963)
- [x] Upgrade `@docusaurus/core` to latest version (waiting for the version supported `noIndex` to be published)

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
