### PR TITLE
Add `getCsrfTokenFromCookie` and `shouldVerifyCsrfToken` utils

### DIFF
--- a/packages/core/src/sessions/http/use-sessions.hook.ts
+++ b/packages/core/src/sessions/http/use-sessions.hook.ts
@@ -23,6 +23,7 @@ import { FetchUser } from './fetch-user.interface';
 import { removeSessionCookie } from './remove-session-cookie';
 import { setSessionCookie } from './set-session-cookie';
 import { getCsrfTokenFromRequest } from './get-csrf-token-from-request';
+import { shouldVerifyCsrfToken } from './utils';
 
 export interface UseSessionOptions {
   user?: FetchUser;
@@ -134,11 +135,7 @@ export function UseSessions(options: UseSessionOptions = {}): HookDecorator {
 
     /* Verify CSRF token */
 
-    if (
-      options.cookie &&
-      (options.csrf ?? Config.get('settings.session.csrf.enabled', 'boolean', false)) &&
-      ![ 'GET', 'HEAD', 'OPTIONS' ].includes(ctx.request.method)
-    ) {
+    if (shouldVerifyCsrfToken(ctx.request, options)) {
       const expectedCsrftoken = session.get<string|undefined>('csrfToken');
       if (!expectedCsrftoken) {
         throw new Error(

--- a/packages/core/src/sessions/http/utils/index.ts
+++ b/packages/core/src/sessions/http/utils/index.ts
@@ -1,0 +1,1 @@
+export { shouldVerifyCsrfToken } from './should-verify-csrf-token';

--- a/packages/core/src/sessions/http/utils/should-verify-csrf-token.spec.ts
+++ b/packages/core/src/sessions/http/utils/should-verify-csrf-token.spec.ts
@@ -199,7 +199,7 @@ describe('shouldVerifyCsrfToken', () => {
         const expected = false;
 
         strictEqual(actual, expected);
-      }).timeout(5000);
+      });
     });
   });
 });

--- a/packages/core/src/sessions/http/utils/should-verify-csrf-token.spec.ts
+++ b/packages/core/src/sessions/http/utils/should-verify-csrf-token.spec.ts
@@ -1,0 +1,205 @@
+// std
+import { strictEqual } from 'assert';
+
+// FoalTS
+import { Config, Context, HttpMethod } from '../../../core';
+import { UseSessionOptions } from '../use-sessions.hook';
+import { shouldVerifyCsrfToken } from './should-verify-csrf-token';
+
+function createRequest(method: HttpMethod): Context['request'] {
+  return {
+    method
+  } as Context['request'];
+}
+
+function createSessionOptions({ cookie, csrf }: { cookie?: boolean, csrf?: boolean }): UseSessionOptions {
+  return {
+    cookie,
+    csrf
+  };
+}
+
+describe('shouldVerifyCsrfToken', () => {
+  context('given options.cookie is undefined', () => {
+    it('should return false.', () => {
+      const request = createRequest('POST');
+      const options = createSessionOptions({
+        cookie: undefined,
+        csrf: true
+      });
+      const actual = shouldVerifyCsrfToken(request, options);
+      const expected = false;
+
+      strictEqual(actual, expected);
+    });
+  });
+  context('given options.cookie is false', () => {
+    it('should return false.', () => {
+      const request = createRequest('POST');
+      const options = createSessionOptions({
+        cookie: false,
+        csrf: true
+      });
+      const actual = shouldVerifyCsrfToken(request, options);
+      const expected = false;
+
+      strictEqual(actual, expected);
+    });
+  });
+  context('given options.cookie is true', () => {
+    context('given options.csrf is undefined', () => {
+      it('should return false.', () => {
+        const request = createRequest('POST');
+        const options = createSessionOptions({
+          cookie: true,
+          csrf: undefined
+        });
+        const actual = shouldVerifyCsrfToken(request, options);
+        const expected = false;
+
+        strictEqual(actual, expected);
+      });
+    });
+    context('given options.csrf is false', () => {
+      it('should return false.', () => {
+        const request = createRequest('POST');
+        const options = createSessionOptions({
+          cookie: true,
+          csrf: false
+        });
+        const actual = shouldVerifyCsrfToken(request, options);
+        const expected = false;
+
+        strictEqual(actual, expected);
+      });
+    });
+    context('given options.csrf is true', () => {
+      context('given request.method is GET', () => {
+        it('should return false.', () => {
+          const request = createRequest('GET');
+          const options = createSessionOptions({
+            cookie: true,
+            csrf: true
+          });
+          const actual = shouldVerifyCsrfToken(request, options);
+          const expected = false;
+
+          strictEqual(actual, expected);
+        });
+      });
+      context('given request.method is HEAD', () => {
+        it('should return false.', () => {
+          const request = createRequest('HEAD');
+          const options = createSessionOptions({
+            cookie: true,
+            csrf: true
+          });
+          const actual = shouldVerifyCsrfToken(request, options);
+          const expected = false;
+
+          strictEqual(actual, expected);
+        });
+      });
+      context('given request.method is OPTIONS', () => {
+        it('should return false.', () => {
+          const request = createRequest('OPTIONS');
+          const options = createSessionOptions({
+            cookie: true,
+            csrf: true
+          });
+          const actual = shouldVerifyCsrfToken(request, options);
+          const expected = false;
+
+          strictEqual(actual, expected);
+        });
+      });
+      context('given request.method is DELETE', () => {
+        it('should return true.', () => {
+          const request = createRequest('DELETE');
+          const options = createSessionOptions({
+            cookie: true,
+            csrf: true
+          });
+          const actual = shouldVerifyCsrfToken(request, options);
+          const expected = true;
+
+          strictEqual(actual, expected);
+        });
+      });
+      context('given request.method is PATCH', () => {
+        it('should return true.', () => {
+          const request = createRequest('PATCH');
+          const options = createSessionOptions({
+            cookie: true,
+            csrf: true
+          });
+          const actual = shouldVerifyCsrfToken(request, options);
+          const expected = true;
+
+          strictEqual(actual, expected);
+        });
+      });
+      context('given request.method is POST', () => {
+        it('should return true.', () => {
+          const request = createRequest('POST');
+          const options = createSessionOptions({
+            cookie: true,
+            csrf: true
+          });
+          const actual = shouldVerifyCsrfToken(request, options);
+          const expected = true;
+
+          strictEqual(actual, expected);
+        });
+      });
+      context('given request.method is PUT', () => {
+        it('should return true.', () => {
+          const request = createRequest('PUT');
+          const options = createSessionOptions({
+            cookie: true,
+            csrf: true
+          });
+          const actual = shouldVerifyCsrfToken(request, options);
+          const expected = true;
+
+          strictEqual(actual, expected);
+        });
+      });
+    });
+    context('given the configuration "settings.session.csrf.enabled" is true and options.csrf is not defined', () => {
+      afterEach(() => Config.remove('settings.session.csrf.enabled'));
+
+      it('should return true if request.method is POST.', () => {
+        Config.set('settings.session.csrf.enabled', true);
+
+        const request = createRequest('POST');
+        const options = createSessionOptions({
+          cookie: true,
+          csrf: undefined
+        });
+        const actual = shouldVerifyCsrfToken(request, options);
+        const expected = true;
+
+        strictEqual(actual, expected);
+      });
+    });
+
+    context('given the configuration "settings.session.csrf.enabled" is true and options.csrf is false', () => {
+      afterEach(() => Config.remove('settings.session.csrf.enabled'));
+
+      it('should return false even if request.method is POST.', () => {
+        Config.set('settings.session.csrf.enabled', true);
+
+        const request = createRequest('POST');
+        const options = createSessionOptions({
+          cookie: true,
+          csrf: false
+        });
+        const actual = shouldVerifyCsrfToken(request, options);
+        const expected = false;
+
+        strictEqual(actual, expected);
+      }).timeout(5000);
+    });
+  });
+});

--- a/packages/core/src/sessions/http/utils/should-verify-csrf-token.ts
+++ b/packages/core/src/sessions/http/utils/should-verify-csrf-token.ts
@@ -1,0 +1,10 @@
+import { Config, Context } from '../../../core';
+import { UseSessionOptions } from '../use-sessions.hook';
+
+export function shouldVerifyCsrfToken(request: Context['request'], options: UseSessionOptions): boolean {
+  return (
+    options.cookie === true &&
+    (options.csrf ?? Config.get('settings.session.csrf.enabled', 'boolean', false)) &&
+    [ 'DELETE', 'PATCH', 'POST', 'PUT' ].includes(request.method)
+  );
+}

--- a/packages/jwt/src/http/jwt.hook.spec.ts
+++ b/packages/jwt/src/http/jwt.hook.spec.ts
@@ -483,219 +483,125 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
   describe('should verify the CSRF token and', () => {
 
-    context('given settings.jwt.csrf.enabled is true', () => {
+    context('given the request needs a CSRF check', () => {
 
       let token: string;
       let sub: string;
       let csrfToken: string;
 
+      function createContextWithPostMethod(headers: {[name:string]: string}, cookies: {[name:string]: string}): Context {
+        return createContext(headers, cookies, {}, 'POST');
+      }
+
       beforeEach(() => {
         sub = 'subX';
         token = sign({ foo: 'bar' }, secret, { subject: sub });
         csrfToken = sign({ foo2: 'bar' }, secret, { subject: sub });
-
-        Config.set('settings.jwt.csrf.enabled', true);
+        hook = getHookFunction(JWT({ cookie: true, csrf: true }))
       });
 
-      afterEach(() => Config.remove('settings.jwt.csrf.enabled'));
+      it('should return an HttpResponseForbidden instance if the request has no CSRF cookie.', async () => {
+        ctx = createContextWithPostMethod(
+          {},
+          {
+            [JWT_DEFAULT_COOKIE_NAME]: token,
+          },
+        );
 
-      context('given options.cookie is false or not defined', () => {
+        const response = await hook(ctx, services);
+        if (!isHttpResponseForbidden(response)) {
+          throw new Error('The hook should have returned a HttpResponseForbidden instance.');
+        }
 
-        beforeEach(() => ctx = createContext({ Authorization: `Bearer ${token}` }));
+        strictEqual(response.body, 'CSRF token missing or incorrect.');
+      });
 
-        it('should not return an HttpResponseForbidden instance if the request has no CSRF token.', async () => {
+      it('should return an HttpResponseForbidden instance if the csrf tokens are equal but have a wrong signature.', async () => {
+        csrfToken = sign({ foo2: 'bar' }, `${secret}2`, {});
+        ctx = createContextWithPostMethod(
+          { 'X-CSRF-Token': csrfToken },
+          {
+            [JWT_DEFAULT_COOKIE_NAME]: token,
+            [JWT_DEFAULT_CSRF_COOKIE_NAME]: csrfToken,
+          },
+        );
+
+        const response = await hook(ctx, services);
+        if (!isHttpResponseForbidden(response)) {
+          throw new Error('The hook should have returned a HttpResponseForbidden instance.');
+        }
+
+        strictEqual(response.body, 'CSRF token missing or incorrect.');
+      });
+
+      it('should return an HttpResponseForbidden instance if the csrf tokens are equal but have a wrong subject.', async () => {
+        csrfToken = sign({ foo2: 'bar' }, secret, { subject: sub + 'Y' });
+        ctx = createContextWithPostMethod(
+          { 'X-CSRF-Token': csrfToken },
+          {
+            [JWT_DEFAULT_COOKIE_NAME]: token,
+            [JWT_DEFAULT_CSRF_COOKIE_NAME]: csrfToken,
+          },
+        );
+
+        const response = await hook(ctx, services);
+        if (!isHttpResponseForbidden(response)) {
+          throw new Error('The hook should have returned a HttpResponseForbidden instance.');
+        }
+
+        strictEqual(response.body, 'CSRF token missing or incorrect.');
+      });
+
+      it('should return an HttpResponseForbidden instance if the csrf tokens are equal but have expired.', async () => {
+        csrfToken = sign({ foo2: 'bar' }, secret, { subject: sub, expiresIn: 0 });
+        ctx = createContextWithPostMethod(
+          { 'X-CSRF-Token': csrfToken },
+          {
+            [JWT_DEFAULT_COOKIE_NAME]: token,
+            [JWT_DEFAULT_CSRF_COOKIE_NAME]: csrfToken,
+          },
+        );
+
+        const response = await hook(ctx, services);
+        if (!isHttpResponseForbidden(response)) {
+          throw new Error('The hook should have returned a HttpResponseForbidden instance.');
+        }
+
+        strictEqual(response.body, 'CSRF token missing or incorrect.');
+      });
+
+      context('given a CSRF token is sent in the request', () => {
+
+        it('should return an HttpResponseForbidden instance if the CSRF tokens are not equal.', async () => {
+          ctx = createContextWithPostMethod(
+            { 'X-CSRF-Token': csrfToken + '2' },
+            {
+              [JWT_DEFAULT_COOKIE_NAME]: token,
+              [JWT_DEFAULT_CSRF_COOKIE_NAME]: csrfToken,
+            },
+          );
+
+          const response = await hook(ctx, services);
+          if (!isHttpResponseForbidden(response)) {
+            throw new Error('The hook should have returned a HttpResponseForbidden instance.');
+          }
+
+          strictEqual(response.body, 'CSRF token missing or incorrect.');
+        });
+
+        it('should not return an HttpResponseForbidden instance if the CSRF tokens are equal.', async () => {
+          ctx = createContextWithPostMethod(
+            { 'X-CSRF-Token': csrfToken },
+            {
+              [JWT_DEFAULT_COOKIE_NAME]: token,
+              [JWT_DEFAULT_CSRF_COOKIE_NAME]: csrfToken,
+            },
+          );
+
           const response = await hook(ctx, services);
           if (isHttpResponseForbidden(response)) {
-            throw new Error('The hook should not have returned a HttpResponseForbidden instance.');
+            throw new Error('The hook should NOT have returned a HttpResponseForbidden instance.');
           }
-        });
-
-      });
-
-      context('given options.cookie is true', () => {
-
-        context('given options.csrf is false', () => {
-
-          beforeEach(() => hook = getHookFunction(JWT({ cookie: true, csrf: false })));
-
-          it('should NOT return an HttpResponseForbidden instance if the request has no CSRF token.', async () => {
-            ctx = createContext({}, { [JWT_DEFAULT_COOKIE_NAME]: token }, {}, 'POST');
-            const response = await hook(ctx, services);
-            if (isHttpResponseForbidden(response)) {
-              throw new Error('The hook should NOT have returned a HttpResponseForbidden instance.');
-            }
-          });
-
-        });
-
-        context('given options.csrf is undefined', () => {
-
-          beforeEach(() => hook = getHookFunction(JWT({ cookie: true })));
-
-          function testUnprotectedMethod(method: HttpMethod) {
-            it('should not return an HttpResponseForbidden instance if the request has no CSRF token.', async () => {
-              ctx = createContext({}, { [JWT_DEFAULT_COOKIE_NAME]: token }, {}, method);
-              const response = await hook(ctx, services);
-              if (isHttpResponseForbidden(response)) {
-                throw new Error('The hook should not have returned a HttpResponseForbidden instance.');
-              }
-            });
-          }
-
-          context('given the request HTTP method is "GET"', () => {
-            testUnprotectedMethod('GET');
-          });
-
-          context('given the request HTTP method is "HEAD"', () => {
-            testUnprotectedMethod('HEAD');
-          });
-
-          context('given the request HTTP method is "OPTIONS"', () => {
-            testUnprotectedMethod('OPTIONS');
-          });
-
-          function testProtectedMethod(method: HttpMethod) {
-            it('should return an HttpResponseForbidden instance if the request has no CSRF cookie.', async () => {
-              ctx = createContext(
-                {},
-                {
-                  [JWT_DEFAULT_COOKIE_NAME]: token,
-                },
-                {},
-                method
-              );
-
-              const response = await hook(ctx, services);
-              if (!isHttpResponseForbidden(response)) {
-                throw new Error('The hook should have returned a HttpResponseForbidden instance.');
-              }
-
-              strictEqual(response.body, 'CSRF token missing or incorrect.');
-            });
-
-            it(
-              'should return an HttpResponseForbidden instance '
-              + 'if the csrf tokens are equal but have a wrong signature.',
-              async () => {
-                csrfToken = sign({ foo2: 'bar' }, `${secret}2`, {});
-                ctx = createContext(
-                  {},
-                  {
-                    [JWT_DEFAULT_COOKIE_NAME]: token,
-                    [JWT_DEFAULT_CSRF_COOKIE_NAME]: csrfToken,
-                  },
-                  { _csrf: csrfToken },
-                  method
-                );
-
-                const response = await hook(ctx, services);
-                if (!isHttpResponseForbidden(response)) {
-                  throw new Error('The hook should have returned a HttpResponseForbidden instance.');
-                }
-
-                strictEqual(response.body, 'CSRF token missing or incorrect.');
-              }
-            );
-
-            it(
-              'should return an HttpResponseForbidden instance if the csrf tokens are equal but have a wrong subject.',
-              async () => {
-                csrfToken = sign({ foo2: 'bar' }, secret, { subject: sub + 'Y' });
-                ctx = createContext(
-                  {},
-                  {
-                    [JWT_DEFAULT_COOKIE_NAME]: token,
-                    [JWT_DEFAULT_CSRF_COOKIE_NAME]: csrfToken,
-                  },
-                  { _csrf: csrfToken },
-                  method
-                );
-
-                const response = await hook(ctx, services);
-                if (!isHttpResponseForbidden(response)) {
-                  throw new Error('The hook should have returned a HttpResponseForbidden instance.');
-                }
-
-                strictEqual(response.body, 'CSRF token missing or incorrect.');
-              }
-            );
-            it(
-              'should return an HttpResponseForbidden instance if the csrf tokens are equal but have expired.',
-              async () => {
-                csrfToken = sign({ foo2: 'bar' }, secret, { subject: sub, expiresIn: 0 });
-                ctx = createContext(
-                  {},
-                  {
-                    [JWT_DEFAULT_COOKIE_NAME]: token,
-                    [JWT_DEFAULT_CSRF_COOKIE_NAME]: csrfToken,
-                  },
-                  { _csrf: csrfToken },
-                  method
-                );
-
-                const response = await hook(ctx, services);
-                if (!isHttpResponseForbidden(response)) {
-                  throw new Error('The hook should have returned a HttpResponseForbidden instance.');
-                }
-
-                strictEqual(response.body, 'CSRF token missing or incorrect.');
-              }
-            );
-
-            function testCsrkToken(getContext: (requestCsrfToken: string, cookieCsrfToken: string) => Context) {
-              it('should return an HttpResponseForbidden instance if the CSRF tokens are not equal.', async () => {
-                ctx = getContext(csrfToken + '2', csrfToken);
-
-                const response = await hook(ctx, services);
-                if (!isHttpResponseForbidden(response)) {
-                  throw new Error('The hook should have returned a HttpResponseForbidden instance.');
-                }
-
-                strictEqual(response.body, 'CSRF token missing or incorrect.');
-              });
-
-              it('should not return an HttpResponseForbidden instance if the CSRF tokens are equal.', async () => {
-                ctx = getContext(csrfToken, csrfToken);
-
-                const response = await hook(ctx, services);
-                if (isHttpResponseForbidden(response)) {
-                  throw new Error('The hook should NOT have returned a HttpResponseForbidden instance.');
-                }
-              });
-            }
-
-            context('given a CSRF token is sent in the request', () => {
-
-              testCsrkToken((requestCsrfToken, cookieCsrfToken) => createContext(
-                { 'X-CSRF-Token': requestCsrfToken },
-                {
-                  [JWT_DEFAULT_COOKIE_NAME]: token,
-                  [JWT_DEFAULT_CSRF_COOKIE_NAME]: cookieCsrfToken,
-                },
-                {},
-                method,
-              ));
-
-            });
-
-          }
-
-          context('given the request HTTP method is "POST"', () => {
-            testProtectedMethod('POST');
-          });
-
-          context('given the request HTTP method is "PUT"', () => {
-            testProtectedMethod('PUT');
-          });
-
-          context('given the request HTTP method is "PATCH"', () => {
-            testProtectedMethod('PATCH');
-          });
-
-          context('given the request HTTP method is "DELETE"', () => {
-            testProtectedMethod('DELETE');
-          });
-
         });
 
       });

--- a/packages/jwt/src/http/jwt.hook.spec.ts
+++ b/packages/jwt/src/http/jwt.hook.spec.ts
@@ -678,28 +678,6 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
 
             });
 
-            context(
-              'given a CSRF token is sent in the request and the csrf cookie name is customized',
-              () => {
-
-                const csrfCookieName = JWT_DEFAULT_CSRF_COOKIE_NAME + '2';
-
-                beforeEach(() => Config.set('settings.jwt.csrf.cookie.name', csrfCookieName));
-
-                afterEach(() => Config.remove('settings.jwt.csrf.cookie.name'));
-
-                testCsrkToken((requestCsrfToken, cookieCsrfToken) => createContext(
-                  { 'X-XSRF-Token': requestCsrfToken },
-                  {
-                    [JWT_DEFAULT_COOKIE_NAME]: token,
-                    [csrfCookieName]: cookieCsrfToken,
-                  },
-                  {},
-                  method,
-                ));
-
-              }
-          );
           }
 
           context('given the request HTTP method is "POST"', () => {

--- a/packages/jwt/src/http/jwt.hook.ts
+++ b/packages/jwt/src/http/jwt.hook.ts
@@ -22,6 +22,7 @@ import { JWT_DEFAULT_COOKIE_NAME, JWT_DEFAULT_CSRF_COOKIE_NAME } from './constan
 import { getSecretOrPublicKey } from '../core';
 import { getCsrfTokenFromRequest } from './get-csrf-token-from-request';
 import { isInvalidTokenError } from './invalid-token.error';
+import { getCsrfTokenFromCookie } from './utils';
 
 class InvalidTokenResponse extends HttpResponseUnauthorized {
 
@@ -172,8 +173,7 @@ export function JWT(required: boolean, options: JWTOptions, verifyOptions: Verif
       (options.csrf ?? Config.get('settings.jwt.csrf.enabled', 'boolean', false)) &&
       ![ 'GET', 'HEAD', 'OPTIONS' ].includes(ctx.request.method)
     ) {
-      const csrfCookieName = Config.get('settings.jwt.csrf.cookie.name', 'string', JWT_DEFAULT_CSRF_COOKIE_NAME);
-      const expectedCsrftoken: string|undefined = ctx.request.cookies[csrfCookieName];
+      const expectedCsrftoken = getCsrfTokenFromCookie(ctx.request);
       if (!expectedCsrftoken) {
         return new HttpResponseForbidden('CSRF token missing or incorrect.');
       }

--- a/packages/jwt/src/http/jwt.hook.ts
+++ b/packages/jwt/src/http/jwt.hook.ts
@@ -22,7 +22,7 @@ import { JWT_DEFAULT_COOKIE_NAME, JWT_DEFAULT_CSRF_COOKIE_NAME } from './constan
 import { getSecretOrPublicKey } from '../core';
 import { getCsrfTokenFromRequest } from './get-csrf-token-from-request';
 import { isInvalidTokenError } from './invalid-token.error';
-import { getCsrfTokenFromCookie } from './utils';
+import { getCsrfTokenFromCookie, shouldVerifyCsrfToken } from './utils';
 
 class InvalidTokenResponse extends HttpResponseUnauthorized {
 
@@ -168,11 +168,7 @@ export function JWT(required: boolean, options: JWTOptions, verifyOptions: Verif
 
     /* Verify CSRF token */
 
-    if (
-      options.cookie &&
-      (options.csrf ?? Config.get('settings.jwt.csrf.enabled', 'boolean', false)) &&
-      ![ 'GET', 'HEAD', 'OPTIONS' ].includes(ctx.request.method)
-    ) {
+    if (shouldVerifyCsrfToken(ctx.request, options)) {
       const expectedCsrftoken = getCsrfTokenFromCookie(ctx.request);
       if (!expectedCsrftoken) {
         return new HttpResponseForbidden('CSRF token missing or incorrect.');

--- a/packages/jwt/src/http/utils/get-csrf-token-from-cookie.spec.ts
+++ b/packages/jwt/src/http/utils/get-csrf-token-from-cookie.spec.ts
@@ -1,0 +1,49 @@
+// std
+import { strictEqual } from 'assert';
+
+// 3p
+import { Config, Context } from '@foal/core';
+
+// FoalTS
+import { JWT_DEFAULT_CSRF_COOKIE_NAME } from '../constants';
+import { getCsrfTokenFromCookie } from './get-csrf-token-from-cookie';
+
+describe('getCsrfTokenFromCookie', () => {
+  context('given the configuration "settings.jwt.csrf.cookie.name" is undefined', () => {
+    it('should return the value of the default CSRF cookie.', () => {
+      const token = '123';
+      const request = {
+        cookies: {
+          [JWT_DEFAULT_CSRF_COOKIE_NAME]: token
+        }
+      } as Context['request'];
+
+      const actualCsrfToken = getCsrfTokenFromCookie(request);
+      const expectedCsrfToken = token;
+
+      strictEqual(actualCsrfToken, expectedCsrfToken);
+    });
+  });
+
+  context('given the configuration "settings.jwt.csrf.cookie.name" is defined', () => {
+
+    afterEach(() => Config.remove('settings.jwt.csrf.cookie.name'));
+
+    it('should return the value of the given CSRF cookie.', () => {
+      const csrfCookieName = `${JWT_DEFAULT_CSRF_COOKIE_NAME}2`;
+      Config.set('settings.jwt.csrf.cookie.name', csrfCookieName);
+
+      const token = '123';
+      const request = {
+        cookies: {
+          [csrfCookieName]: token
+        }
+      } as Context['request'];
+
+      const actualCsrfToken = getCsrfTokenFromCookie(request);
+      const expectedCsrfToken = token;
+
+      strictEqual(actualCsrfToken, expectedCsrfToken);
+    });
+  });
+})

--- a/packages/jwt/src/http/utils/get-csrf-token-from-cookie.ts
+++ b/packages/jwt/src/http/utils/get-csrf-token-from-cookie.ts
@@ -1,0 +1,10 @@
+// std
+import { Config, Context } from '@foal/core';
+
+// FoalTS
+import { JWT_DEFAULT_CSRF_COOKIE_NAME } from '../constants';
+
+export function getCsrfTokenFromCookie(request: Context['request']): string|undefined {
+  const csrfCookieName = Config.get('settings.jwt.csrf.cookie.name', 'string', JWT_DEFAULT_CSRF_COOKIE_NAME);
+  return request.cookies[csrfCookieName];
+}

--- a/packages/jwt/src/http/utils/index.ts
+++ b/packages/jwt/src/http/utils/index.ts
@@ -1,0 +1,1 @@
+export { getCsrfTokenFromCookie } from './get-csrf-token-from-cookie';

--- a/packages/jwt/src/http/utils/index.ts
+++ b/packages/jwt/src/http/utils/index.ts
@@ -1,1 +1,2 @@
 export { getCsrfTokenFromCookie } from './get-csrf-token-from-cookie';
+export { shouldVerifyCsrfToken } from './should-verify-csrf-token';

--- a/packages/jwt/src/http/utils/should-verify-csrf-token.spec.ts
+++ b/packages/jwt/src/http/utils/should-verify-csrf-token.spec.ts
@@ -201,7 +201,7 @@ describe('shouldVerifyCsrfToken', () => {
         const expected = false;
 
         strictEqual(actual, expected);
-      }).timeout(5000);
+      });
     });
   });
 });

--- a/packages/jwt/src/http/utils/should-verify-csrf-token.spec.ts
+++ b/packages/jwt/src/http/utils/should-verify-csrf-token.spec.ts
@@ -1,0 +1,207 @@
+// std
+import { strictEqual } from 'assert';
+
+// 3p
+import { Config, Context, HttpMethod } from '@foal/core';
+
+// FoalTS
+import { JWTOptions } from '../jwt.hook';
+import { shouldVerifyCsrfToken } from './should-verify-csrf-token';
+
+function createRequest(method: HttpMethod): Context['request'] {
+  return {
+    method
+  } as Context['request'];
+}
+
+function createJwtOptions({ cookie, csrf }: { cookie?: boolean, csrf?: boolean }): JWTOptions {
+  return {
+    cookie,
+    csrf
+  };
+}
+
+describe('shouldVerifyCsrfToken', () => {
+  context('given options.cookie is undefined', () => {
+    it('should return false.', () => {
+      const request = createRequest('POST');
+      const options = createJwtOptions({
+        cookie: undefined,
+        csrf: true
+      });
+      const actual = shouldVerifyCsrfToken(request, options);
+      const expected = false;
+
+      strictEqual(actual, expected);
+    });
+  });
+  context('given options.cookie is false', () => {
+    it('should return false.', () => {
+      const request = createRequest('POST');
+      const options = createJwtOptions({
+        cookie: false,
+        csrf: true
+      });
+      const actual = shouldVerifyCsrfToken(request, options);
+      const expected = false;
+
+      strictEqual(actual, expected);
+    });
+  });
+  context('given options.cookie is true', () => {
+    context('given options.csrf is undefined', () => {
+      it('should return false.', () => {
+        const request = createRequest('POST');
+        const options = createJwtOptions({
+          cookie: true,
+          csrf: undefined
+        });
+        const actual = shouldVerifyCsrfToken(request, options);
+        const expected = false;
+
+        strictEqual(actual, expected);
+      });
+    });
+    context('given options.csrf is false', () => {
+      it('should return false.', () => {
+        const request = createRequest('POST');
+        const options = createJwtOptions({
+          cookie: true,
+          csrf: false
+        });
+        const actual = shouldVerifyCsrfToken(request, options);
+        const expected = false;
+
+        strictEqual(actual, expected);
+      });
+    });
+    context('given options.csrf is true', () => {
+      context('given request.method is GET', () => {
+        it('should return false.', () => {
+          const request = createRequest('GET');
+          const options = createJwtOptions({
+            cookie: true,
+            csrf: true
+          });
+          const actual = shouldVerifyCsrfToken(request, options);
+          const expected = false;
+
+          strictEqual(actual, expected);
+        });
+      });
+      context('given request.method is HEAD', () => {
+        it('should return false.', () => {
+          const request = createRequest('HEAD');
+          const options = createJwtOptions({
+            cookie: true,
+            csrf: true
+          });
+          const actual = shouldVerifyCsrfToken(request, options);
+          const expected = false;
+
+          strictEqual(actual, expected);
+        });
+      });
+      context('given request.method is OPTIONS', () => {
+        it('should return false.', () => {
+          const request = createRequest('OPTIONS');
+          const options = createJwtOptions({
+            cookie: true,
+            csrf: true
+          });
+          const actual = shouldVerifyCsrfToken(request, options);
+          const expected = false;
+
+          strictEqual(actual, expected);
+        });
+      });
+      context('given request.method is DELETE', () => {
+        it('should return true.', () => {
+          const request = createRequest('DELETE');
+          const options = createJwtOptions({
+            cookie: true,
+            csrf: true
+          });
+          const actual = shouldVerifyCsrfToken(request, options);
+          const expected = true;
+
+          strictEqual(actual, expected);
+        });
+      });
+      context('given request.method is PATCH', () => {
+        it('should return true.', () => {
+          const request = createRequest('PATCH');
+          const options = createJwtOptions({
+            cookie: true,
+            csrf: true
+          });
+          const actual = shouldVerifyCsrfToken(request, options);
+          const expected = true;
+
+          strictEqual(actual, expected);
+        });
+      });
+      context('given request.method is POST', () => {
+        it('should return true.', () => {
+          const request = createRequest('POST');
+          const options = createJwtOptions({
+            cookie: true,
+            csrf: true
+          });
+          const actual = shouldVerifyCsrfToken(request, options);
+          const expected = true;
+
+          strictEqual(actual, expected);
+        });
+      });
+      context('given request.method is PUT', () => {
+        it('should return true.', () => {
+          const request = createRequest('PUT');
+          const options = createJwtOptions({
+            cookie: true,
+            csrf: true
+          });
+          const actual = shouldVerifyCsrfToken(request, options);
+          const expected = true;
+
+          strictEqual(actual, expected);
+        });
+      });
+    });
+    context('given the configuration "settings.jwt.csrf.enabled" is true and options.csrf is not defined', () => {
+      afterEach(() => Config.remove('settings.jwt.csrf.enabled'));
+
+      it('should return true if request.method is POST.', () => {
+        Config.set('settings.jwt.csrf.enabled', true);
+
+        const request = createRequest('POST');
+        const options = createJwtOptions({
+          cookie: true,
+          csrf: undefined
+        });
+        const actual = shouldVerifyCsrfToken(request, options);
+        const expected = true;
+
+        strictEqual(actual, expected);
+      });
+    });
+
+    context('given the configuration "settings.jwt.csrf.enabled" is true and options.csrf is false', () => {
+      afterEach(() => Config.remove('settings.jwt.csrf.enabled'));
+
+      it('should return false even if request.method is POST.', () => {
+        Config.set('settings.jwt.csrf.enabled', true);
+
+        const request = createRequest('POST');
+        const options = createJwtOptions({
+          cookie: true,
+          csrf: false
+        });
+        const actual = shouldVerifyCsrfToken(request, options);
+        const expected = false;
+
+        strictEqual(actual, expected);
+      }).timeout(5000);
+    });
+  });
+});

--- a/packages/jwt/src/http/utils/should-verify-csrf-token.ts
+++ b/packages/jwt/src/http/utils/should-verify-csrf-token.ts
@@ -1,0 +1,10 @@
+import { Config, Context } from '@foal/core';
+import { JWTOptions } from '../jwt.hook';
+
+export function shouldVerifyCsrfToken(request: Context['request'], options: JWTOptions): boolean {
+  return (
+    options.cookie === true &&
+    (options.csrf ?? Config.get('settings.jwt.csrf.enabled', 'boolean', false)) &&
+    [ 'DELETE', 'PATCH', 'POST', 'PUT' ].includes(request.method)
+  );
+}


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

The `@UseSessions` and `@JWT` hooks do too much stuff and so the tests are difficult to maintain and modify.

# Solution and steps

- [x] Add a `getCsrfTokenFromCookie` util to externalize this part.
- [x] Add a `shouldVerifyCsrfToken` util to externalize this part.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
