### PR TITLE
Revert dependency change in @foal/social

### DIFF
--- a/packages/social/package-lock.json
+++ b/packages/social/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.10.2",
       "license": "MIT",
       "dependencies": {
-        "axios": "0.26.1"
+        "node-fetch": "~2.6.7"
       },
       "devDependencies": {
         "@types/mocha": "9.1.1",
@@ -221,14 +221,6 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
-    },
-    "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
-      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -709,25 +701,6 @@
       "dev": true,
       "bin": {
         "flat": "cli.js"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/fs-exists-sync": {
@@ -1418,6 +1391,25 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1820,6 +1812,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/ts-node": {
       "version": "10.8.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
@@ -1918,6 +1915,20 @@
       },
       "engines": {
         "node": ">= 0.9"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -2286,14 +2297,6 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
-    },
-    "axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "requires": {
-        "follow-redirects": "^1.14.8"
-      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -2664,11 +2667,6 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true
-    },
-    "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "fs-exists-sync": {
       "version": "0.1.0",
@@ -3213,6 +3211,14 @@
       "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3521,6 +3527,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "ts-node": {
       "version": "10.8.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
@@ -3583,6 +3594,20 @@
         "clone": "^1.0.0",
         "clone-stats": "^0.0.1",
         "replace-ext": "0.0.1"
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@foal/core": "^2.10.2",
-    "axios": "0.26.1"
+    "node-fetch": "~2.6.7"
   },
   "devDependencies": {
     "@types/mocha": "9.1.1",

--- a/packages/social/src/abstract-provider.service.ts
+++ b/packages/social/src/abstract-provider.service.ts
@@ -4,7 +4,7 @@ import * as crypto from 'crypto';
 
 // 3p
 import { Config, Context, generateToken, HttpResponseRedirect, convertBase64ToBase64url } from '@foal/core';
-import axios from 'axios';
+import * as fetch from 'node-fetch';
 
 /**
  * Tokens returned by an OAuth2 authorization server.
@@ -352,14 +352,18 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
       headers.Authorization = `Basic ${auth}`;
     }
 
-    try {
-      const response = await axios.post(this.tokenEndpoint, params, {
-        headers,
-      });
-      return response.data;
-    } catch (error: any) {
-      throw new TokenError(error.response.data);
+    const response = await fetch(this.tokenEndpoint, {
+      body: params,
+      headers,
+      method: 'POST',
+    });
+    const body = await response.json();
+
+    if (!response.ok) {
+      throw new TokenError(body);
     }
+
+    return body;
   }
 
   /**

--- a/packages/social/src/facebook-provider.service.ts
+++ b/packages/social/src/facebook-provider.service.ts
@@ -2,7 +2,7 @@
 import { URL } from 'url';
 
 // 3p
-import axios from 'axios';
+import * as fetch from 'node-fetch';
 
 // FoalTS
 import { AbstractProvider, SocialTokens } from './abstract-provider.service';
@@ -44,12 +44,14 @@ export class FacebookProvider extends AbstractProvider<FacebookAuthParams, Faceb
     const fields = params && params.fields ? params.fields : this.fields;
     url.searchParams.set('fields', fields.join(','));
 
-    try {
-      const response = await axios.get(url.href);
-      return response.data;
-    } catch (error: any) {
-      throw new UserInfoError(error.response.data);
+    const response = await fetch(url.href);
+    const body = await response.json();
+
+    if (!response.ok) {
+      throw new UserInfoError(body);
     }
+
+    return body;
   }
 
 }

--- a/packages/social/src/github-provider.service.ts
+++ b/packages/social/src/github-provider.service.ts
@@ -1,5 +1,5 @@
 // 3p
-import axios from 'axios';
+import * as fetch from 'node-fetch';
 
 // FoalTS
 import { AbstractProvider, SocialTokens } from './abstract-provider.service';
@@ -28,14 +28,16 @@ export class GithubProvider extends AbstractProvider<GithubAuthParams, never> {
   protected userInfoEndpoint = 'https://api.github.com/user';
 
   async getUserInfoFromTokens(tokens: SocialTokens) {
-    try {
-      const response = await axios.get(this.userInfoEndpoint, {
-        headers: { Authorization: `token ${tokens.access_token}` }
-      });
-      return response.data;
-    } catch (error: any) {
-      throw new UserInfoError(error.response.data);
+    const response = await fetch(this.userInfoEndpoint, {
+      headers: { Authorization: `token ${tokens.access_token}` }
+    });
+    const body = await response.json();
+
+    if (!response.ok) {
+      throw new UserInfoError(body);
     }
+
+    return body;
   }
 
 }

--- a/packages/social/src/linkedin-provider.service.ts
+++ b/packages/social/src/linkedin-provider.service.ts
@@ -2,7 +2,7 @@
 import { URL } from 'url';
 
 // 3p
-import axios from 'axios';
+import * as fetch from 'node-fetch';
 
 // FoalTS
 import { AbstractProvider, SocialTokens } from './abstract-provider.service';
@@ -43,14 +43,16 @@ export class LinkedInProvider extends AbstractProvider<never, LinkedInUserInfoPa
       url.searchParams.set('fields', params.fields.join(','));
     }
 
-    try {
-      const response = await axios.get(url.href, {
-        headers: { Authorization: `Bearer ${tokens.access_token}` }
-      });
-      return response.data;
-    } catch (error: any) {
-      throw new UserInfoError(error.response.data);
+    const response = await fetch(url.href, {
+      headers: { Authorization: `Bearer ${tokens.access_token}` }
+    });
+    const body = await response.json();
+
+    if (!response.ok) {
+      throw new UserInfoError(body);
     }
+
+    return body;
   }
 
 }

--- a/packages/social/src/twitter-provider.service.ts
+++ b/packages/social/src/twitter-provider.service.ts
@@ -1,5 +1,5 @@
 // 3p
-import axios from 'axios';
+import * as fetch from 'node-fetch';
 
 // FoalTS
 import { AbstractProvider, SocialTokens } from './abstract-provider.service';
@@ -31,13 +31,15 @@ export class TwitterProvider extends AbstractProvider<TwitterAuthParameter, neve
   protected defaultScopes: string[] = [ 'users.read', 'tweet.read' ];
 
   async getUserInfoFromTokens(tokens: SocialTokens) {
-    try {
-      const response = await axios.get(this.userInfoEndpoint, {
-        headers: { Authorization: `${tokens.token_type} ${tokens.access_token}` }
-      });
-      return response.data;
-    } catch (error: any) {
-      throw new UserInfoError(error.response.data);
+    const response = await fetch(this.userInfoEndpoint, {
+      headers: { Authorization: `${tokens.token_type} ${tokens.access_token}` }
+    });
+    const body = await response.json();
+
+    if (!response.ok) {
+      throw new UserInfoError(body);
     }
+
+    return body;
   }
 }

--- a/packages/social/typings/node-fetch/index.d.ts
+++ b/packages/social/typings/node-fetch/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'node-fetch';


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

In v3, we changed the `node-fetch` dependency to `axios` in `@foal/social` (#1056). The reason behind this is that we couldn't upgrade `node-fetch` to `node-fetch@3` because it was requiring ES modules.

Since `fetch` is available since Node 18, we will just remove the dependency when the support of Node 16 is dropped in Foal. In this way, we don't need to change anything in the package for now and so we don't need to do a manual test before releasing v3.

# Solution and steps

- [x] Revert dependency change in `@foal/social`

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
