### PR TITLE
Add `getCsrfTokenFromRequest` util

### DIFF
--- a/packages/core/src/sessions/http/get-csrf-token-from-request.spec.ts
+++ b/packages/core/src/sessions/http/get-csrf-token-from-request.spec.ts
@@ -1,0 +1,53 @@
+// std
+import { strictEqual } from 'assert';
+
+// FoalTS
+import { Context } from '../../core';
+import { getCsrfTokenFromRequest } from './get-csrf-token-from-request';
+
+function createRequest(body: { [name: string]: any }, headers: { [name: string ]: string}): Context['request'] {
+  return {
+    body,
+    get(headerName: string): string|undefined {
+      return headers[headerName];
+    }
+  } as Context['request'];
+}
+
+describe('getCsrfTokenFromRequest', () => {
+  context('given the CSRF token is in the request body field "_csrf"', () => {
+    it('should return the CSRF token.', () => {
+      const token = '123';
+      const request = createRequest({ _csrf: token }, {});
+      const csrfToken = getCsrfTokenFromRequest(request);
+
+      strictEqual(csrfToken, token);
+    });
+  });
+  context('given the CSRF token is in the request header "X-CSRF-Token"', () => {
+    it('should return the CSRF token.', () => {
+      const token = '123';
+      const request = createRequest({}, { 'X-CSRF-Token': token });
+      const csrfToken = getCsrfTokenFromRequest(request);
+
+      strictEqual(csrfToken, token);
+    });
+  });
+  context('given the CSRF token is in the request header "X-XSRF-Token"', () => {
+    it('should return the CSRF token.', () => {
+      const token = '123';
+      const request = createRequest({}, { 'X-XSRF-Token': token });
+      const csrfToken = getCsrfTokenFromRequest(request);
+
+      strictEqual(csrfToken, token);
+    });
+  });
+  context('given the CSRF token is not provided', () => {
+    it('should return undefined.', () => {
+      const request = createRequest({}, {});
+      const csrfToken = getCsrfTokenFromRequest(request);
+
+      strictEqual(csrfToken, undefined);
+    });
+  });
+});

--- a/packages/core/src/sessions/http/get-csrf-token-from-request.ts
+++ b/packages/core/src/sessions/http/get-csrf-token-from-request.ts
@@ -1,0 +1,5 @@
+import { Context } from '../../core';
+
+export function getCsrfTokenFromRequest(request: Context['request']): string|undefined {
+  return request.body._csrf || request.get('X-CSRF-Token') || request.get('X-XSRF-Token');
+}

--- a/packages/core/src/sessions/http/use-sessions.hook.spec.ts
+++ b/packages/core/src/sessions/http/use-sessions.hook.spec.ts
@@ -577,9 +577,15 @@ describe('UseSessions', () => {
               );
             });
 
-            function testCsrkToken(getContext: (token: string) => Context) {
+            context('given a CSRF token is sent in the request', () => {
+
               it('should return an HttpResponseForbidden instance if the CSRF token is incorrect.', async () => {
-                ctx = getContext(incorrectCsrfToken);
+                ctx = createContext(
+                  { 'X-CSRF-Token': incorrectCsrfToken },
+                  { [SESSION_DEFAULT_COOKIE_NAME]: csrfSessionID },
+                  {},
+                  method,
+                );
 
                 const response = await hook(ctx, services);
                 if (!isHttpResponseForbidden(response)) {
@@ -590,46 +596,18 @@ describe('UseSessions', () => {
               });
 
               it('should not return an HttpResponseForbidden instance if the CSRF token is correct.', async () => {
-                ctx = getContext(csrfToken);
+                ctx = createContext(
+                  { 'X-CSRF-Token': csrfToken },
+                  { [SESSION_DEFAULT_COOKIE_NAME]: csrfSessionID },
+                  {},
+                  method,
+                );
 
                 const response = await hook(ctx, services);
                 if (isHttpResponseForbidden(response)) {
                   throw new Error('The hook should NOT have returned a HttpResponseForbidden instance.');
                 }
               });
-            }
-
-            context('given a CSRF token is sent in the request body field "_csrf"', () => {
-
-              testCsrkToken(token => createContext(
-                {},
-                { [SESSION_DEFAULT_COOKIE_NAME]: csrfSessionID },
-                { _csrf: token },
-                method,
-              ));
-
-            });
-
-            context('given a CSRF token is sent in the request header "X-CSRF-Token"', () => {
-
-              testCsrkToken(token => createContext(
-                { 'X-CSRF-Token': token },
-                { [SESSION_DEFAULT_COOKIE_NAME]: csrfSessionID },
-                {},
-                method,
-              ));
-
-            });
-
-            context('given a CSRF token is sent in the request header "X-XSRF-Token"', () => {
-
-              testCsrkToken(token => createContext(
-                { 'X-XSRF-Token': token },
-                { [SESSION_DEFAULT_COOKIE_NAME]: csrfSessionID },
-                {},
-                method,
-              ));
-
             });
           }
 

--- a/packages/core/src/sessions/http/use-sessions.hook.ts
+++ b/packages/core/src/sessions/http/use-sessions.hook.ts
@@ -25,6 +25,7 @@ import { readSession } from '../core/read-session';
 import { removeSessionCookie } from './remove-session-cookie';
 import { SessionStore } from '../core/session-store';
 import { setSessionCookie } from './set-session-cookie';
+import { getCsrfTokenFromRequest } from './get-csrf-token-from-request';
 
 export type UseSessionOptions = {
   store?: Class<SessionStore>;
@@ -137,9 +138,7 @@ export function UseSessions(options: UseSessionOptions = {}): HookDecorator {
           + 'Are you sure you created the session with "createSession"?'
         );
       }
-      const actualCsrfToken = ctx.request.body._csrf ||
-        ctx.request.get('X-CSRF-Token') ||
-        ctx.request.get('X-XSRF-Token');
+      const actualCsrfToken = getCsrfTokenFromRequest(ctx.request);
       if (actualCsrfToken !== expectedCsrftoken) {
         return new HttpResponseForbidden('CSRF token missing or incorrect.');
       }

--- a/packages/jwt/src/http/get-csrf-token-from-request.spec.ts
+++ b/packages/jwt/src/http/get-csrf-token-from-request.spec.ts
@@ -1,0 +1,55 @@
+// std
+import { strictEqual } from 'assert';
+
+// 3p
+import { Context } from '@foal/core';
+
+// FoalTS
+import { getCsrfTokenFromRequest } from './get-csrf-token-from-request';
+
+function createRequest(body: { [name: string]: any }, headers: { [name: string ]: string}): Context['request'] {
+  return {
+    body,
+    get(headerName: string): string|undefined {
+      return headers[headerName];
+    }
+  } as Context['request'];
+}
+
+describe('getCsrfTokenFromRequest', () => {
+  context('given the CSRF token is in the request body field "_csrf"', () => {
+    it('should return the CSRF token.', () => {
+      const token = '123';
+      const request = createRequest({ _csrf: token }, {});
+      const csrfToken = getCsrfTokenFromRequest(request);
+
+      strictEqual(csrfToken, token);
+    });
+  });
+  context('given the CSRF token is in the request header "X-CSRF-Token"', () => {
+    it('should return the CSRF token.', () => {
+      const token = '123';
+      const request = createRequest({}, { 'X-CSRF-Token': token });
+      const csrfToken = getCsrfTokenFromRequest(request);
+
+      strictEqual(csrfToken, token);
+    });
+  });
+  context('given the CSRF token is in the request header "X-XSRF-Token"', () => {
+    it('should return the CSRF token.', () => {
+      const token = '123';
+      const request = createRequest({}, { 'X-XSRF-Token': token });
+      const csrfToken = getCsrfTokenFromRequest(request);
+
+      strictEqual(csrfToken, token);
+    });
+  });
+  context('given the CSRF token is not provided', () => {
+    it('should return undefined.', () => {
+      const request = createRequest({}, {});
+      const csrfToken = getCsrfTokenFromRequest(request);
+
+      strictEqual(csrfToken, undefined);
+    });
+  });
+});

--- a/packages/jwt/src/http/get-csrf-token-from-request.ts
+++ b/packages/jwt/src/http/get-csrf-token-from-request.ts
@@ -1,0 +1,5 @@
+import { Context } from '@foal/core';
+
+export function getCsrfTokenFromRequest(request: Context['request']): string|undefined {
+  return request.body._csrf || request.get('X-CSRF-Token') || request.get('X-XSRF-Token');
+}

--- a/packages/jwt/src/jwt.hook.spec.ts
+++ b/packages/jwt/src/jwt.hook.spec.ts
@@ -663,21 +663,7 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
               });
             }
 
-            context('given a CSRF token is sent in the request body field "_csrf"', () => {
-
-              testCsrkToken((requestCsrfToken, cookieCsrfToken) => createContext(
-                {},
-                {
-                  [JWT_DEFAULT_COOKIE_NAME]: token,
-                  [JWT_DEFAULT_CSRF_COOKIE_NAME]: cookieCsrfToken,
-                },
-                { _csrf: requestCsrfToken },
-                method,
-              ));
-
-            });
-
-            context('given a CSRF token is sent in the request header "X-CSRF-Token"', () => {
+            context('given a CSRF token is sent in the request', () => {
 
               testCsrkToken((requestCsrfToken, cookieCsrfToken) => createContext(
                 { 'X-CSRF-Token': requestCsrfToken },
@@ -691,21 +677,8 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
             });
 
-            context('given a CSRF token is sent in the request header "X-XSRF-Token"', () => {
-
-              testCsrkToken((requestCsrfToken, cookieCsrfToken) => createContext(
-                { 'X-XSRF-Token': requestCsrfToken },
-                {
-                  [JWT_DEFAULT_COOKIE_NAME]: token,
-                  [JWT_DEFAULT_CSRF_COOKIE_NAME]: cookieCsrfToken,
-                },
-                {},
-                method,
-              ));
-
-            });
             context(
-              'given a CSRF token is sent in the request header "X-XSRF-Token" and the csrf cookie name is customized',
+              'given a CSRF token is sent in the request and the csrf cookie name is customized',
               () => {
 
                 const csrfCookieName = JWT_DEFAULT_CSRF_COOKIE_NAME + '2';

--- a/packages/jwt/src/jwt.hook.ts
+++ b/packages/jwt/src/jwt.hook.ts
@@ -20,6 +20,7 @@ import { decode, verify } from 'jsonwebtoken';
 import { JWT_DEFAULT_COOKIE_NAME, JWT_DEFAULT_CSRF_COOKIE_NAME } from './constants';
 import { getSecretOrPublicKey } from './get-secret-or-public-key.util';
 import { checkAndConvertUserIdType } from './http/check-and-convert-user-id-type';
+import { getCsrfTokenFromRequest } from './http/get-csrf-token-from-request';
 import { getJwtFromRequest, RequestValidationError } from './http/get-jwt-from-request';
 import { isInvalidTokenError } from './invalid-token.error';
 
@@ -184,10 +185,7 @@ export function JWT(required: boolean, options: JWTOptions, verifyOptions: Verif
         return new HttpResponseForbidden('CSRF token missing or incorrect.');
       }
 
-      const actualCsrfToken =
-        ctx.request.body._csrf ||
-        ctx.request.get('X-CSRF-Token') ||
-        ctx.request.get('X-XSRF-Token');
+      const actualCsrfToken = getCsrfTokenFromRequest(ctx.request);
       if (actualCsrfToken !== expectedCsrftoken) {
         return new HttpResponseForbidden('CSRF token missing or incorrect.');
       }


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

The `@UseSessions` and `@JWT` hooks do too much stuff and so the tests are difficult to maintain and modify.

# Solution and steps

- [x] Add a `getCsrfTokenFromRequest` util to externalize this part.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
