### PR TITLE
Update TypeORM version and fix peer dependency issue

### DIFF
--- a/packages/acceptance-tests/package-lock.json
+++ b/packages/acceptance-tests/package-lock.json
@@ -26,7 +26,7 @@
         "socket.io-client": "~4.5.1",
         "superagent": "~7.1.6",
         "supertest": "~6.2.3",
-        "typeorm": "~0.3.7",
+        "typeorm": "^0.3.10",
         "yamljs": "~0.3.0"
       },
       "devDependencies": {
@@ -3125,9 +3125,9 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.7.tgz",
-      "integrity": "sha512-MsPJeP6Zuwfe64c++l80+VRqpGEGxf0CkztIEnehQ+CMmQPSHjOnFbFxwBuZ2jiLqZTjLk2ZqQdVF0RmvxNF3Q==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.10.tgz",
+      "integrity": "sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==",
       "dependencies": {
         "@sqltools/formatter": "^1.2.2",
         "app-root-path": "^3.0.0",
@@ -5854,9 +5854,9 @@
       }
     },
     "typeorm": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.7.tgz",
-      "integrity": "sha512-MsPJeP6Zuwfe64c++l80+VRqpGEGxf0CkztIEnehQ+CMmQPSHjOnFbFxwBuZ2jiLqZTjLk2ZqQdVF0RmvxNF3Q==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.10.tgz",
+      "integrity": "sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==",
       "requires": {
         "@sqltools/formatter": "^1.2.2",
         "app-root-path": "^3.0.0",

--- a/packages/acceptance-tests/package.json
+++ b/packages/acceptance-tests/package.json
@@ -43,7 +43,7 @@
     "socket.io-client": "~4.5.1",
     "superagent": "~7.1.6",
     "supertest": "~6.2.3",
-    "typeorm": "~0.3.7",
+    "typeorm": "^0.3.10",
     "yamljs": "~0.3.0"
   },
   "devDependencies": {

--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -28,7 +28,7 @@
     "@foal/typeorm": "3.0.0-alpha.0",
     "source-map-support": "~0.5.21",
     "better-sqlite3": "~7.6.2",
-    "typeorm": "0.3.7"
+    "typeorm": "0.3.10"
   },
   "devDependencies": {
     "@foal/cli": "^2.9.0",

--- a/packages/cli/src/generate/specs/app/package.mongodb.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.json
@@ -24,7 +24,7 @@
     "@foal/core": "3.0.0-alpha.0",
     "mongodb": "~3.7.3",
     "source-map-support": "~0.5.21",
-    "typeorm": "0.3.6"
+    "typeorm": "0.3.10"
   },
   "devDependencies": {
     "@foal/cli": "^2.9.0",

--- a/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
@@ -24,7 +24,7 @@
     "@foal/core": "3.0.0-alpha.0",
     "mongodb": "~3.7.3",
     "source-map-support": "~0.5.21",
-    "typeorm": "0.3.6",
+    "typeorm": "0.3.10",
     "yamljs": "~0.3.0"
   },
   "devDependencies": {

--- a/packages/cli/src/generate/specs/app/package.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.yaml.json
@@ -28,7 +28,7 @@
     "@foal/typeorm": "3.0.0-alpha.0",
     "source-map-support": "~0.5.21",
     "better-sqlite3": "~7.5.0",
-    "typeorm": "0.3.6",
+    "typeorm": "0.3.10",
     "yamljs": "~0.3.0"
   },
   "devDependencies": {

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -28,7 +28,7 @@
     "@foal/typeorm": "3.0.0-alpha.0",
     "source-map-support": "~0.5.21",
     "better-sqlite3": "~7.6.2",
-    "typeorm": "0.3.7"
+    "typeorm": "0.3.10"
   },
   "devDependencies": {
     "@foal/cli": "^2.9.0",

--- a/packages/cli/src/generate/templates/app/package.mongodb.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.json
@@ -24,7 +24,7 @@
     "@foal/core": "3.0.0-alpha.0",
     "mongodb": "~3.7.3",
     "source-map-support": "~0.5.21",
-    "typeorm": "0.3.6"
+    "typeorm": "0.3.10"
   },
   "devDependencies": {
     "@foal/cli": "^2.9.0",

--- a/packages/cli/src/generate/templates/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.yaml.json
@@ -24,7 +24,7 @@
     "@foal/core": "3.0.0-alpha.0",
     "mongodb": "~3.7.3",
     "source-map-support": "~0.5.21",
-    "typeorm": "0.3.6",
+    "typeorm": "0.3.10",
     "yamljs": "~0.3.0"
   },
   "devDependencies": {

--- a/packages/cli/src/generate/templates/app/package.yaml.json
+++ b/packages/cli/src/generate/templates/app/package.yaml.json
@@ -28,7 +28,7 @@
     "@foal/typeorm": "3.0.0-alpha.0",
     "source-map-support": "~0.5.21",
     "better-sqlite3": "~7.5.0",
-    "typeorm": "0.3.6",
+    "typeorm": "0.3.10",
     "yamljs": "~0.3.0"
   },
   "devDependencies": {

--- a/packages/examples/package-lock.json
+++ b/packages/examples/package-lock.json
@@ -12,7 +12,7 @@
         "better-sqlite3": "~7.6.2",
         "graphql": "~15.8.0",
         "source-map-support": "~0.5.21",
-        "typeorm": "~0.3.7",
+        "typeorm": "^0.3.10",
         "yamljs": "~0.3.0"
       },
       "devDependencies": {
@@ -2420,9 +2420,9 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.7.tgz",
-      "integrity": "sha512-MsPJeP6Zuwfe64c++l80+VRqpGEGxf0CkztIEnehQ+CMmQPSHjOnFbFxwBuZ2jiLqZTjLk2ZqQdVF0RmvxNF3Q==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.10.tgz",
+      "integrity": "sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==",
       "dependencies": {
         "@sqltools/formatter": "^1.2.2",
         "app-root-path": "^3.0.0",
@@ -4681,9 +4681,9 @@
       }
     },
     "typeorm": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.7.tgz",
-      "integrity": "sha512-MsPJeP6Zuwfe64c++l80+VRqpGEGxf0CkztIEnehQ+CMmQPSHjOnFbFxwBuZ2jiLqZTjLk2ZqQdVF0RmvxNF3Q==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.10.tgz",
+      "integrity": "sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==",
       "requires": {
         "@sqltools/formatter": "^1.2.2",
         "app-root-path": "^3.0.0",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -55,7 +55,7 @@
     "better-sqlite3": "~7.6.2",
     "graphql": "~15.8.0",
     "source-map-support": "~0.5.21",
-    "typeorm": "~0.3.7",
+    "typeorm": "^0.3.10",
     "yamljs": "~0.3.0"
   },
   "devDependencies": {

--- a/packages/typeorm/package-lock.json
+++ b/packages/typeorm/package-lock.json
@@ -18,7 +18,7 @@
         "rimraf": "~3.0.2",
         "sqlite3": "~5.0.10",
         "ts-node": "~10.8.1",
-        "typeorm": "0.3.7",
+        "typeorm": "0.3.10",
         "typescript": "~4.7.4"
       },
       "engines": {
@@ -28,7 +28,7 @@
         "url": "https://github.com/sponsors/LoicPoullain"
       },
       "peerDependencies": {
-        "typeorm": "~0.3.7"
+        "typeorm": "^0.3.10"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -3165,9 +3165,9 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.7.tgz",
-      "integrity": "sha512-MsPJeP6Zuwfe64c++l80+VRqpGEGxf0CkztIEnehQ+CMmQPSHjOnFbFxwBuZ2jiLqZTjLk2ZqQdVF0RmvxNF3Q==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.10.tgz",
+      "integrity": "sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==",
       "dev": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.2",
@@ -6070,9 +6070,9 @@
       }
     },
     "typeorm": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.7.tgz",
-      "integrity": "sha512-MsPJeP6Zuwfe64c++l80+VRqpGEGxf0CkztIEnehQ+CMmQPSHjOnFbFxwBuZ2jiLqZTjLk2ZqQdVF0RmvxNF3Q==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.10.tgz",
+      "integrity": "sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==",
       "dev": true,
       "requires": {
         "@sqltools/formatter": "^1.2.2",

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -51,7 +51,7 @@
     "@foal/core": "^3.0.0-alpha.0"
   },
   "peerDependencies": {
-    "typeorm": "~0.3.7"
+    "typeorm": "^0.3.10"
   },
   "devDependencies": {
     "@types/mocha": "9.1.1",
@@ -63,7 +63,7 @@
     "rimraf": "~3.0.2",
     "sqlite3": "~5.0.10",
     "ts-node": "~10.8.1",
-    "typeorm": "0.3.7",
+    "typeorm": "0.3.10",
     "typescript": "~4.7.4"
   }
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

- The TypeORM dependency needs to be updated (more recent version available)
- They are some inconsistencies between peer dependencies and versions installed by `createapp` causing the npm install to fail.

# Solution and steps

- [x] Use `^` for `0.x` versions
- [x] Upgrade to TypeORM 0.3.10

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
