### PR TITLE
Homogenize `getSessionIDsOf` and `destroyAllSessionsOf` methods of all stores

### DIFF
--- a/docs/docs/authentication-and-access-control/session-tokens.md
+++ b/docs/docs/authentication-and-access-control/session-tokens.md
@@ -718,7 +718,7 @@ foal run revoke-all-sessions
 
 ```typescript
 const user = { id: 1 };
-const ids = await store.getSessionIDsOf(user);
+const ids = await store.getSessionIDsOf(user.id);
 ```
 
 ### Query All Connected Users
@@ -735,7 +735,7 @@ const ids = await store.getAuthenticatedUserIds();
 
 ```typescript
 const user = { id: 1 };
-await store.destroyAllSessionsOf(user);
+await store.destroyAllSessionsOf(user.id);
 ```
 
 ### Re-generate the Session ID

--- a/docs/docs/upgrade-to-v3/README.md
+++ b/docs/docs/upgrade-to-v3/README.md
@@ -240,6 +240,7 @@ Here are the breaking changes and new features:
     }
     ```
 - If you need to create a connection in your tests (E2E or unit), import `createDataSource` from `db.ts` and initialize the connection. 
+- If you use the methods `TypeORMStore.getSessionIDsOf` and `TypeORMStore.destroyAllSessionsOf`, they take the user ID as parameter and no longer the user object.
 - The complete migration guide to `typeorm@0.3` can be found [here](https://github.com/typeorm/typeorm/releases/tag/0.3.0).
 
 *Quick migration guide*

--- a/packages/typeorm/src/typeorm-store.service.spec.ts
+++ b/packages/typeorm/src/typeorm-store.service.spec.ts
@@ -609,7 +609,7 @@ function storeTestSuite(type: DBType) {
 
       it('destroy all the sessions of the given user.', async () => {
         const user = { id: 2 };
-        await store.destroyAllSessionsOf(user);
+        await store.destroyAllSessionsOf(user.id);
 
         const sessions = await dataSource.getRepository(DatabaseSession).find();
         strictEqual(sessions.length, 2);
@@ -661,13 +661,13 @@ function storeTestSuite(type: DBType) {
 
       it('should return an empty array if the user ID does not match any users.', async () => {
         const user = { id: 0 };
-        const sessions = await store.getSessionIDsOf(user);
+        const sessions = await store.getSessionIDsOf(user.id);
         strictEqual(sessions.length, 0);
       });
 
       it('should return the IDs of the sessions associated with the given user.', async () => {
         const user = { id: 2 };
-        const sessions = await store.getSessionIDsOf(user);
+        const sessions = await store.getSessionIDsOf(user.id);
         strictEqual(sessions.length, 2);
 
         strictEqual(sessions[0], 'c');

--- a/packages/typeorm/src/typeorm-store.service.ts
+++ b/packages/typeorm/src/typeorm-store.service.ts
@@ -144,15 +144,15 @@ export class TypeORMStore extends SessionStore {
     return sessions.map(({ user_id }) => user_id);
   }
 
-  async destroyAllSessionsOf(user: { id: number }): Promise<void> {
-    await this.repository.delete({ user_id: user.id });
+  async destroyAllSessionsOf(userId: number): Promise<void> {
+    await this.repository.delete({ user_id: userId });
   }
 
-  async getSessionIDsOf(user: { id: number }): Promise<string[]> {
+  async getSessionIDsOf(userId: number): Promise<string[]> {
     const databaseSessions = await this.repository.find({
       // Do not select unused fields.
       select: { id: true },
-      where: { user_id: user.id },
+      where: { user_id: userId },
     });
     return databaseSessions.map(dbSession => dbSession.id);
   }


### PR DESCRIPTION
# Issue

There is a pending PR (#1142) that will add the same methods for MongoDB. As in Mongo, there might be two IDs (`_id` an d `id`), it becomes complicated to pass the user object. 

# Solution and steps

- Make `TypeORMStore.getSessionIDsOf` and `TypeORMStore.destroyAllSessionsOf` the user ID as parameter.

# Breaking changes

- `TypeORMStore.getSessionIDsOf` and `TypeORMStore.destroyAllSessionsOf` no longer take the user object as parameter but the user ID.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
