### PR TITLE
Support custom OpenAPI "example" keyword in AJV validation

### DIFF
--- a/docs/blog/version-3.1-release-notes.md
+++ b/docs/blog/version-3.1-release-notes.md
@@ -24,3 +24,7 @@ settings:
     cookie:
       domain: foalts.org
 ```
+
+## Regression on OpenAPI keyword "example" has been fixed
+
+In version 3.0, using the keyword `example` in an validation object was raising an error. This has been fixed.

--- a/packages/core/src/common/validation/get-ajv-instance.spec.ts
+++ b/packages/core/src/common/validation/get-ajv-instance.spec.ts
@@ -119,6 +119,18 @@ describe('getAjvInstance', () => {
     doesNotThrow(() => getAjvInstance().validate(schema, data));
   });
 
+  it('should support the custom OpenAPI keyword "example".', () => {
+    const schema = {
+      properties: {
+        name: { type: 'string', example: 'My Organization Name' },
+      },
+      type: 'object',
+    };
+    const data = { hello: 'world' };
+
+    doesNotThrow(() => getAjvInstance().validate(schema, data));
+  });
+
   it('should support JSON schema formats for AJV (email, date, etc).', () => {
     const schema = {
       properties: {

--- a/packages/core/src/common/validation/get-ajv-instance.ts
+++ b/packages/core/src/common/validation/get-ajv-instance.ts
@@ -31,6 +31,7 @@ export function getAjvInstance(): Ajv {
       useDefaults: Config.get('settings.ajv.useDefaults', 'boolean|string', true) as boolean|'empty',
     });
     _instanceWrapper.instance.addKeyword({ keyword: 'components' });
+    _instanceWrapper.instance.addKeyword({ keyword: 'example' });
     addFormats(_instanceWrapper.instance);
   }
   return _instanceWrapper.instance;


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Resolves #1192.

# Solution and steps

- [x] Add the support of the keyword in AJV validation instance

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
