### PR TITLE
Make GraphQLController with new version of GraphiQL

### DIFF
--- a/docs/docs/api-section/graphql.md
+++ b/docs/docs/api-section/graphql.md
@@ -34,21 +34,6 @@ npm install graphql@15 @foal/graphql
 npm install graphql@14 @foal/graphql
 ```
 
-Due to a specificity of the `graphql` library, you must also modify your `tsconfig.json` as follows:
-
-```json
-{
-  "compilerOptions": {
-    ...
-    "lib": [
-      ...
-      "ESNext.AsyncIterable"
-    ]
-  }
-  ...
-}
-```
-
 ## Basic Usage
 
 The main component of the package is the abstract `GraphQLController`. Inheriting this class allows you to create a controller that is compatible with common GraphQL clients ([graphql-request](https://www.npmjs.com/package/graphql-request), [Apollo Client](https://www.apollographql.com/docs/react/), etc) or any client that follows the HTTP specification defined [here](https://graphql.org/learn/serving-over-http/).

--- a/packages/graphql/src/graphql.controller.ts
+++ b/packages/graphql/src/graphql.controller.ts
@@ -15,7 +15,7 @@ const getQuerySchema = {
 
 const postBodySchema = {
   properties: {
-    operationName: { type: 'string' },
+    operationName: { type: 'string', nullable: true },
     query: { type: 'string' },
     variables: { type: ['object', 'null'] },
   },


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

In new version of GraphiQL, if the operation name is not defined, the browser stills send a `operationName` property with `null` as value. This case is not supported and the server responds with a 400 status.

# Solution and steps

- [x] Allow `null` values

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
