### PR TITLE
docs(update) Fix issue in auth user code example

### DIFF
--- a/docs/docs/tutorials/real-world-example-with-react/9-authenticated-api.md
+++ b/docs/docs/tutorials/real-world-example-with-react/9-authenticated-api.md
@@ -32,7 +32,7 @@ export class StoriesController {
     additionalProperties: false,
   })
   @UserRequired()
-  async createStory(ctx: Context) {
+  async createStory(ctx: Context<User>) {
     const story = new Story();
     story.title = ctx.request.body.title;
     story.link = ctx.request.body.link;


### PR DESCRIPTION
Add casting to prevent build error:
```
stories.controller.ts:47:5 - error TS2322: Type '{ [key: string]: any; } | null' is not assignable to type 'User'.
  Type 'null' is not assignable to type 'User'.

47     story.author = ctx.user;
````


Maybe there is a better way to fix this?

<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

```
$ npm run build

src/app/controllers/api/stories.controller.ts:47:5 - error TS2322: Type '{ [key: string]: any; } | null' is not assignable to type 'User'.
  Type 'null' is not assignable to type 'User'.

47     story.author = ctx.user;
       ~~~~~~~~~~~~

47     story.author = ctx.user;
````

# Solution and steps

Add casting

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).

