### PR TITLE
Changed max-age of Strict-Transport-Security header

### DIFF
--- a/docs/docs/cookbook/limit-repeated-requests.md
+++ b/docs/docs/cookbook/limit-repeated-requests.md
@@ -35,7 +35,7 @@ async function main() {
       res.setHeader('X-Content-Type-Options', 'nosniff');
       res.setHeader('X-Frame-Options', 'SAMEORIGIN');
       res.setHeader('X-XSS-Protection', '1; mode=block');
-      res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+      res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
       
       // Send the response with the default statusCode and message from rateLimit
       res.status(this.statusCode || 429).send(this.message);
@@ -66,7 +66,7 @@ expressApp.use(rateLimit({
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('X-Frame-Options', 'SAMEORIGIN');
     res.setHeader('X-XSS-Protection', '1; mode=block');
-    res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+    res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 
     // Set CORS headers
     res.setHeader('Access-Control-Allow-Origin', '*');

--- a/docs/docs/security/http-headers-protection.md
+++ b/docs/docs/security/http-headers-protection.md
@@ -9,7 +9,7 @@ To protect the application against some (!) common attacks, FoalTS sets by defau
 
 | Header name | Value |
 | --- | --- |
-| `Strict-Transport-Security` | `max-age=15552000; includeSubDomains` |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |
 | `X-Content-Type-Options` | `nosniff` |
 | `X-Frame-Options` | `SAMEORIGIN` |
 | `X-XSS-Protection` | `1; mode=block` |

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/cookbook/limit-repeated-requests.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/cookbook/limit-repeated-requests.md
@@ -35,7 +35,7 @@ async function main() {
       res.setHeader('X-Content-Type-Options', 'nosniff');
       res.setHeader('X-Frame-Options', 'SAMEORIGIN');
       res.setHeader('X-XSS-Protection', '1; mode=block');
-      res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+      res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
       
       // Send the response with the default statusCode and message from rateLimit
       res.status(this.statusCode || 429).send(this.message);
@@ -66,7 +66,7 @@ expressApp.use(rateLimit({
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('X-Frame-Options', 'SAMEORIGIN');
     res.setHeader('X-XSS-Protection', '1; mode=block');
-    res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+    res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 
     // Set CORS headers
     res.setHeader('Access-Control-Allow-Origin', '*');

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/security/http-headers-protection.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/security/http-headers-protection.md
@@ -9,7 +9,7 @@ To protect the application against some (!) common attacks, FoalTS sets by defau
 
 | Header name | Value |
 | --- | --- |
-| `Strict-Transport-Security` | `max-age=15552000; includeSubDomains` |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |
 | `X-Content-Type-Options` | `nosniff` |
 | `X-Frame-Options` | `SAMEORIGIN` |
 | `X-XSS-Protection` | `1; mode=block` |

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/cookbook/limit-repeated-requests.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/cookbook/limit-repeated-requests.md
@@ -35,7 +35,7 @@ async function main() {
       res.setHeader('X-Content-Type-Options', 'nosniff');
       res.setHeader('X-Frame-Options', 'SAMEORIGIN');
       res.setHeader('X-XSS-Protection', '1; mode=block');
-      res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+      res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
       
       // Send the response with the default statusCode and message from rateLimit
       res.status(this.statusCode || 429).send(this.message);
@@ -66,7 +66,7 @@ expressApp.use(rateLimit({
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('X-Frame-Options', 'SAMEORIGIN');
     res.setHeader('X-XSS-Protection', '1; mode=block');
-    res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+    res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 
     // Set CORS headers
     res.setHeader('Access-Control-Allow-Origin', '*');

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/security/http-headers-protection.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/security/http-headers-protection.md
@@ -9,7 +9,7 @@ To protect the application against some (!) common attacks, FoalTS sets by defau
 
 | Header name | Value |
 | --- | --- |
-| `Strict-Transport-Security` | `max-age=15552000; includeSubDomains` |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |
 | `X-Content-Type-Options` | `nosniff` |
 | `X-Frame-Options` | `SAMEORIGIN` |
 | `X-XSS-Protection` | `1; mode=block` |

--- a/docs/i18n/id/docusaurus-plugin-content-docs/current/cookbook/limit-repeated-requests.md
+++ b/docs/i18n/id/docusaurus-plugin-content-docs/current/cookbook/limit-repeated-requests.md
@@ -35,7 +35,7 @@ async function main() {
       res.setHeader('X-Content-Type-Options', 'nosniff');
       res.setHeader('X-Frame-Options', 'SAMEORIGIN');
       res.setHeader('X-XSS-Protection', '1; mode=block');
-      res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+      res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
       
       // Send the response with the default statusCode and message from rateLimit
       res.status(this.statusCode || 429).send(this.message);
@@ -66,7 +66,7 @@ expressApp.use(rateLimit({
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('X-Frame-Options', 'SAMEORIGIN');
     res.setHeader('X-XSS-Protection', '1; mode=block');
-    res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+    res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 
     // Set CORS headers
     res.setHeader('Access-Control-Allow-Origin', '*');

--- a/docs/i18n/id/docusaurus-plugin-content-docs/current/security/http-headers-protection.md
+++ b/docs/i18n/id/docusaurus-plugin-content-docs/current/security/http-headers-protection.md
@@ -9,7 +9,7 @@ To protect the application against some (!) common attacks, FoalTS sets by defau
 
 | Header name | Value |
 | --- | --- |
-| `Strict-Transport-Security` | `max-age=15552000; includeSubDomains` |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |
 | `X-Content-Type-Options` | `nosniff` |
 | `X-Frame-Options` | `SAMEORIGIN` |
 | `X-XSS-Protection` | `1; mode=block` |

--- a/docs/versioned_docs/version-1.x/cookbook/limit-repeated-requests.md
+++ b/docs/versioned_docs/version-1.x/cookbook/limit-repeated-requests.md
@@ -37,7 +37,7 @@ async function main() {
       res.setHeader('X-Download-Options', 'noopen');
       res.setHeader('X-Frame-Options', 'SAMEORIGIN');
       res.setHeader('X-XSS-Protection', '1; mode=block');
-      res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+      res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
       
       // Send the response with the default statusCode and message from rateLimit
       res.status(this.statusCode).send(this.message);
@@ -73,7 +73,7 @@ expressApp.use(rateLimit({
     res.setHeader('X-Download-Options', 'noopen');
     res.setHeader('X-Frame-Options', 'SAMEORIGIN');
     res.setHeader('X-XSS-Protection', '1; mode=block');
-    res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+    res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 
     // Set CORS headers
     res.setHeader('Access-Control-Allow-Origin', '*');

--- a/docs/versioned_docs/version-1.x/security/http-headers-protection.md
+++ b/docs/versioned_docs/version-1.x/security/http-headers-protection.md
@@ -8,7 +8,7 @@ To protect the application against some (!) common attacks, FoalTS sets by defau
 
 | Header name | Value |
 | --- | --- |
-| `Strict-Transport-Security` | `max-age=15552000; includeSubDomains` |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |
 | `X-Content-Type-Options` | `nosniff` |
 | `X-DNS-Prefetch-Control` | `off` |
 | `X-Download-Options` | `noopen` |

--- a/packages/acceptance-tests/src/docs/cookbook/limit-repeated-requests.spec.ts
+++ b/packages/acceptance-tests/src/docs/cookbook/limit-repeated-requests.spec.ts
@@ -21,7 +21,7 @@ it('[Docs] Cookbook > Limit Repeated Requests', () => {
         res.setHeader('X-Content-Type-Options', 'nosniff');
         res.setHeader('X-Frame-Options', 'SAMEORIGIN');
         res.setHeader('X-XSS-Protection', '1; mode=block');
-        res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+        res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 
         // Send the response with the default statusCode and message from rateLimit
         res.status(this.statusCode || 429).send(this.message);

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -73,7 +73,7 @@ describe('createApp', () => {
       .expect('X-Content-Type-Options', 'nosniff')
       .expect('X-Frame-Options', 'SAMEORIGIN')
       .expect('X-XSS-Protection', '1; mode=block')
-      .expect('Strict-Transport-Security', 'max-age=15552000; includeSubDomains')
+      .expect('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
       .expect('X-Custom-Header', 'foobar');
   });
 

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -45,7 +45,7 @@ function protectionHeaders(req: any, res: any, next: (err?: any) => any) {
   res.setHeader('X-Content-Type-Options', 'nosniff');
   res.setHeader('X-Frame-Options', 'SAMEORIGIN');
   res.setHeader('X-XSS-Protection', '1; mode=block');
-  res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+  res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
   next();
 }
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Resolves #1146.

max-age in the Strict-Transport-Security header is set to 15552000 (1 year) but this is better set to 31536000 (2 years) according to multiple security best practice sources.

# Solution and steps
Change value from 15552000 to 31536000 across codebase

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [ ] Add/update/check tests.
- [ ] Update/check the cli generators.
