### PR TITLE
Support whitespaces around variable names in `.env` files

### DIFF
--- a/packages/core/src/core/config/env.spec.ts
+++ b/packages/core/src/core/config/env.spec.ts
@@ -13,6 +13,7 @@ function removeFile(path: string) {
 
 const dotEnvContent = `HELLO=world
 FOO_BAR=hello
+ FOO_BAR_WITH_WHITESPACES_AROUND_THE_NAME = hello you
 FOO_BAR_WITH_EQUAL=hello=world
 FOO_BAR_WITH_WINDOWS_NEW_LINE=hello new line\r
 # FOO_BAR_COMMENTED=hello commented
@@ -113,6 +114,10 @@ describe('Env', () => {
         it('should return its value.', () => {
           strictEqual(Env.get('FOO_BAR'), 'hello');
         });
+
+        it('should return its value even if there are whitespaces around the variable name.', () => {
+          strictEqual(Env.get('FOO_BAR_WITH_WHITESPACES_AROUND_THE_NAME'), 'hello you');
+        })
 
         it('should return its value (value with an equal).', () => {
           strictEqual(Env.get('FOO_BAR_WITH_EQUAL'), 'hello=world');

--- a/packages/core/src/core/config/env.ts
+++ b/packages/core/src/core/config/env.ts
@@ -51,16 +51,17 @@ export class Env {
 
       const [ key, ...values ] = line.split('=');
       const value = values.join('=').trim();
+      const trimmedKey = key.trim();
 
       if (
         (value.startsWith('"') && value.endsWith('"')) ||
         (value.startsWith('\'') && value.endsWith('\''))
       ) {
-        this.dotEnv[key] = value.substr(1, value.length - 2);
+        this.dotEnv[trimmedKey] = value.substr(1, value.length - 2);
         continue;
       }
 
-      this.dotEnv[key] = value;
+      this.dotEnv[trimmedKey] = value;
     }
   }
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Resolves #1182.

# Solution and steps

- [x] Use `str.trim()`

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
