### PR TITLE
Remove pm2 to fix CLI failure

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -25,8 +25,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Install pm2
-      run: npm install -g pm2
     - name: Install FoalTS CLI
       run: npm install -g @foal/cli
     - name: Run acceptance tests (Bash)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Use npm version 8.5
       run: npm install -g npm@8.5
-    - name: Install global dependencies (pm2, codecov)
-      run: npm install -g pm2 codecov
+    - name: Install global dependencies (codecov)
+      run: npm install -g codecov
     - name: Install project dependencies
       run: npm install
     - name: Install package dependencies and build packages

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -115,7 +115,7 @@ test_rest_api DELETE "http://localhost:3001/products/1" 204
 test_rest_api DELETE "http://localhost:3001/products/1" 404
 test_rest_api DELETE "http://localhost:3001/products/ab" 400
 
-killall `ps | grep node`
+kill -9 $(ps aux | grep '\snode\s')
 
 # Test the default shell scripts to create users.
 foal run create-user

--- a/e2e_test.sh
+++ b/e2e_test.sh
@@ -41,7 +41,7 @@ npm run start:e2e
 npm run build
 
 # Test the application when it is started
-pm2 start build/index.js
+node build/index.js &
 sleep 1
 response=$(
     curl http://localhost:3001 \
@@ -115,7 +115,7 @@ test_rest_api DELETE "http://localhost:3001/products/1" 204
 test_rest_api DELETE "http://localhost:3001/products/1" 404
 test_rest_api DELETE "http://localhost:3001/products/ab" 400
 
-pm2 delete index
+killall `ps | grep node`
 
 # Test the default shell scripts to create users.
 foal run create-user


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

When using PM2, we get failures in the CI with a "exit code 7". This is not the first time it happens and I don't understand what the issue is.

# Solution and steps

- [x] Remove PM2 and use another solution

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
