### PR TITLE
Adapt generated eslint config to support ctx.session!

### DIFF
--- a/packages/cli/src/generate/specs/app/.eslintrc.js
+++ b/packages/cli/src/generate/specs/app/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
     '@typescript-eslint/no-unsafe-call': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-return': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
   },
   ignorePatterns: [
     'src/migrations/*.ts'

--- a/packages/cli/src/generate/templates/app/.eslintrc.js
+++ b/packages/cli/src/generate/templates/app/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
     '@typescript-eslint/no-unsafe-call': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-return': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
   },
   ignorePatterns: [
     'src/migrations/*.ts'


### PR DESCRIPTION
# Issue

When following the second tutorial, we get an ESLint warning with the IDE on statements such as `ctx.session!`. This PR removes this warning to not confuse people following the tutorial.

# Solution and steps

- [x] Disable config rule `@typescript-eslint/no-non-null-assertion`

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
