### PR TITLE
Feature/MongoDB Session Functions

### DIFF
--- a/docs/docs/authentication-and-access-control/session-tokens.md
+++ b/docs/docs/authentication-and-access-control/session-tokens.md
@@ -715,24 +715,29 @@ foal run revoke-all-sessions
 
 ### Query All Sessions of a User
 
-> *This feature is only available with the TypeORM store.*
+The `getSessionIDsOf` function returns an array of all session ID's of a user.
 
 ```typescript
 const user = { id: 1 };
 const ids = await store.getSessionIDsOf(user);
 ```
 
-### Query All Connected Users
+The `getSessionsOf` function returns an array of all complete session objects of a user.
 
-> *This feature is only available with the TypeORM store.*
+> *This feature is only available with the MongoDB store.*
+
+```typescript
+const user = { id: '507f1f77bcf86cd799439011' };
+const sessions = await store.getSessionsOf(user);
+```
+
+### Query All Connected Users
 
 ```typescript
 const ids = await store.getAuthenticatedUserIds();
 ```
 
 ### Force the Disconnection of a User
-
-> *This feature is only available with the TypeORM store.*
 
 ```typescript
 const user = { id: 1 };

--- a/packages/mongodb/src/mongodb-store.service.spec.ts
+++ b/packages/mongodb/src/mongodb-store.service.spec.ts
@@ -454,6 +454,59 @@ describe('MongoDBStore', () => {
 
     });
 
+    describe('has a "getAuthenticatedUserIds" method that', () => {
+
+      beforeEach(async () => {
+        await createSessionTestData();
+      });
+
+      it('should return all distinct user ids', async () => {
+        const sessions = await store.getAuthenticatedUserIds();
+
+        strictEqual(sessions.length, 2);
+        strictEqual(sessions[0], '1234');
+        strictEqual(sessions[1], 'asdf');
+      });
+
+    });
+
+    describe('has a "destroyAllSessionsOf" method that', () => {
+
+      beforeEach(async () => {
+        await createSessionTestData();
+      });
+
+      it('should destroy all sessions of a user', async () => {
+        const user = { id: 'asdf' };
+        await store.destroyAllSessionsOf(user);
+        const sessions = await store.getSessionsOf(user);
+
+        strictEqual(sessions.length, 0);
+
+        const user2 = { id: '1234' };
+        const sessions2 = await store.getSessionsOf(user2);
+
+        strictEqual(sessions2.length, 1);
+        strictEqual(sessions2[0].sessionID, 'xxx');
+      });
+
+      it('should destroy all sessions of another user', async () => {
+        const user = { id: '1234' };
+        await store.destroyAllSessionsOf(user);
+        const sessions = await store.getSessionsOf(user);
+
+        strictEqual(sessions.length, 0);
+
+        const user2 = { id: 'asdf' };
+        const sessions2 = await store.getSessionsOf(user2);
+
+        strictEqual(sessions2.length, 2);
+        strictEqual(sessions2[0].sessionID, 'yyy');
+        strictEqual(sessions2[1].sessionID, 'zzz');
+      });
+
+    });
+
     describe('has a "getSessionsOf" method that', () => {
 
       beforeEach(async () => {
@@ -514,22 +567,6 @@ describe('MongoDBStore', () => {
         const sessions = await store.getSessionIDsOf(user);
 
         strictEqual(sessions.length, 0);
-      });
-
-    });
-
-    describe('has a "getAuthenticatedUserIds" method that', () => {
-
-      beforeEach(async () => {
-        await createSessionTestData();
-      });
-
-      it('should return all distinct user ids', async () => {
-        const sessions = await store.getAuthenticatedUserIds();
-
-        strictEqual(sessions.length, 2);
-        strictEqual(sessions[0], '1234');
-        strictEqual(sessions[1], 'asdf');
       });
 
     });

--- a/packages/mongodb/src/mongodb-store.service.spec.ts
+++ b/packages/mongodb/src/mongodb-store.service.spec.ts
@@ -427,6 +427,118 @@ describe('MongoDBStore', () => {
 
     });
 
+    describe('has a "getSessionsOf" method that', () => {
+
+      beforeEach(async () => {
+
+        const states: SessionState[] = [
+          {
+            ...createState(),
+            id: 'xxx',
+            userId: '1234'
+          },
+          {
+            ...createState(),
+            id: 'yyy',
+            userId: 'asdf'
+          },
+          {
+            ...createState(),
+            id: 'zzz',
+            userId: 'asdf'
+          },
+        ];
+
+        for (const state of states) {
+          await insertSessionIntoDB({
+            sessionID: state.id,
+            state,
+          });
+        }
+      });
+
+      it('should return all sessions of first user', async () => {
+        const user = { id: 'asdf' }
+        const sessions = await store.getSessionsOf(user);
+
+        strictEqual(sessions.length, 2)
+        strictEqual(sessions[0].sessionID, 'yyy')
+        strictEqual(sessions[1].sessionID, 'zzz')
+      });
+
+      it('should return all sessions of second user', async () => {
+        const user = { id: '1234' }
+        const sessions = await store.getSessionsOf(user);
+
+        strictEqual(sessions.length, 1)
+        strictEqual(sessions[0].sessionID, 'xxx')
+      });
+
+      it('should return no sessions for not existing id', async () => {
+        const user = { id: '1234567890' }
+        const sessions = await store.getSessionsOf(user);
+
+        strictEqual(sessions.length, 0)
+      });
+
+    });
+
+    describe('has a "getSessionIDsOf" method that',  () => {
+
+      beforeEach(async () => {
+
+        const states: SessionState[] = [
+          {
+            ...createState(),
+            id: 'xxx',
+            userId: '1234'
+          },
+          {
+            ...createState(),
+            id: 'yyy',
+            userId: 'asdf'
+          },
+          {
+            ...createState(),
+            id: 'zzz',
+            userId: 'asdf'
+          },
+        ];
+
+        for (const state of states) {
+          await insertSessionIntoDB({
+            sessionID: state.id,
+            state,
+          });
+        }
+      });
+
+      it('should return all session ids of first user', async () => {
+        const user = { id: 'asdf' }
+        const sessions = await store.getSessionIDsOf(user);
+
+        strictEqual(sessions.length, 2)
+        strictEqual(sessions[0], 'yyy')
+        strictEqual(sessions[1], 'zzz')
+      });
+
+      it('should return all session ids of second user', async () => {
+        const user = { id: '1234' }
+        const sessions = await store.getSessionIDsOf(user);
+
+        strictEqual(sessions.length, 1)
+        strictEqual(sessions[0], 'xxx')
+      });
+
+      it('should return no session ids for not existing id', async () => {
+        const user = { id: '1234567890' }
+        const sessions = await store.getSessionIDsOf(user);
+
+        strictEqual(sessions.length, 0)
+      });
+
+    });
+
   });
 
 });

--- a/packages/mongodb/src/mongodb-store.service.spec.ts
+++ b/packages/mongodb/src/mongodb-store.service.spec.ts
@@ -161,6 +161,33 @@ describe('MongoDBStore', () => {
       return session;
     }
 
+    async function createSessionTestData(): Promise<void> {
+      const states: SessionState[] = [
+        {
+          ...createState(),
+          id: 'xxx',
+          userId: '1234'
+        },
+        {
+          ...createState(),
+          id: 'yyy',
+          userId: 'asdf'
+        },
+        {
+          ...createState(),
+          id: 'zzz',
+          userId: 'asdf'
+        },
+      ];
+
+      for (const state of states) {
+        await insertSessionIntoDB({
+          sessionID: state.id,
+          state,
+        });
+      }
+    }
+
     it('should support sessions IDs of length 44.', async () => {
       const session = await createSession({} as any);
       const id = session.getToken();
@@ -430,111 +457,79 @@ describe('MongoDBStore', () => {
     describe('has a "getSessionsOf" method that', () => {
 
       beforeEach(async () => {
-
-        const states: SessionState[] = [
-          {
-            ...createState(),
-            id: 'xxx',
-            userId: '1234'
-          },
-          {
-            ...createState(),
-            id: 'yyy',
-            userId: 'asdf'
-          },
-          {
-            ...createState(),
-            id: 'zzz',
-            userId: 'asdf'
-          },
-        ];
-
-        for (const state of states) {
-          await insertSessionIntoDB({
-            sessionID: state.id,
-            state,
-          });
-        }
+        await createSessionTestData();
       });
 
       it('should return all sessions of first user', async () => {
-        const user = { id: 'asdf' }
+        const user = { id: 'asdf' };
         const sessions = await store.getSessionsOf(user);
 
-        strictEqual(sessions.length, 2)
-        strictEqual(sessions[0].sessionID, 'yyy')
-        strictEqual(sessions[1].sessionID, 'zzz')
+        strictEqual(sessions.length, 2);
+        strictEqual(sessions[0].sessionID, 'yyy');
+        strictEqual(sessions[1].sessionID, 'zzz');
       });
 
       it('should return all sessions of second user', async () => {
-        const user = { id: '1234' }
+        const user = { id: '1234' };
         const sessions = await store.getSessionsOf(user);
 
-        strictEqual(sessions.length, 1)
-        strictEqual(sessions[0].sessionID, 'xxx')
+        strictEqual(sessions.length, 1);
+        strictEqual(sessions[0].sessionID, 'xxx');
       });
 
       it('should return no sessions for not existing id', async () => {
-        const user = { id: '1234567890' }
+        const user = { id: '1234567890' };
         const sessions = await store.getSessionsOf(user);
 
-        strictEqual(sessions.length, 0)
+        strictEqual(sessions.length, 0);
       });
 
     });
 
-    describe('has a "getSessionIDsOf" method that',  () => {
+    describe('has a "getSessionIDsOf" method that', () => {
 
       beforeEach(async () => {
-
-        const states: SessionState[] = [
-          {
-            ...createState(),
-            id: 'xxx',
-            userId: '1234'
-          },
-          {
-            ...createState(),
-            id: 'yyy',
-            userId: 'asdf'
-          },
-          {
-            ...createState(),
-            id: 'zzz',
-            userId: 'asdf'
-          },
-        ];
-
-        for (const state of states) {
-          await insertSessionIntoDB({
-            sessionID: state.id,
-            state,
-          });
-        }
+        await createSessionTestData();
       });
 
       it('should return all session ids of first user', async () => {
-        const user = { id: 'asdf' }
+        const user = { id: 'asdf' };
         const sessions = await store.getSessionIDsOf(user);
 
-        strictEqual(sessions.length, 2)
-        strictEqual(sessions[0], 'yyy')
-        strictEqual(sessions[1], 'zzz')
+        strictEqual(sessions.length, 2);
+        strictEqual(sessions[0], 'yyy');
+        strictEqual(sessions[1], 'zzz');
       });
 
       it('should return all session ids of second user', async () => {
-        const user = { id: '1234' }
+        const user = { id: '1234' };
         const sessions = await store.getSessionIDsOf(user);
 
-        strictEqual(sessions.length, 1)
-        strictEqual(sessions[0], 'xxx')
+        strictEqual(sessions.length, 1);
+        strictEqual(sessions[0], 'xxx');
       });
 
       it('should return no session ids for not existing id', async () => {
         const user = { id: '1234567890' }
         const sessions = await store.getSessionIDsOf(user);
 
-        strictEqual(sessions.length, 0)
+        strictEqual(sessions.length, 0);
+      });
+
+    });
+
+    describe('has a "getAuthenticatedUserIds" method that', () => {
+
+      beforeEach(async () => {
+        await createSessionTestData();
+      });
+
+      it('should return all distinct user ids', async () => {
+        const sessions = await store.getAuthenticatedUserIds();
+
+        strictEqual(sessions.length, 2);
+        strictEqual(sessions[0], '1234');
+        strictEqual(sessions[1], 'asdf');
       });
 
     });

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -129,4 +129,13 @@ export class MongoDBStore extends SessionStore {
     return sessions.map((dbSession: { sessionID: string; }) => dbSession.sessionID);
   }
 
+  /**
+   * Returns all distinct session user id's.
+   */
+  async getAuthenticatedUserIds(): Promise<string[]> {
+    return await this.collection.distinct('state.userId', {
+      'state.userId': { $ne: null }
+    });
+  }
+
 }

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -51,7 +51,7 @@ export class MongoDBStore extends SessionStore {
   }
 
   async read(id: string): Promise<SessionState | null> {
-    const session: DatabaseSession | null = await this.collection.findOne({ sessionID: id });
+    const session: DatabaseSession|null = await this.collection.findOne({ sessionID: id });
     if (session === null) {
       return session;
     }

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -107,16 +107,26 @@ export class MongoDBStore extends SessionStore {
   async getSessionsOf(user: { id: string }): Promise<DatabaseSession[]> {
     return await this.collection.find({
       'state.userId': user.id.toString()
-    }).toArray()
+    }).toArray();
   }
 
   /**
    * Returns all session id's of a user.
+   *
    * @param user
    */
-  async getSessionIDsOf(user:{ id: string }): Promise<string[]> {
-    const sessions = await this.getSessionsOf(user)
-    return sessions.map((dbSession: { sessionID: string; }) => dbSession.sessionID)
+  async getSessionIDsOf(user: { id: string }): Promise<string[]> {
+    const sessions = await this.collection.find(
+      {
+        'state.userId': user.id.toString()
+      },
+      {
+        projection: {
+          _id: 0,
+          sessionID: 1
+        }
+      }).toArray();
+    return sessions.map((dbSession: { sessionID: string; }) => dbSession.sessionID);
   }
 
 }

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -51,7 +51,7 @@ export class MongoDBStore extends SessionStore {
   }
 
   async read(id: string): Promise<SessionState | null> {
-    const session: DatabaseSession|null = await this.collection.findOne({ sessionID: id });
+    const session: DatabaseSession | null = await this.collection.findOne({ sessionID: id });
     if (session === null) {
       return session;
     }
@@ -91,12 +91,21 @@ export class MongoDBStore extends SessionStore {
   }
 
   /**
-   * Closes the connection to the database.
-   *
-   * @memberof MongoDBStore
+   * Returns all distinct session user id's.
    */
-  async close(): Promise<void> {
-    await this.mongoDBClient.close();
+  async getAuthenticatedUserIds(): Promise<string[]> {
+    return await this.collection.distinct('state.userId', {
+      'state.userId': { $ne: null }
+    });
+  }
+
+  /**
+   * Destroys all sessions of a user.
+   *
+   * @param user
+   */
+  async destroyAllSessionsOf(user: { id: string }): Promise<void> {
+    await this.collection.deleteMany({ 'state.userId': user.id.toString() });
   }
 
   /**
@@ -130,12 +139,12 @@ export class MongoDBStore extends SessionStore {
   }
 
   /**
-   * Returns all distinct session user id's.
+   * Closes the connection to the database.
+   *
+   * @memberof MongoDBStore
    */
-  async getAuthenticatedUserIds(): Promise<string[]> {
-    return await this.collection.distinct('state.userId', {
-      'state.userId': { $ne: null }
-    });
+  async close(): Promise<void> {
+    await this.mongoDBClient.close();
   }
 
 }

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -99,4 +99,16 @@ export class MongoDBStore extends SessionStore {
     await this.mongoDBClient.close();
   }
 
+  async getSessionsOf(user: { id: string }): Promise<DatabaseSession[]> {
+    // TODO: Clear expired Sessions?
+    return await this.collection.find({
+      'state.userId': user.id.toString()
+    }).toArray()
+  }
+
+  async getSessionIDsOf(user:{ id: string }): Promise<string[]> {
+    const sessions = await this.getSessionsOf(user)
+    return sessions.map((dbSession: { sessionID: string; }) => dbSession.sessionID)
+  }
+
 }

--- a/packages/mongodb/src/mongodb-store.service.ts
+++ b/packages/mongodb/src/mongodb-store.service.ts
@@ -99,13 +99,21 @@ export class MongoDBStore extends SessionStore {
     await this.mongoDBClient.close();
   }
 
+  /**
+   * Returns all sessions of a user.
+   *
+   * @param user
+   */
   async getSessionsOf(user: { id: string }): Promise<DatabaseSession[]> {
-    // TODO: Clear expired Sessions?
     return await this.collection.find({
       'state.userId': user.id.toString()
     }).toArray()
   }
 
+  /**
+   * Returns all session id's of a user.
+   * @param user
+   */
   async getSessionIDsOf(user:{ id: string }): Promise<string[]> {
     const sessions = await this.getSessionsOf(user)
     return sessions.map((dbSession: { sessionID: string; }) => dbSession.sessionID)


### PR DESCRIPTION
# Issue

The MongoDB session store service is missing some functions, which we needed in a past project. In that, we were using FoalTS with MongoDB, and we extended those functionalities. This PR is supposed to contribute them back.

# Solution and steps

- [x] Add **getSessionIDsOf** function
- [x] Add **getSessionsOf** function (a new one which returns all whole session objects for a user)
- [x] Add **getAuthenticatedUserIds** function
- [x] Add **destroyAllSessionsOf** function

# Checklist

- [x] Add function docs
- [x] Add tests
- [x] Update foal docs [Session Tokens](https://foalts.org/docs/authentication-and-access-control/session-tokens) ("*This feature is only available with the TypeORM store.*" comments)
