### PR TITLE
Add empty "Who's using Foal?" page

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -86,7 +86,7 @@ module.exports = {
           dropdownActiveClassDisabled: true,
         },
         // {
-        //   to: 'to-complete',
+        //   to: 'who-is-using-foal',
         //   label: 'Who\'s using Foal?',
         //   position: 'right'
         // },

--- a/docs/src/pages/who-is-using-foal.jsx
+++ b/docs/src/pages/who-is-using-foal.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+
+export default function Newsletter() {
+  return (
+    <Layout
+      description='Who is using Foal'>
+      TO DO
+    </Layout>
+  );
+}


### PR DESCRIPTION
# Issue

See #1165

# Solution and steps

- [x] Add an empty page

<img width="1280" alt="Capture d’écran 2022-10-30 à 09 44 24" src="https://user-images.githubusercontent.com/13604533/198870097-0ef86e34-9059-478c-ab1f-de1e924568e9.png">
