### PR TITLE
Upgrade db dependencies for version 4

### DIFF
--- a/docs/docs/authentication/session-tokens.md
+++ b/docs/docs/authentication/session-tokens.md
@@ -1064,26 +1064,14 @@ async function main() {
 #### `MongoDBStore`
 
 ```
-npm install mongodb@4
+npm install mongodb@5
 ```
-
-> The `MongoDBStore` requires version 4 of the [mongodb](https://www.npmjs.com/package/mongodb) package. If you are using TypeORM with MongoDB, which requires version 3, you can have both versions coexist in your `package.json` as follows:
-> ```json
-> {
->   "mongodb": "~3.7.3",
->   "mongodb4": "npm:mongodb@~4.3.1",
-> }
-> ```
->
-> ```typescript
-> import { MongoClient } from 'mongodb4';
-> ```
 
 *index.ts*
 ```typescript
 import { createApp, ServiceManager } from '@foal/core';
 import { MongoDBStore } from '@foal/mongodb';
-import { MongoClient } from 'mongodb'; // or from 'mongodb4';
+import { MongoClient } from 'mongodb';
 
 async function main() {
   const mongoDBClient = await MongoClient.connect('mongodb://localhost:27017/db');

--- a/docs/docs/databases/typeorm/mongodb.md
+++ b/docs/docs/databases/typeorm/mongodb.md
@@ -18,7 +18,7 @@ foal createapp my-app --mongodb
 ## Configuration
 
 ```
-npm install mongodb
+npm install mongodb@5
 ```
 
 <Tabs

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/authentication/session-tokens.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/authentication/session-tokens.md
@@ -1064,26 +1064,14 @@ async function main() {
 #### `MongoDBStore`
 
 ```
-npm install mongodb@4
+npm install mongodb@5
 ```
-
-> The `MongoDBStore` requires version 4 of the [mongodb](https://www.npmjs.com/package/mongodb) package. If you are using TypeORM with MongoDB, which requires version 3, you can have both versions coexist in your `package.json` as follows:
-> ```json
-> {
->   "mongodb": "~3.7.3",
->   "mongodb4": "npm:mongodb@~4.3.1",
-> }
-> ```
->
-> ```typescript
-> import { MongoClient } from 'mongodb4';
-> ```
 
 *index.ts*
 ```typescript
 import { createApp, ServiceManager } from '@foal/core';
 import { MongoDBStore } from '@foal/mongodb';
-import { MongoClient } from 'mongodb'; // or from 'mongodb4';
+import { MongoClient } from 'mongodb';
 
 async function main() {
   const mongoDBClient = await MongoClient.connect('mongodb://localhost:27017/db');

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/authentication/session-tokens.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/authentication/session-tokens.md
@@ -1064,26 +1064,14 @@ async function main() {
 #### `MongoDBStore`
 
 ```
-npm install mongodb@4
+npm install mongodb@5
 ```
-
-> The `MongoDBStore` requires version 4 of the [mongodb](https://www.npmjs.com/package/mongodb) package. If you are using TypeORM with MongoDB, which requires version 3, you can have both versions coexist in your `package.json` as follows:
-> ```json
-> {
->   "mongodb": "~3.7.3",
->   "mongodb4": "npm:mongodb@~4.3.1",
-> }
-> ```
->
-> ```typescript
-> import { MongoClient } from 'mongodb4';
-> ```
 
 *index.ts*
 ```typescript
 import { createApp, ServiceManager } from '@foal/core';
 import { MongoDBStore } from '@foal/mongodb';
-import { MongoClient } from 'mongodb'; // or from 'mongodb4';
+import { MongoClient } from 'mongodb';
 
 async function main() {
   const mongoDBClient = await MongoClient.connect('mongodb://localhost:27017/db');

--- a/docs/i18n/id/docusaurus-plugin-content-docs/current/authentication/session-tokens.md
+++ b/docs/i18n/id/docusaurus-plugin-content-docs/current/authentication/session-tokens.md
@@ -1064,26 +1064,14 @@ async function main() {
 #### `MongoDBStore`
 
 ```
-npm install mongodb@4
+npm install mongodb@5
 ```
-
-> The `MongoDBStore` requires version 4 of the [mongodb](https://www.npmjs.com/package/mongodb) package. If you are using TypeORM with MongoDB, which requires version 3, you can have both versions coexist in your `package.json` as follows:
-> ```json
-> {
->   "mongodb": "~3.7.3",
->   "mongodb4": "npm:mongodb@~4.3.1",
-> }
-> ```
->
-> ```typescript
-> import { MongoClient } from 'mongodb4';
-> ```
 
 *index.ts*
 ```typescript
 import { createApp, ServiceManager } from '@foal/core';
 import { MongoDBStore } from '@foal/mongodb';
-import { MongoClient } from 'mongodb'; // or from 'mongodb4';
+import { MongoClient } from 'mongodb';
 
 async function main() {
   const mongoDBClient = await MongoClient.connect('mongodb://localhost:27017/db');

--- a/packages/acceptance-tests/package-lock.json
+++ b/packages/acceptance-tests/package-lock.json
@@ -17,8 +17,7 @@
         "express": "~4.18.2",
         "express-rate-limit": "~6.4.0",
         "jsonwebtoken": "~9.0.1",
-        "mongodb": "~3.7.3",
-        "mongodb4": "npm:mongodb@~4.7.0",
+        "mongodb": "~5.8.1",
         "react": "~18.1.0",
         "react-dom": "~18.1.0",
         "redis": "~4.1.0",
@@ -26,7 +25,7 @@
         "sqlite3": "~5.1.6",
         "superagent": "~7.1.6",
         "supertest": "~6.3.3",
-        "typeorm": "^0.3.10",
+        "typeorm": "0.3.17",
         "yamljs": "~0.3.0"
       },
       "devDependencies": {
@@ -182,6 +181,15 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "node_modules/@npmcli/fs": {
@@ -644,7 +652,8 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -716,15 +725,6 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "node_modules/bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "node_modules/body-parser": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
@@ -765,7 +765,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -789,11 +788,11 @@
       "dev": true
     },
     "node_modules/bson": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
+      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
       "engines": {
-        "node": ">=0.6.19"
+        "node": ">=14.20.1"
       }
     },
     "node_modules/buffer": {
@@ -1102,11 +1101,6 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -1197,14 +1191,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
-    },
-    "node_modules/denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -2019,11 +2005,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2039,6 +2020,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2287,7 +2269,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
       "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -2458,27 +2439,32 @@
       "dev": true
     },
     "node_modules/mongodb": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.1.tgz",
+      "integrity": "sha512-wKyh4kZvm6NrCPH8AxyzXm3JBoEf4Xulo0aUWh3hCgwgYJxyQ1KLST86ZZaSWdj6/kxYUA3+YZuyADCE61CMSg==",
       "dependencies": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2"
+        "bson": "^5.4.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=14.20.1"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.0"
+        "@mongodb-js/saslprep": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
       },
       "peerDependenciesMeta": {
-        "aws4": {
+        "@aws-sdk/credential-providers": {
           "optional": true
         },
-        "bson-ext": {
+        "@mongodb-js/zstd": {
           "optional": true
         },
         "kerberos": {
@@ -2487,81 +2473,18 @@
         "mongodb-client-encryption": {
           "optional": true
         },
-        "mongodb-extjson": {
-          "optional": true
-        },
         "snappy": {
           "optional": true
         }
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.4.tgz",
-      "integrity": "sha512-SeAxuWs0ez3iI3vvmLk/j2y+zHwigTDKQhtdxTgt5ZCOQQS5+HW4g45/Xw5vzzbn7oQXCNQ24Z40AkJsizEy7w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "dependencies": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
-      }
-    },
-    "node_modules/mongodb4": {
-      "name": "mongodb",
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.7.0.tgz",
-      "integrity": "sha512-HhVar6hsUeMAVlIbwQwWtV36iyjKd9qdhY+s4wcU8K6TOj4Q331iiMy+FoPuxEntDIijTYWivwFJkLv8q/ZgvA==",
-      "dependencies": {
-        "bson": "^4.6.3",
-        "denque": "^2.0.1",
-        "mongodb-connection-string-url": "^2.5.2",
-        "socks": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=12.9.0"
-      },
-      "optionalDependencies": {
-        "saslprep": "^1.0.3"
-      }
-    },
-    "node_modules/mongodb4/node_modules/bson": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
-      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
-      "dependencies": {
-        "buffer": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/mongodb4/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/mongodb4/node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/ms": {
@@ -2821,17 +2744,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/optional-require": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-      "dependencies": {
-        "require-at": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -2963,11 +2875,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
@@ -3138,25 +3045,6 @@
         "react": "^18.1.0"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3186,14 +3074,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
-    },
-    "node_modules/require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -3257,23 +3137,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "optional": true,
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/scheduler": {
       "version": "0.22.0",
@@ -3941,9 +3804,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -3971,27 +3834,25 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.10.tgz",
-      "integrity": "sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.17.tgz",
+      "integrity": "sha512-UDjUEwIQalO9tWw9O2A4GU+sT3oyoUXheHJy4ft+RFdnRdQctdQ34L9SqE2p7LdwzafHx1maxT+bqXON+Qnmig==",
       "dependencies": {
-        "@sqltools/formatter": "^1.2.2",
-        "app-root-path": "^3.0.0",
+        "@sqltools/formatter": "^1.2.5",
+        "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "chalk": "^4.1.0",
+        "chalk": "^4.1.2",
         "cli-highlight": "^2.1.11",
-        "date-fns": "^2.28.0",
-        "debug": "^4.3.3",
-        "dotenv": "^16.0.0",
-        "glob": "^7.2.0",
-        "js-yaml": "^4.1.0",
-        "mkdirp": "^1.0.4",
+        "date-fns": "^2.29.3",
+        "debug": "^4.3.4",
+        "dotenv": "^16.0.3",
+        "glob": "^8.1.0",
+        "mkdirp": "^2.1.3",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2",
-        "xml2js": "^0.4.23",
-        "yargs": "^17.3.1"
+        "tslib": "^2.5.0",
+        "uuid": "^9.0.0",
+        "yargs": "^17.6.2"
       },
       "bin": {
         "typeorm": "cli.js",
@@ -4007,12 +3868,12 @@
       "peerDependencies": {
         "@google-cloud/spanner": "^5.18.0",
         "@sap/hana-client": "^2.12.25",
-        "better-sqlite3": "^7.1.2",
+        "better-sqlite3": "^7.1.2 || ^8.0.0",
         "hdb-pool": "^0.1.6",
         "ioredis": "^5.0.4",
-        "mongodb": "^3.6.0",
-        "mssql": "^7.3.0",
-        "mysql2": "^2.2.5",
+        "mongodb": "^5.2.0",
+        "mssql": "^9.1.1",
+        "mysql2": "^2.2.5 || ^3.0.1",
         "oracledb": "^5.1.0",
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
@@ -4090,10 +3951,42 @@
         "node": ">=12"
       }
     },
+    "node_modules/typeorm/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typeorm/node_modules/mkdirp": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typeorm/node_modules/yargs": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
-      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -4101,7 +3994,7 @@
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
         "node": ">=12"
@@ -4181,9 +4074,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -4298,26 +4191,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/xmlhttprequest-ssl": {
@@ -4537,6 +4410,15 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "tar": "^6.1.11"
+      }
+    },
+    "@mongodb-js/saslprep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "@npmcli/fs": {
@@ -4929,7 +4811,8 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -4983,15 +4866,6 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "body-parser": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
@@ -5030,7 +4904,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0"
       }
@@ -5051,9 +4924,9 @@
       "dev": true
     },
     "bson": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
+      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA=="
     },
     "buffer": {
       "version": "6.0.3",
@@ -5282,11 +5155,6 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -5344,11 +5212,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
-    },
-    "denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "depd": {
       "version": "2.0.0",
@@ -5979,11 +5842,6 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5999,6 +5857,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -6188,7 +6047,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
       "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^2.0.1"
       }
@@ -6315,61 +6173,23 @@
       }
     },
     "mongodb": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.1.tgz",
+      "integrity": "sha512-wKyh4kZvm6NrCPH8AxyzXm3JBoEf4Xulo0aUWh3hCgwgYJxyQ1KLST86ZZaSWdj6/kxYUA3+YZuyADCE61CMSg==",
       "requires": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "@mongodb-js/saslprep": "^1.1.0",
+        "bson": "^5.4.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
       }
     },
     "mongodb-connection-string-url": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.4.tgz",
-      "integrity": "sha512-SeAxuWs0ez3iI3vvmLk/j2y+zHwigTDKQhtdxTgt5ZCOQQS5+HW4g45/Xw5vzzbn7oQXCNQ24Z40AkJsizEy7w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "requires": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
-      }
-    },
-    "mongodb4": {
-      "version": "npm:mongodb@4.7.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.7.0.tgz",
-      "integrity": "sha512-HhVar6hsUeMAVlIbwQwWtV36iyjKd9qdhY+s4wcU8K6TOj4Q331iiMy+FoPuxEntDIijTYWivwFJkLv8q/ZgvA==",
-      "requires": {
-        "bson": "^4.6.3",
-        "denque": "^2.0.1",
-        "mongodb-connection-string-url": "^2.5.2",
-        "saslprep": "^1.0.3",
-        "socks": "^2.6.2"
-      },
-      "dependencies": {
-        "bson": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
-          "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
-          "requires": {
-            "buffer": "^5.6.0"
-          }
-        },
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        },
-        "denque": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-          "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
-        }
       }
     },
     "ms": {
@@ -6574,14 +6394,6 @@
         "wrappy": "1"
       }
     },
-    "optional-require": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-      "requires": {
-        "require-at": "^1.0.6"
-      }
-    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6676,11 +6488,6 @@
         "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0"
       }
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -6815,27 +6622,6 @@
         "scheduler": "^0.22.0"
       }
     },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
-      }
-    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -6862,11 +6648,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
-    },
-    "require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -6901,20 +6682,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "optional": true,
-      "requires": {
-        "sparse-bitfield": "^3.0.3"
-      }
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scheduler": {
       "version": "0.22.0",
@@ -7409,9 +7176,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -7433,27 +7200,25 @@
       }
     },
     "typeorm": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.10.tgz",
-      "integrity": "sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.17.tgz",
+      "integrity": "sha512-UDjUEwIQalO9tWw9O2A4GU+sT3oyoUXheHJy4ft+RFdnRdQctdQ34L9SqE2p7LdwzafHx1maxT+bqXON+Qnmig==",
       "requires": {
-        "@sqltools/formatter": "^1.2.2",
-        "app-root-path": "^3.0.0",
+        "@sqltools/formatter": "^1.2.5",
+        "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "chalk": "^4.1.0",
+        "chalk": "^4.1.2",
         "cli-highlight": "^2.1.11",
-        "date-fns": "^2.28.0",
-        "debug": "^4.3.3",
-        "dotenv": "^16.0.0",
-        "glob": "^7.2.0",
-        "js-yaml": "^4.1.0",
-        "mkdirp": "^1.0.4",
+        "date-fns": "^2.29.3",
+        "debug": "^4.3.4",
+        "dotenv": "^16.0.3",
+        "glob": "^8.1.0",
+        "mkdirp": "^2.1.3",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2",
-        "xml2js": "^0.4.23",
-        "yargs": "^17.3.1"
+        "tslib": "^2.5.0",
+        "uuid": "^9.0.0",
+        "yargs": "^17.6.2"
       },
       "dependencies": {
         "cliui": {
@@ -7466,10 +7231,27 @@
             "wrap-ansi": "^7.0.0"
           }
         },
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "mkdirp": {
+          "version": "2.1.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+          "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A=="
+        },
         "yargs": {
-          "version": "17.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
-          "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "requires": {
             "cliui": "^8.0.1",
             "escalade": "^3.1.1",
@@ -7477,7 +7259,7 @@
             "require-directory": "^2.1.1",
             "string-width": "^4.2.3",
             "y18n": "^5.0.5",
-            "yargs-parser": "^21.0.0"
+            "yargs-parser": "^21.1.1"
           }
         },
         "yargs-parser": {
@@ -7540,9 +7322,9 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -7617,20 +7399,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
       "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
       "requires": {}
-    },
-    "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlhttprequest-ssl": {
       "version": "2.0.0",

--- a/packages/acceptance-tests/package.json
+++ b/packages/acceptance-tests/package.json
@@ -35,15 +35,14 @@
     "express": "~4.18.2",
     "express-rate-limit": "~6.4.0",
     "jsonwebtoken": "~9.0.1",
-    "mongodb": "~3.7.3",
-    "mongodb4": "npm:mongodb@~4.7.0",
+    "mongodb": "~5.8.1",
     "react": "~18.1.0",
     "react-dom": "~18.1.0",
     "redis": "~4.1.0",
     "socket.io-client": "~4.5.1",
     "superagent": "~7.1.6",
     "supertest": "~6.3.3",
-    "typeorm": "^0.3.10",
+    "typeorm": "0.3.17",
     "yamljs": "~0.3.0"
   },
   "devDependencies": {

--- a/packages/acceptance-tests/src/additional/typeorm.mongodb-store.spec.ts
+++ b/packages/acceptance-tests/src/additional/typeorm.mongodb-store.spec.ts
@@ -35,7 +35,7 @@ import {
 } from 'typeorm';
 import { createAndInitializeDataSource } from '../common';
 
-describe.only('[Sample] TypeORM & MongoDB Store', async () => {
+describe('[Sample] TypeORM & MongoDB Store', async () => {
 
   const MONGODB_URI = 'mongodb://localhost:27017/e2e_db';
 

--- a/packages/acceptance-tests/src/additional/typeorm.mongodb-store.spec.ts
+++ b/packages/acceptance-tests/src/additional/typeorm.mongodb-store.spec.ts
@@ -21,7 +21,7 @@ import {
   verifyPassword
 } from '@foal/core';
 import { MongoDBStore } from '@foal/mongodb';
-import { MongoClient, ObjectId } from 'mongodb';
+import { MongoClient, ObjectId as ObjectId2 } from 'mongodb';
 import * as request from 'supertest';
 
 // FoalTS
@@ -30,12 +30,12 @@ import {
   Column,
   DataSource,
   Entity,
-  ObjectID,
+  ObjectId,
   ObjectIdColumn
 } from 'typeorm';
 import { createAndInitializeDataSource } from '../common';
 
-describe('[Sample] TypeORM & MongoDB Store', async () => {
+describe.only('[Sample] TypeORM & MongoDB Store', async () => {
 
   const MONGODB_URI = 'mongodb://localhost:27017/e2e_db';
 
@@ -46,7 +46,7 @@ describe('[Sample] TypeORM & MongoDB Store', async () => {
   @Entity()
   class User extends BaseEntity {
     @ObjectIdColumn()
-    _id: ObjectID;
+    _id: ObjectId;
 
     @Column({ unique: true })
     email: string;
@@ -67,7 +67,7 @@ describe('[Sample] TypeORM & MongoDB Store', async () => {
   }
 
   @UseSessions({
-    user: id => User.findOneBy({ _id: new ObjectId(id) }),
+    user: id => User.findOneBy({ _id: new ObjectId2(id) }),
     userIdType: 'string',
     store: MongoDBStore,
     required: true
@@ -147,7 +147,7 @@ describe('[Sample] TypeORM & MongoDB Store', async () => {
       type: 'mongodb',
     });
 
-    mongoClient = await MongoClient.connect(MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true });
+    mongoClient = await MongoClient.connect(MONGODB_URI);
 
     await mongoClient.db().collection('foalSessions').deleteMany({});
 

--- a/packages/acceptance-tests/src/additional/typeorm.redis-store.spec.ts
+++ b/packages/acceptance-tests/src/additional/typeorm.redis-store.spec.ts
@@ -23,7 +23,7 @@ import {
 import { RedisStore } from '@foal/redis';
 import { createClient } from 'redis';
 import * as request from 'supertest';
-import { ObjectId } from 'mongodb';
+import { ObjectId as ObjectId2 } from 'mongodb';
 
 // FoalTS
 import {
@@ -31,12 +31,12 @@ import {
   Column,
   DataSource,
   Entity,
-  ObjectID,
+  ObjectId,
   ObjectIdColumn
 } from 'typeorm';
 import { createAndInitializeDataSource } from '../common';
 
-describe('[Sample] MongoDB & Redis Store', async () => {
+describe.only('[Sample] MongoDB & Redis Store', async () => {
 
   let app: any;
   let token: string;
@@ -45,7 +45,7 @@ describe('[Sample] MongoDB & Redis Store', async () => {
   @Entity()
   class User extends BaseEntity {
     @ObjectIdColumn()
-    _id: ObjectID;
+    _id: ObjectId;
 
     @Column({ unique: true })
     email: string;
@@ -66,7 +66,7 @@ describe('[Sample] MongoDB & Redis Store', async () => {
   }
 
   @UseSessions({
-    user: id => User.findOneBy({ _id: new ObjectId(id) }),
+    user: id => User.findOneBy({ _id: new ObjectId2(id) }),
     userIdType: 'string',
     store: RedisStore,
     required: true,

--- a/packages/acceptance-tests/src/additional/typeorm.redis-store.spec.ts
+++ b/packages/acceptance-tests/src/additional/typeorm.redis-store.spec.ts
@@ -36,7 +36,7 @@ import {
 } from 'typeorm';
 import { createAndInitializeDataSource } from '../common';
 
-describe.only('[Sample] MongoDB & Redis Store', async () => {
+describe('[Sample] MongoDB & Redis Store', async () => {
 
   let app: any;
   let token: string;

--- a/packages/acceptance-tests/src/docs/authentication/session-tokens/providing-a-custom-client-to-use-in-stores.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication/session-tokens/providing-a-custom-client-to-use-in-stores.feature.ts
@@ -1,7 +1,7 @@
 // 3p
 import * as request from 'supertest';
 import { createClient } from 'redis';
-import { MongoClient } from 'mongodb4';
+import { MongoClient } from 'mongodb';
 
 // FoalTS
 import { createApp, createSession, dependency, Get, HttpResponseInternalServerError, HttpResponseOK, ServiceManager } from '@foal/core';

--- a/packages/acceptance-tests/typings/mongodb/index.d.ts
+++ b/packages/acceptance-tests/typings/mongodb/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'mongodb';

--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -28,7 +28,7 @@
     "@foal/typeorm": "^3.0.0",
     "source-map-support": "~0.5.21",
     "sqlite3": "~5.1.6",
-    "typeorm": "0.3.10"
+    "typeorm": "0.3.17"
   },
   "devDependencies": {
     "@foal/cli": "^3.0.0",

--- a/packages/cli/src/generate/specs/app/package.mongodb.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.json
@@ -22,9 +22,9 @@
   },
   "dependencies": {
     "@foal/core": "^3.0.0",
-    "mongodb": "~3.7.3",
+    "mongodb": "~5.8.1",
     "source-map-support": "~0.5.21",
-    "typeorm": "0.3.10"
+    "typeorm": "0.3.17"
   },
   "devDependencies": {
     "@foal/cli": "^3.0.0",

--- a/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
@@ -22,9 +22,9 @@
   },
   "dependencies": {
     "@foal/core": "^3.0.0",
-    "mongodb": "~3.7.3",
+    "mongodb": "~5.8.1",
     "source-map-support": "~0.5.21",
-    "typeorm": "0.3.10",
+    "typeorm": "0.3.17",
     "yamljs": "~0.3.0"
   },
   "devDependencies": {

--- a/packages/cli/src/generate/specs/app/package.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.yaml.json
@@ -28,7 +28,7 @@
     "@foal/typeorm": "^3.0.0",
     "source-map-support": "~0.5.21",
     "sqlite3": "~5.1.6",
-    "typeorm": "0.3.10",
+    "typeorm": "0.3.17",
     "yamljs": "~0.3.0"
   },
   "devDependencies": {

--- a/packages/cli/src/generate/specs/app/src/app/entities/user.entity.mongodb.ts
+++ b/packages/cli/src/generate/specs/app/src/app/entities/user.entity.mongodb.ts
@@ -1,9 +1,9 @@
-import { BaseEntity, Entity, ObjectID, ObjectIdColumn } from 'typeorm';
+import { BaseEntity, Entity, ObjectId, ObjectIdColumn } from 'typeorm';
 
 @Entity()
 export class User extends BaseEntity {
 
   @ObjectIdColumn()
-  _id: ObjectID;
+  _id: ObjectId;
 
 }

--- a/packages/cli/src/generate/specs/entity/test-foo-bar.entity.mongodb.ts
+++ b/packages/cli/src/generate/specs/entity/test-foo-bar.entity.mongodb.ts
@@ -1,10 +1,10 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { BaseEntity, Column, Entity, ObjectID, ObjectIdColumn } from 'typeorm';
+import { BaseEntity, Column, Entity, ObjectId, ObjectIdColumn } from 'typeorm';
 
 @Entity()
 export class TestFooBar extends BaseEntity {
 
   @ObjectIdColumn()
-  _id: ObjectID;
+  _id: ObjectId;
 
 }

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -28,7 +28,7 @@
     "@foal/typeorm": "^3.0.0",
     "source-map-support": "~0.5.21",
     "sqlite3": "~5.1.6",
-    "typeorm": "0.3.10"
+    "typeorm": "0.3.17"
   },
   "devDependencies": {
     "@foal/cli": "^3.0.0",

--- a/packages/cli/src/generate/templates/app/package.mongodb.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.json
@@ -22,9 +22,9 @@
   },
   "dependencies": {
     "@foal/core": "^3.0.0",
-    "mongodb": "~3.7.3",
+    "mongodb": "~5.8.1",
     "source-map-support": "~0.5.21",
-    "typeorm": "0.3.10"
+    "typeorm": "0.3.17"
   },
   "devDependencies": {
     "@foal/cli": "^3.0.0",

--- a/packages/cli/src/generate/templates/app/src/app/entities/user.entity.mongodb.ts
+++ b/packages/cli/src/generate/templates/app/src/app/entities/user.entity.mongodb.ts
@@ -1,9 +1,9 @@
-import { BaseEntity, Entity, ObjectID, ObjectIdColumn } from 'typeorm';
+import { BaseEntity, Entity, ObjectId, ObjectIdColumn } from 'typeorm';
 
 @Entity()
 export class User extends BaseEntity {
 
   @ObjectIdColumn()
-  _id: ObjectID;
+  _id: ObjectId;
 
 }

--- a/packages/cli/src/generate/templates/entity/entity.mongodb.ts
+++ b/packages/cli/src/generate/templates/entity/entity.mongodb.ts
@@ -1,10 +1,10 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { BaseEntity, Column, Entity, ObjectID, ObjectIdColumn } from 'typeorm';
+import { BaseEntity, Column, Entity, ObjectId, ObjectIdColumn } from 'typeorm';
 
 @Entity()
 export class /* upperFirstCamelName */ extends BaseEntity {
 
   @ObjectIdColumn()
-  _id: ObjectID;
+  _id: ObjectId;
 
 }

--- a/packages/examples/package-lock.json
+++ b/packages/examples/package-lock.json
@@ -12,7 +12,7 @@
         "graphql": "~15.8.0",
         "source-map-support": "~0.5.21",
         "sqlite3": "~5.1.6",
-        "typeorm": "^0.3.10",
+        "typeorm": "^0.3.17",
         "yamljs": "~0.3.0"
       },
       "devDependencies": {
@@ -268,7 +268,8 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/arr-union": {
       "version": "3.1.0",
@@ -1619,6 +1620,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2586,11 +2588,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "optional": true
     },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
     "node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -3159,9 +3156,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -3177,27 +3174,25 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.10.tgz",
-      "integrity": "sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.17.tgz",
+      "integrity": "sha512-UDjUEwIQalO9tWw9O2A4GU+sT3oyoUXheHJy4ft+RFdnRdQctdQ34L9SqE2p7LdwzafHx1maxT+bqXON+Qnmig==",
       "dependencies": {
-        "@sqltools/formatter": "^1.2.2",
-        "app-root-path": "^3.0.0",
+        "@sqltools/formatter": "^1.2.5",
+        "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "chalk": "^4.1.0",
+        "chalk": "^4.1.2",
         "cli-highlight": "^2.1.11",
-        "date-fns": "^2.28.0",
-        "debug": "^4.3.3",
-        "dotenv": "^16.0.0",
-        "glob": "^7.2.0",
-        "js-yaml": "^4.1.0",
-        "mkdirp": "^1.0.4",
+        "date-fns": "^2.29.3",
+        "debug": "^4.3.4",
+        "dotenv": "^16.0.3",
+        "glob": "^8.1.0",
+        "mkdirp": "^2.1.3",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2",
-        "xml2js": "^0.4.23",
-        "yargs": "^17.3.1"
+        "tslib": "^2.5.0",
+        "uuid": "^9.0.0",
+        "yargs": "^17.6.2"
       },
       "bin": {
         "typeorm": "cli.js",
@@ -3213,12 +3208,12 @@
       "peerDependencies": {
         "@google-cloud/spanner": "^5.18.0",
         "@sap/hana-client": "^2.12.25",
-        "better-sqlite3": "^7.1.2",
+        "better-sqlite3": "^7.1.2 || ^8.0.0",
         "hdb-pool": "^0.1.6",
         "ioredis": "^5.0.4",
-        "mongodb": "^3.6.0",
-        "mssql": "^7.3.0",
-        "mysql2": "^2.2.5",
+        "mongodb": "^5.2.0",
+        "mssql": "^9.1.1",
+        "mysql2": "^2.2.5 || ^3.0.1",
         "oracledb": "^5.1.0",
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
@@ -3283,6 +3278,14 @@
         }
       }
     },
+    "node_modules/typeorm/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/typeorm/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -3306,15 +3309,47 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/typeorm/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
+    "node_modules/typeorm/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typeorm/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/typeorm/node_modules/mkdirp": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typescript": {
@@ -3363,9 +3398,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -3444,26 +3479,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -3754,7 +3769,8 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
@@ -4770,6 +4786,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -5500,11 +5517,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "optional": true
     },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
     "semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -5932,9 +5944,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -5947,29 +5959,35 @@
       }
     },
     "typeorm": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.10.tgz",
-      "integrity": "sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.17.tgz",
+      "integrity": "sha512-UDjUEwIQalO9tWw9O2A4GU+sT3oyoUXheHJy4ft+RFdnRdQctdQ34L9SqE2p7LdwzafHx1maxT+bqXON+Qnmig==",
       "requires": {
-        "@sqltools/formatter": "^1.2.2",
-        "app-root-path": "^3.0.0",
+        "@sqltools/formatter": "^1.2.5",
+        "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "chalk": "^4.1.0",
+        "chalk": "^4.1.2",
         "cli-highlight": "^2.1.11",
-        "date-fns": "^2.28.0",
-        "debug": "^4.3.3",
-        "dotenv": "^16.0.0",
-        "glob": "^7.2.0",
-        "js-yaml": "^4.1.0",
-        "mkdirp": "^1.0.4",
+        "date-fns": "^2.29.3",
+        "debug": "^4.3.4",
+        "dotenv": "^16.0.3",
+        "glob": "^8.1.0",
+        "mkdirp": "^2.1.3",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2",
-        "xml2js": "^0.4.23",
-        "yargs": "^17.3.1"
+        "tslib": "^2.5.0",
+        "uuid": "^9.0.0",
+        "yargs": "^17.6.2"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "buffer": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -5979,10 +5997,30 @@
             "ieee754": "^1.2.1"
           }
         },
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
         "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+          "version": "2.1.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+          "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A=="
         }
       }
     },
@@ -6022,9 +6060,9 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "vinyl": {
       "version": "1.2.0",
@@ -6088,20 +6126,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -55,7 +55,7 @@
     "sqlite3": "~5.1.6",
     "graphql": "~15.8.0",
     "source-map-support": "~0.5.21",
-    "typeorm": "^0.3.10",
+    "typeorm": "^0.3.17",
     "yamljs": "~0.3.0"
   },
   "devDependencies": {

--- a/packages/mongodb/package-lock.json
+++ b/packages/mongodb/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
-        "mongodb": "~4.11.0"
+        "mongodb": "~5.8.1"
       },
       "devDependencies": {
         "@types/mocha": "10.0.1",
@@ -20,7 +20,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -31,6 +31,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
       "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -39,13 +40,15 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
       "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/ie11-detection": "^2.0.0",
         "@aws-crypto/sha256-js": "^2.0.0",
@@ -61,13 +64,15 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
       "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -78,13 +83,15 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
       "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -93,13 +100,15 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@aws-crypto/util": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
       "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -110,13 +119,15 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@aws-sdk/abort-controller": {
       "version": "3.198.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.198.0.tgz",
       "integrity": "sha512-kmK1fNJ5nkBH23wOrAdxWcVtG/NNCaX66cxr90jnbGvSAeNRi5nLLqlmQOyZ0RRg+tpNCec+N/qqfxAmmD3NdQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -130,6 +141,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.199.0.tgz",
       "integrity": "sha512-F7VvJkaSYBBiAAtlrWO6Hq5GbqARMerihtlFvQra2Uy0bSX/okNgefurjjW1Gijh4xk6brWPO+46GD9OpZXtcQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -177,6 +189,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.199.0.tgz",
       "integrity": "sha512-xRTI39cLcCU1lGlSaE2arCPzRwUY16Oq46fGoe+9pwalDL3oKeE6uq/idTxPzPZdZFhzpLUVc0QdfwGDYhJpXg==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -221,6 +234,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.199.0.tgz",
       "integrity": "sha512-ly7kLi/KFRr9RrvTVVlDAXlROkInTMRy4BL02Ugw7brSPysUJabzdlDB5gxC+jbeq8qpai/vCybePf6lgrcvFw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -269,6 +283,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.198.0.tgz",
       "integrity": "sha512-CxpbkTOfOYZLWcNgcZqooSIlLnixzHVz6skDgxOfeN2vohNOgt8hwU0Dmif3sC4AeyeV0CBm7ew9tg/WzsBxhg==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/signature-v4": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -285,6 +300,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.199.0.tgz",
       "integrity": "sha512-vhdvaCq9Q/LPvAdTN9HFnsR713iDb1qI7yTmnGzJYym1J9a2pR4YQvZr1pRyXbn176ORkgEiPMNSoDw8CiCRlg==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-cognito-identity": "3.199.0",
         "@aws-sdk/property-provider": "3.198.0",
@@ -300,6 +316,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.198.0.tgz",
       "integrity": "sha512-Psui5iNdbHrHNF14vejORMtSEaH7EOt51pQcfmP1jk8Tinf+KMMMdbOqyzL4LHYwLTLH9Cr6m6UGrJXdmFiIZA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -314,6 +331,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.198.0.tgz",
       "integrity": "sha512-p2xMCo3whCnXd5/dH738rAVURXhlppjRNDv0sCkDcVtr3exn4s5x5ednFM8K0zNo/hsqjqFbK3jT4W72bgHphw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/node-config-provider": "3.198.0",
         "@aws-sdk/property-provider": "3.198.0",
@@ -330,6 +348,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.199.0.tgz",
       "integrity": "sha512-6m3WtK+oKGyo7iCHjORwmHN4wUp4F9j79dSedEf0EYxDbHpH9yMnEE6hYV11GdmM+/i8x8DYA45apAZo8gCIcA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.198.0",
         "@aws-sdk/credential-provider-imds": "3.198.0",
@@ -349,6 +368,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.199.0.tgz",
       "integrity": "sha512-pgJhOnTHj+ZZkcN9v7R+m2VnkQi4vvyA7N6k3EDWMQ8tdo48ofwObORkzA4gPX+TPuIjpYa1lU03dpY4zuzJKQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.198.0",
         "@aws-sdk/credential-provider-imds": "3.198.0",
@@ -370,6 +390,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.198.0.tgz",
       "integrity": "sha512-LWiwKDCui7ILr+6opBzLCCAho9ZOppuEthUdKZx6T7+yD2cQT0caN5PkVUBMtfTu9+DZnHD2bpIL1T2KEaqEUw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.198.0",
         "@aws-sdk/shared-ini-file-loader": "3.198.0",
@@ -385,6 +406,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.199.0.tgz",
       "integrity": "sha512-aMNZkEj/5RN6jSbfkVadjNblExJtHCJGvcnKnzIGfXLgqOFoWGzY+YIHmn/GTgCnpuMbN5hXYXV6w76HwIvWGw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.199.0",
         "@aws-sdk/property-provider": "3.198.0",
@@ -401,6 +423,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.198.0.tgz",
       "integrity": "sha512-D+fhnmqN18P/Roq5oxVq53J3mqS9Oi9IJaIKdrbdK/FibqOyKmTERaLKWkONwG35qExSECOpoEGn7ioUMQgAgQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -415,6 +438,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.199.0.tgz",
       "integrity": "sha512-PpOgvV7akew9cXrrEEF+h6H/JGURVCPw+UsvN0yjN8oSexwe0sUzKG1AVIrHYiAWkZKIohtsv7NNzBAKvJ4Qmw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-cognito-identity": "3.199.0",
         "@aws-sdk/client-sso": "3.199.0",
@@ -441,6 +465,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.199.0.tgz",
       "integrity": "sha512-o1jRUMoJR/HOhqA2euYIQxzKLkbqBGwMGH3ahm5eqEJ9kCp84c2KsxT/HOEqjvAQi3f3np8VlTPbuscvDKUN4w==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.198.0",
         "@aws-sdk/querystring-builder": "3.199.0",
@@ -454,6 +479,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.198.0.tgz",
       "integrity": "sha512-+UTjEEQlvT4+IIwLpN36Qb1DOQHe3zHkvIVe6SjLln+Z/UEK6NhMI0tsJNbiW38WAfwOjJ+otrRBHuD93SBRxQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.198.0",
         "@aws-sdk/util-buffer-from": "3.188.0",
@@ -468,6 +494,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.198.0.tgz",
       "integrity": "sha512-lbwS+H7WYk/g9/nHoTgt7xkrZCJ/OJuBfsx41RvMxW7zPxJeHYD/PvgPvYOB9lTUBkr7SDCeMoS5PtGdAwVOfg==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -478,6 +505,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
       "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -490,6 +518,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.199.0.tgz",
       "integrity": "sha512-Q76J6xZl36tqS401TGs/NPIu8lYbNG1EtqxM88CWe/u0SH+D4LIR9AMXq9c4PH0ldIMWAGVGbRLLc0/H3rPyBg==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -504,6 +533,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.198.0.tgz",
       "integrity": "sha512-J/rQkIXUbFJAlD6LSDVGU4bGbwD/2pvF5N39ePzvaJ8SwV9Y78XER/2fIAERhFNppuYinGdBdMLiPsC6qPT6ZA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-serde": "3.198.0",
         "@aws-sdk/protocol-http": "3.198.0",
@@ -523,6 +553,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.198.0.tgz",
       "integrity": "sha512-keHstrdw0bFzEkUrkMQ9+UxaKu5b1K87cH6guqLf4JBo04CT+2kPRlDSma65XCi2U81zfTnWApk+/SPPFN3otA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -537,6 +568,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.198.0.tgz",
       "integrity": "sha512-IFvNO4MI80FyltPzrEpYHMG47EYXawcD5zTzcbimpeLTpyrLY/zkSJqh5cVFu+NcDWsuD6U1geuvfN+i+2Bg1Q==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -550,6 +582,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.198.0.tgz",
       "integrity": "sha512-VHyz5xBJOaLZwdL94XWB04XCA+pwbURy+4ESF66vIY1umWgfanbZPkvw1XlRaQJydOmyIDFqhNG2AzB28WN9iw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -564,6 +597,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.198.0.tgz",
       "integrity": "sha512-dwv5QJYTPNkmjKcQ0RtClkNumFomECzxjXvSiyjD9Ft6AWHcUeyqJfGKbmP5mFHpezWckK1qcT6cPMVrJilgjw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.198.0",
         "@aws-sdk/service-error-classification": "3.198.0",
@@ -581,6 +615,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.199.0.tgz",
       "integrity": "sha512-ISM3Lx1AM2IiHpcQPdwHHvnW/dRyC/jGy2fHQvmYxj8x2oIYnEXxk4vA7DFnrYupxwi2yTSp3k8On2+1VgMjiw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-signing": "3.198.0",
         "@aws-sdk/property-provider": "3.198.0",
@@ -598,6 +633,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.198.0.tgz",
       "integrity": "sha512-RlAua2691KCFabp3kjnsd5p+1nQbULTK1Ia/jvlTAyG4tGOeA0x1At6KZoI1LfkN+VjstV5/3b9aOCtcFuxkhA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -611,6 +647,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.198.0.tgz",
       "integrity": "sha512-HPY9d1c1CUiV6JBVxiiQQgYfmELl1cn6h0TI00EmOAM5/wxUoiYBX2cGWf2NRF9/iBTppZjxwAKMYPIqF5Tkvw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.198.0",
         "@aws-sdk/protocol-http": "3.198.0",
@@ -628,6 +665,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.198.0.tgz",
       "integrity": "sha512-5mHRjiJFHxziXOiChW3kttQHjgqH5qW9xRIDJepyf+NRJ60L8bZj0t8oGecqVqo27S02+UvrFgOzoRvBbATVFw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -640,6 +678,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.198.0.tgz",
       "integrity": "sha512-SMteVixqoSazxUN1ROMj+nSf/zgTMRVPaTCKU0iEAtrE7ilp9Xv6FEC7ffm1MM9xIoAZ2eY1eAtY3uN0yxBm4A==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -654,6 +693,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.198.0.tgz",
       "integrity": "sha512-W+msdp94ZjR8mJMtGPHjWHsIdsOu3HaVX4x+AQq9cj7+pg/D5CvWw7fnbkUQeG+V8Ia/aqzBNxlUpr/FAeQY/g==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.198.0",
         "@aws-sdk/shared-ini-file-loader": "3.198.0",
@@ -669,6 +709,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.199.0.tgz",
       "integrity": "sha512-F+6T7MHHm0b3+GVRxEnFCuIyqUQb0b8a3Hne3QFV4cxtnX58O/SSF8KlpuGZwobivdRC/AKDaTdI/eA0PQfegA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/abort-controller": "3.198.0",
         "@aws-sdk/protocol-http": "3.198.0",
@@ -685,6 +726,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.198.0.tgz",
       "integrity": "sha512-jnQeJgZlk+6YJS2/eFz6pm9+XHzvCB0jTxHBwt2zYwZfcJ98viRQWMYfkY1XsemuQb/uIoHRBRhFXaJSLpXVDQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -698,6 +740,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.198.0.tgz",
       "integrity": "sha512-x+Qc+kwYqaZvLJ/820rxoFUIgSnSS/XlUHwmS+CTn7nJ68CeL3dzmae6TVOslpVBLCvoS2CbEpEoBbofOpsbGw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -711,6 +754,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.199.0.tgz",
       "integrity": "sha512-P4MWPzCqtH3sgI9iXXVdYirYVgggtg4uq5MVefnfHW+osZu8ZR+UKJw5ojAFfOCqcnKOU/xJjz185RroOjrzYQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.198.0",
         "@aws-sdk/util-uri-escape": "3.188.0",
@@ -725,6 +769,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.198.0.tgz",
       "integrity": "sha512-oMybZYINxNiwSELR7tOwqu+1S7CeEC3g5L4IQXk2wvVx96HEf3sQgLr1wbmV1b7lEnTuH9OrgI5RgDUBVqipdw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -738,6 +783,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.198.0.tgz",
       "integrity": "sha512-bVsWOIYuDtSmwJtPF1pU84x2TL20Pj02C0+/6ua4qLvRatVKFbj1wxWiU/nKvgjiGFX8VWuQUKMzXUYQfYn4nw==",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -747,6 +793,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.198.0.tgz",
       "integrity": "sha512-n3Ykuvtb6f+WQuhcMVumY9VxQwPp8+cMSc5s6YHptkvZkz/cd2wmPhO914gKE/i2MoC/zQsFCXT8Z1YnS7k8sA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -760,6 +807,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.198.0.tgz",
       "integrity": "sha512-8EIyEt7ElTK/tQamYyB16IGwc7EwtLlSVcksaiII780ZtYULnOjogi/UImCYqSejQw+EHhXfbj14HRQT56rqEQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.188.0",
         "@aws-sdk/types": "3.198.0",
@@ -777,6 +825,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.198.0.tgz",
       "integrity": "sha512-IKUzJSoIkxYkYpRdlrh6REtDcW5c87FKeqtMC8VTpaTxrXwnJOqbenp7IwArwOnbXp4aIVmzdxT/nvQrftlgWg==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -791,6 +840,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.198.0.tgz",
       "integrity": "sha512-ljgY9Pgb2CSRrf4IeaNy5gkhTsBae9STKc/mqfScSzvZOvRHu+BOIAGM33fDoCwxD1viKNVJvU1KemiI57Gbvw==",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -800,6 +850,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.198.0.tgz",
       "integrity": "sha512-wm3+OTDWKsMEOlLGvJ+jxCcOXMjgd5qBDVbu2bTiyTahc2poNlM7kKhSwL4I8PkmGZVAqfAlHD4Wj38WecHQPw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/querystring-parser": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -811,6 +862,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
       "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -820,6 +872,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.188.0.tgz",
       "integrity": "sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.188.0",
         "tslib": "^2.3.1"
@@ -833,6 +886,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
       "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -842,6 +896,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.188.0.tgz",
       "integrity": "sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -854,6 +909,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
       "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.188.0",
         "tslib": "^2.3.1"
@@ -867,6 +923,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
       "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -879,6 +936,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.198.0.tgz",
       "integrity": "sha512-IG4iVKQdFjdVFMH5KbSUY2l48wL9aCX/qzoCyTPjKkVumvmwnfkt5OCslkNcaqRdvp5o7QL7aHbq0EZ3K7Ya0A==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -894,6 +952,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.198.0.tgz",
       "integrity": "sha512-LBKSKJjEs0D8tjalblDNmq9DWYTDQ1wVUksAIBO2gQU+EZHJwPb9qxyAk32gbnVTOYceZpJ5/vAGT7speDzEyw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/config-resolver": "3.198.0",
         "@aws-sdk/credential-provider-imds": "3.198.0",
@@ -911,6 +970,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.198.0.tgz",
       "integrity": "sha512-fpeJNVoe/QsIcGybgJ+D2jZcUFi7d37FlMiZd9eVnS5LyMGDNH8tVS7aPT7dgb0z30/FKMBIKKG6QxDGxFaqjQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -924,6 +984,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
       "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -936,6 +997,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.188.0.tgz",
       "integrity": "sha512-SxobBVLZkkLSawTCfeQnhVX3Azm9O+C2dngZVe1+BqtF8+retUbVTs7OfYeWBlawVkULKF2e781lTzEHBBjCzw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -948,6 +1010,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.198.0.tgz",
       "integrity": "sha512-hEdkuGRWhZdEb1plzkGCN2kT8SqiPrEQHngB+1q7pjFJcKWkYkmaLHGw2zhbg1EVNpcGmj5DzCSWzwoPkpDRsw==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -960,6 +1023,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
       "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       },
@@ -972,6 +1036,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.198.0.tgz",
       "integrity": "sha512-XIwaaKtrEsxsayk1yUNjx15AZenP6YRaRDa3f6dhGO+D6OOXP+0S38O5lakyDDGW7nkwkmXa2NIv/OPHPYJ+jQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.198.0",
         "bowser": "^2.11.0",
@@ -983,6 +1048,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.198.0.tgz",
       "integrity": "sha512-21bi3pNO7jvo3l9LtMJyR48ERN69PuBqMnwnjsDVqyIFBbnZr/JR5rWQx7jdZ0iUt6mRlgZ17xHXlGUGMCxznA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/node-config-provider": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -1005,6 +1071,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
       "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.1"
       }
@@ -1014,6 +1081,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.199.0.tgz",
       "integrity": "sha512-Kk3qCdGbe5k0PUE8EBgMsRxNstvDCoWStYWjNwsHWuc/hJitSf44PColzXw6xxHqH1sY+6LcgIaMwJZ5C4bB6w==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/util-buffer-from": "3.188.0",
         "tslib": "^2.3.1"
@@ -1153,6 +1221,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1344,25 +1421,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1382,7 +1440,8 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1413,37 +1472,11 @@
       "dev": true
     },
     "node_modules/bson": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
-      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
-      "dependencies": {
-        "buffer": "^5.6.0"
-      },
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
+      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
       "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "node": ">=14.20.1"
       }
     },
     "node_modules/camelcase": {
@@ -1713,14 +1746,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -1792,6 +1817,7 @@
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
       "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "strnum": "^1.0.5"
       },
@@ -2036,25 +2062,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -2589,27 +2596,49 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.11.0.tgz",
-      "integrity": "sha512-9l9n4Nk2BYZzljW3vHah3Z0rfS5npKw6ktnkmFgTcnzaXH1DRm3pDl6VMHu84EVb1lzmSaJC4OzWZqTkB5i2wg==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.1.tgz",
+      "integrity": "sha512-wKyh4kZvm6NrCPH8AxyzXm3JBoEf4Xulo0aUWh3hCgwgYJxyQ1KLST86ZZaSWdj6/kxYUA3+YZuyADCE61CMSg==",
       "dependencies": {
-        "bson": "^4.7.0",
-        "denque": "^2.1.0",
-        "mongodb-connection-string-url": "^2.5.4",
+        "bson": "^5.4.0",
+        "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
       "engines": {
-        "node": ">=12.9.0"
+        "node": ">=14.20.1"
       },
       "optionalDependencies": {
-        "@aws-sdk/credential-providers": "^3.186.0",
-        "saslprep": "^1.0.3"
+        "@mongodb-js/saslprep": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.4.tgz",
-      "integrity": "sha512-SeAxuWs0ez3iI3vvmLk/j2y+zHwigTDKQhtdxTgt5ZCOQQS5+HW4g45/Xw5vzzbn7oQXCNQ24Z40AkJsizEy7w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "dependencies": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
@@ -2761,9 +2790,9 @@
       "dev": true
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "engines": {
         "node": ">=6"
       }
@@ -2924,18 +2953,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "optional": true,
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
@@ -3129,7 +3146,8 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/success-symbol": {
       "version": "0.1.0",
@@ -3337,7 +3355,8 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/typescript": {
       "version": "4.9.5",
@@ -3372,6 +3391,7 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "optional": true,
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -3563,6 +3583,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
       "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -3571,7 +3592,8 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -3580,6 +3602,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
       "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-crypto/ie11-detection": "^2.0.0",
         "@aws-crypto/sha256-js": "^2.0.0",
@@ -3595,7 +3618,8 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -3604,6 +3628,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
       "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-crypto/util": "^2.0.0",
         "@aws-sdk/types": "^3.1.0",
@@ -3614,7 +3639,8 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -3623,6 +3649,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
       "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -3631,7 +3658,8 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -3640,6 +3668,7 @@
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
       "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -3650,7 +3679,8 @@
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -3659,6 +3689,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.198.0.tgz",
       "integrity": "sha512-kmK1fNJ5nkBH23wOrAdxWcVtG/NNCaX66cxr90jnbGvSAeNRi5nLLqlmQOyZ0RRg+tpNCec+N/qqfxAmmD3NdQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -3669,6 +3700,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.199.0.tgz",
       "integrity": "sha512-F7VvJkaSYBBiAAtlrWO6Hq5GbqARMerihtlFvQra2Uy0bSX/okNgefurjjW1Gijh4xk6brWPO+46GD9OpZXtcQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -3713,6 +3745,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.199.0.tgz",
       "integrity": "sha512-xRTI39cLcCU1lGlSaE2arCPzRwUY16Oq46fGoe+9pwalDL3oKeE6uq/idTxPzPZdZFhzpLUVc0QdfwGDYhJpXg==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -3754,6 +3787,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.199.0.tgz",
       "integrity": "sha512-ly7kLi/KFRr9RrvTVVlDAXlROkInTMRy4BL02Ugw7brSPysUJabzdlDB5gxC+jbeq8qpai/vCybePf6lgrcvFw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -3799,6 +3833,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.198.0.tgz",
       "integrity": "sha512-CxpbkTOfOYZLWcNgcZqooSIlLnixzHVz6skDgxOfeN2vohNOgt8hwU0Dmif3sC4AeyeV0CBm7ew9tg/WzsBxhg==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/signature-v4": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -3812,6 +3847,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.199.0.tgz",
       "integrity": "sha512-vhdvaCq9Q/LPvAdTN9HFnsR713iDb1qI7yTmnGzJYym1J9a2pR4YQvZr1pRyXbn176ORkgEiPMNSoDw8CiCRlg==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/client-cognito-identity": "3.199.0",
         "@aws-sdk/property-provider": "3.198.0",
@@ -3824,6 +3860,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.198.0.tgz",
       "integrity": "sha512-Psui5iNdbHrHNF14vejORMtSEaH7EOt51pQcfmP1jk8Tinf+KMMMdbOqyzL4LHYwLTLH9Cr6m6UGrJXdmFiIZA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -3835,6 +3872,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.198.0.tgz",
       "integrity": "sha512-p2xMCo3whCnXd5/dH738rAVURXhlppjRNDv0sCkDcVtr3exn4s5x5ednFM8K0zNo/hsqjqFbK3jT4W72bgHphw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/node-config-provider": "3.198.0",
         "@aws-sdk/property-provider": "3.198.0",
@@ -3848,6 +3886,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.199.0.tgz",
       "integrity": "sha512-6m3WtK+oKGyo7iCHjORwmHN4wUp4F9j79dSedEf0EYxDbHpH9yMnEE6hYV11GdmM+/i8x8DYA45apAZo8gCIcA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.198.0",
         "@aws-sdk/credential-provider-imds": "3.198.0",
@@ -3864,6 +3903,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.199.0.tgz",
       "integrity": "sha512-pgJhOnTHj+ZZkcN9v7R+m2VnkQi4vvyA7N6k3EDWMQ8tdo48ofwObORkzA4gPX+TPuIjpYa1lU03dpY4zuzJKQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.198.0",
         "@aws-sdk/credential-provider-imds": "3.198.0",
@@ -3882,6 +3922,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.198.0.tgz",
       "integrity": "sha512-LWiwKDCui7ILr+6opBzLCCAho9ZOppuEthUdKZx6T7+yD2cQT0caN5PkVUBMtfTu9+DZnHD2bpIL1T2KEaqEUw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.198.0",
         "@aws-sdk/shared-ini-file-loader": "3.198.0",
@@ -3894,6 +3935,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.199.0.tgz",
       "integrity": "sha512-aMNZkEj/5RN6jSbfkVadjNblExJtHCJGvcnKnzIGfXLgqOFoWGzY+YIHmn/GTgCnpuMbN5hXYXV6w76HwIvWGw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/client-sso": "3.199.0",
         "@aws-sdk/property-provider": "3.198.0",
@@ -3907,6 +3949,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.198.0.tgz",
       "integrity": "sha512-D+fhnmqN18P/Roq5oxVq53J3mqS9Oi9IJaIKdrbdK/FibqOyKmTERaLKWkONwG35qExSECOpoEGn7ioUMQgAgQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -3918,6 +3961,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.199.0.tgz",
       "integrity": "sha512-PpOgvV7akew9cXrrEEF+h6H/JGURVCPw+UsvN0yjN8oSexwe0sUzKG1AVIrHYiAWkZKIohtsv7NNzBAKvJ4Qmw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/client-cognito-identity": "3.199.0",
         "@aws-sdk/client-sso": "3.199.0",
@@ -3941,6 +3985,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.199.0.tgz",
       "integrity": "sha512-o1jRUMoJR/HOhqA2euYIQxzKLkbqBGwMGH3ahm5eqEJ9kCp84c2KsxT/HOEqjvAQi3f3np8VlTPbuscvDKUN4w==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.198.0",
         "@aws-sdk/querystring-builder": "3.199.0",
@@ -3954,6 +3999,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.198.0.tgz",
       "integrity": "sha512-+UTjEEQlvT4+IIwLpN36Qb1DOQHe3zHkvIVe6SjLln+Z/UEK6NhMI0tsJNbiW38WAfwOjJ+otrRBHuD93SBRxQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.198.0",
         "@aws-sdk/util-buffer-from": "3.188.0",
@@ -3965,6 +4011,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.198.0.tgz",
       "integrity": "sha512-lbwS+H7WYk/g9/nHoTgt7xkrZCJ/OJuBfsx41RvMxW7zPxJeHYD/PvgPvYOB9lTUBkr7SDCeMoS5PtGdAwVOfg==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -3975,6 +4022,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
       "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -3984,6 +4032,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.199.0.tgz",
       "integrity": "sha512-Q76J6xZl36tqS401TGs/NPIu8lYbNG1EtqxM88CWe/u0SH+D4LIR9AMXq9c4PH0ldIMWAGVGbRLLc0/H3rPyBg==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -3995,6 +4044,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.198.0.tgz",
       "integrity": "sha512-J/rQkIXUbFJAlD6LSDVGU4bGbwD/2pvF5N39ePzvaJ8SwV9Y78XER/2fIAERhFNppuYinGdBdMLiPsC6qPT6ZA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/middleware-serde": "3.198.0",
         "@aws-sdk/protocol-http": "3.198.0",
@@ -4011,6 +4061,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.198.0.tgz",
       "integrity": "sha512-keHstrdw0bFzEkUrkMQ9+UxaKu5b1K87cH6guqLf4JBo04CT+2kPRlDSma65XCi2U81zfTnWApk+/SPPFN3otA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -4022,6 +4073,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.198.0.tgz",
       "integrity": "sha512-IFvNO4MI80FyltPzrEpYHMG47EYXawcD5zTzcbimpeLTpyrLY/zkSJqh5cVFu+NcDWsuD6U1geuvfN+i+2Bg1Q==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -4032,6 +4084,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.198.0.tgz",
       "integrity": "sha512-VHyz5xBJOaLZwdL94XWB04XCA+pwbURy+4ESF66vIY1umWgfanbZPkvw1XlRaQJydOmyIDFqhNG2AzB28WN9iw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -4043,6 +4096,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.198.0.tgz",
       "integrity": "sha512-dwv5QJYTPNkmjKcQ0RtClkNumFomECzxjXvSiyjD9Ft6AWHcUeyqJfGKbmP5mFHpezWckK1qcT6cPMVrJilgjw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.198.0",
         "@aws-sdk/service-error-classification": "3.198.0",
@@ -4057,6 +4111,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.199.0.tgz",
       "integrity": "sha512-ISM3Lx1AM2IiHpcQPdwHHvnW/dRyC/jGy2fHQvmYxj8x2oIYnEXxk4vA7DFnrYupxwi2yTSp3k8On2+1VgMjiw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/middleware-signing": "3.198.0",
         "@aws-sdk/property-provider": "3.198.0",
@@ -4071,6 +4126,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.198.0.tgz",
       "integrity": "sha512-RlAua2691KCFabp3kjnsd5p+1nQbULTK1Ia/jvlTAyG4tGOeA0x1At6KZoI1LfkN+VjstV5/3b9aOCtcFuxkhA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -4081,6 +4137,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.198.0.tgz",
       "integrity": "sha512-HPY9d1c1CUiV6JBVxiiQQgYfmELl1cn6h0TI00EmOAM5/wxUoiYBX2cGWf2NRF9/iBTppZjxwAKMYPIqF5Tkvw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.198.0",
         "@aws-sdk/protocol-http": "3.198.0",
@@ -4095,6 +4152,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.198.0.tgz",
       "integrity": "sha512-5mHRjiJFHxziXOiChW3kttQHjgqH5qW9xRIDJepyf+NRJ60L8bZj0t8oGecqVqo27S02+UvrFgOzoRvBbATVFw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -4104,6 +4162,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.198.0.tgz",
       "integrity": "sha512-SMteVixqoSazxUN1ROMj+nSf/zgTMRVPaTCKU0iEAtrE7ilp9Xv6FEC7ffm1MM9xIoAZ2eY1eAtY3uN0yxBm4A==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -4115,6 +4174,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.198.0.tgz",
       "integrity": "sha512-W+msdp94ZjR8mJMtGPHjWHsIdsOu3HaVX4x+AQq9cj7+pg/D5CvWw7fnbkUQeG+V8Ia/aqzBNxlUpr/FAeQY/g==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.198.0",
         "@aws-sdk/shared-ini-file-loader": "3.198.0",
@@ -4127,6 +4187,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.199.0.tgz",
       "integrity": "sha512-F+6T7MHHm0b3+GVRxEnFCuIyqUQb0b8a3Hne3QFV4cxtnX58O/SSF8KlpuGZwobivdRC/AKDaTdI/eA0PQfegA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/abort-controller": "3.198.0",
         "@aws-sdk/protocol-http": "3.198.0",
@@ -4140,6 +4201,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.198.0.tgz",
       "integrity": "sha512-jnQeJgZlk+6YJS2/eFz6pm9+XHzvCB0jTxHBwt2zYwZfcJ98viRQWMYfkY1XsemuQb/uIoHRBRhFXaJSLpXVDQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -4150,6 +4212,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.198.0.tgz",
       "integrity": "sha512-x+Qc+kwYqaZvLJ/820rxoFUIgSnSS/XlUHwmS+CTn7nJ68CeL3dzmae6TVOslpVBLCvoS2CbEpEoBbofOpsbGw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -4160,6 +4223,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.199.0.tgz",
       "integrity": "sha512-P4MWPzCqtH3sgI9iXXVdYirYVgggtg4uq5MVefnfHW+osZu8ZR+UKJw5ojAFfOCqcnKOU/xJjz185RroOjrzYQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.198.0",
         "@aws-sdk/util-uri-escape": "3.188.0",
@@ -4171,6 +4235,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.198.0.tgz",
       "integrity": "sha512-oMybZYINxNiwSELR7tOwqu+1S7CeEC3g5L4IQXk2wvVx96HEf3sQgLr1wbmV1b7lEnTuH9OrgI5RgDUBVqipdw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -4180,13 +4245,15 @@
       "version": "3.198.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.198.0.tgz",
       "integrity": "sha512-bVsWOIYuDtSmwJtPF1pU84x2TL20Pj02C0+/6ua4qLvRatVKFbj1wxWiU/nKvgjiGFX8VWuQUKMzXUYQfYn4nw==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@aws-sdk/shared-ini-file-loader": {
       "version": "3.198.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.198.0.tgz",
       "integrity": "sha512-n3Ykuvtb6f+WQuhcMVumY9VxQwPp8+cMSc5s6YHptkvZkz/cd2wmPhO914gKE/i2MoC/zQsFCXT8Z1YnS7k8sA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -4197,6 +4264,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.198.0.tgz",
       "integrity": "sha512-8EIyEt7ElTK/tQamYyB16IGwc7EwtLlSVcksaiII780ZtYULnOjogi/UImCYqSejQw+EHhXfbj14HRQT56rqEQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.188.0",
         "@aws-sdk/types": "3.198.0",
@@ -4211,6 +4279,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.198.0.tgz",
       "integrity": "sha512-IKUzJSoIkxYkYpRdlrh6REtDcW5c87FKeqtMC8VTpaTxrXwnJOqbenp7IwArwOnbXp4aIVmzdxT/nvQrftlgWg==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/middleware-stack": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -4221,13 +4290,15 @@
       "version": "3.198.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.198.0.tgz",
       "integrity": "sha512-ljgY9Pgb2CSRrf4IeaNy5gkhTsBae9STKc/mqfScSzvZOvRHu+BOIAGM33fDoCwxD1viKNVJvU1KemiI57Gbvw==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "@aws-sdk/url-parser": {
       "version": "3.198.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.198.0.tgz",
       "integrity": "sha512-wm3+OTDWKsMEOlLGvJ+jxCcOXMjgd5qBDVbu2bTiyTahc2poNlM7kKhSwL4I8PkmGZVAqfAlHD4Wj38WecHQPw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/querystring-parser": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -4239,6 +4310,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
       "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
       "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -4248,6 +4320,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.188.0.tgz",
       "integrity": "sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "3.188.0",
         "tslib": "^2.3.1"
@@ -4258,6 +4331,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
       "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
       "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -4267,6 +4341,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.188.0.tgz",
       "integrity": "sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==",
       "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -4276,6 +4351,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
       "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.188.0",
         "tslib": "^2.3.1"
@@ -4286,6 +4362,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
       "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
       "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -4295,6 +4372,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.198.0.tgz",
       "integrity": "sha512-IG4iVKQdFjdVFMH5KbSUY2l48wL9aCX/qzoCyTPjKkVumvmwnfkt5OCslkNcaqRdvp5o7QL7aHbq0EZ3K7Ya0A==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -4307,6 +4385,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.198.0.tgz",
       "integrity": "sha512-LBKSKJjEs0D8tjalblDNmq9DWYTDQ1wVUksAIBO2gQU+EZHJwPb9qxyAk32gbnVTOYceZpJ5/vAGT7speDzEyw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/config-resolver": "3.198.0",
         "@aws-sdk/credential-provider-imds": "3.198.0",
@@ -4321,6 +4400,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.198.0.tgz",
       "integrity": "sha512-fpeJNVoe/QsIcGybgJ+D2jZcUFi7d37FlMiZd9eVnS5LyMGDNH8tVS7aPT7dgb0z30/FKMBIKKG6QxDGxFaqjQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.198.0",
         "tslib": "^2.3.1"
@@ -4331,6 +4411,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
       "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -4340,6 +4421,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.188.0.tgz",
       "integrity": "sha512-SxobBVLZkkLSawTCfeQnhVX3Azm9O+C2dngZVe1+BqtF8+retUbVTs7OfYeWBlawVkULKF2e781lTzEHBBjCzw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -4349,6 +4431,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.198.0.tgz",
       "integrity": "sha512-hEdkuGRWhZdEb1plzkGCN2kT8SqiPrEQHngB+1q7pjFJcKWkYkmaLHGw2zhbg1EVNpcGmj5DzCSWzwoPkpDRsw==",
       "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -4358,6 +4441,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
       "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
       "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -4367,6 +4451,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.198.0.tgz",
       "integrity": "sha512-XIwaaKtrEsxsayk1yUNjx15AZenP6YRaRDa3f6dhGO+D6OOXP+0S38O5lakyDDGW7nkwkmXa2NIv/OPHPYJ+jQ==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.198.0",
         "bowser": "^2.11.0",
@@ -4378,6 +4463,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.198.0.tgz",
       "integrity": "sha512-21bi3pNO7jvo3l9LtMJyR48ERN69PuBqMnwnjsDVqyIFBbnZr/JR5rWQx7jdZ0iUt6mRlgZ17xHXlGUGMCxznA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/node-config-provider": "3.198.0",
         "@aws-sdk/types": "3.198.0",
@@ -4389,6 +4475,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
       "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
       "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -4398,6 +4485,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.199.0.tgz",
       "integrity": "sha512-Kk3qCdGbe5k0PUE8EBgMsRxNstvDCoWStYWjNwsHWuc/hJitSf44PColzXw6xxHqH1sY+6LcgIaMwJZ5C4bB6w==",
       "optional": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/util-buffer-from": "3.188.0",
         "tslib": "^2.3.1"
@@ -4497,6 +4585,15 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@mongodb-js/saslprep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "@pkgjs/parseargs": {
@@ -4649,11 +4746,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -4670,7 +4762,8 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -4698,21 +4791,9 @@
       "dev": true
     },
     "bson": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
-      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
-      "requires": {
-        "buffer": "^5.6.0"
-      }
-    },
-    "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
+      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA=="
     },
     "camelcase": {
       "version": "6.3.0",
@@ -4915,11 +4996,6 @@
         "is-descriptor": "^0.1.0"
       }
     },
-    "denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
-    },
     "diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -4973,6 +5049,7 @@
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
       "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "strnum": "^1.0.5"
       }
@@ -5149,11 +5226,6 @@
       "requires": {
         "parse-passwd": "^1.0.0"
       }
-    },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -5565,22 +5637,20 @@
       }
     },
     "mongodb": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.11.0.tgz",
-      "integrity": "sha512-9l9n4Nk2BYZzljW3vHah3Z0rfS5npKw6ktnkmFgTcnzaXH1DRm3pDl6VMHu84EVb1lzmSaJC4OzWZqTkB5i2wg==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.1.tgz",
+      "integrity": "sha512-wKyh4kZvm6NrCPH8AxyzXm3JBoEf4Xulo0aUWh3hCgwgYJxyQ1KLST86ZZaSWdj6/kxYUA3+YZuyADCE61CMSg==",
       "requires": {
-        "@aws-sdk/credential-providers": "^3.186.0",
-        "bson": "^4.7.0",
-        "denque": "^2.1.0",
-        "mongodb-connection-string-url": "^2.5.4",
-        "saslprep": "^1.0.3",
+        "@mongodb-js/saslprep": "^1.1.0",
+        "bson": "^5.4.0",
+        "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       }
     },
     "mongodb-connection-string-url": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.4.tgz",
-      "integrity": "sha512-SeAxuWs0ez3iI3vvmLk/j2y+zHwigTDKQhtdxTgt5ZCOQQS5+HW4g45/Xw5vzzbn7oQXCNQ24Z40AkJsizEy7w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "requires": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
@@ -5684,9 +5754,9 @@
       "dev": true
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -5798,15 +5868,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
-    },
-    "saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "optional": true,
-      "requires": {
-        "sparse-bitfield": "^3.0.3"
-      }
     },
     "serialize-javascript": {
       "version": "6.0.0",
@@ -5953,7 +6014,8 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "success-symbol": {
       "version": "0.1.0",
@@ -6110,7 +6172,8 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "typescript": {
       "version": "4.9.5",
@@ -6134,7 +6197,8 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "@foal/core": "^3.3.0",
-    "mongodb": "~4.11.0"
+    "mongodb": "~5.8.1"
   },
   "devDependencies": {
     "@types/mocha": "10.0.1",

--- a/packages/typeorm/package-lock.json
+++ b/packages/typeorm/package-lock.json
@@ -10,25 +10,24 @@
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "10.0.1",
-        "better-sqlite3": "~7.6.2",
         "mocha": "~10.2.0",
-        "mongodb": "~3.7.3",
+        "mongodb": "~5.8.1",
         "mysql": "~2.18.1",
-        "pg": "~8.7.3",
+        "pg": "~8.11.3",
         "rimraf": "~5.0.1",
-        "sqlite3": "~5.1.2",
+        "sqlite3": "~5.1.6",
         "ts-node": "~10.9.1",
-        "typeorm": "0.3.10",
+        "typeorm": "0.3.17",
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
       },
       "peerDependencies": {
-        "typeorm": "^0.3.10"
+        "typeorm": "^0.3.17"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -206,6 +205,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@npmcli/fs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
@@ -307,8 +316,23 @@
       "version": "18.11.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.8.tgz",
       "integrity": "sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A==",
+      "dev": true
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==",
+      "dev": true
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "dev": true,
-      "peer": true
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -516,6 +540,8 @@
       "integrity": "sha512-S5zIU1Hink2AH4xPsN0W43T1/AJ5jrPh7Oy07ocuW/AKYYY02GWzz9NH0nbSMn/gw6fDZ5jZ1QsHt1BXAwJ6Lg==",
       "dev": true,
       "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.0"
@@ -544,18 +570,10 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/brace-expansion": {
@@ -586,12 +604,12 @@
       "dev": true
     },
     "node_modules/bson": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
+      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
       "dev": true,
       "engines": {
-        "node": ">=0.6.19"
+        "node": ">=14.20.1"
       }
     },
     "node_modules/buffer": {
@@ -909,6 +927,8 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -924,6 +944,8 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -933,15 +955,6 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "dev": true
-    },
-    "node_modules/denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/depd": {
       "version": "1.1.2",
@@ -1007,6 +1020,8 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -1054,6 +1069,8 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -1062,7 +1079,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -1133,7 +1152,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -1200,7 +1221,9 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -1421,14 +1444,15 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/ip": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -1664,6 +1688,8 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1688,6 +1714,8 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1803,7 +1831,9 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/mocha": {
       "version": "10.2.0",
@@ -1846,28 +1876,33 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.1.tgz",
+      "integrity": "sha512-wKyh4kZvm6NrCPH8AxyzXm3JBoEf4Xulo0aUWh3hCgwgYJxyQ1KLST86ZZaSWdj6/kxYUA3+YZuyADCE61CMSg==",
       "dev": true,
       "dependencies": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2"
+        "bson": "^5.4.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=14.20.1"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.0"
+        "@mongodb-js/saslprep": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
       },
       "peerDependenciesMeta": {
-        "aws4": {
+        "@aws-sdk/credential-providers": {
           "optional": true
         },
-        "bson-ext": {
+        "@mongodb-js/zstd": {
           "optional": true
         },
         "kerberos": {
@@ -1876,12 +1911,53 @@
         "mongodb-client-encryption": {
           "optional": true
         },
-        "mongodb-extjson": {
-          "optional": true
-        },
         "snappy": {
           "optional": true
         }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ms": {
@@ -1938,7 +2014,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -1955,6 +2033,8 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
       "integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -2148,18 +2228,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/optional-require": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-      "dev": true,
-      "dependencies": {
-        "require-at": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -2295,24 +2363,27 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.7.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.3.tgz",
-      "integrity": "sha512-HPmH4GH4H3AOprDJOazoIcpI49XFsHCe8xlrjHkWiapdbHK+HLtbm/GQzXYAZwmPju/kzKhjaSfMACG+8cgJcw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
+      "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
       "dev": true,
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.5.0",
-        "pg-pool": "^3.5.1",
-        "pg-protocol": "^1.5.0",
+        "pg-connection-string": "^2.6.2",
+        "pg-pool": "^3.6.1",
+        "pg-protocol": "^1.6.0",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       },
       "engines": {
         "node": ">= 8.0.0"
       },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
       "peerDependencies": {
-        "pg-native": ">=2.0.0"
+        "pg-native": ">=3.0.1"
       },
       "peerDependenciesMeta": {
         "pg-native": {
@@ -2320,10 +2391,17 @@
         }
       }
     },
+    "node_modules/pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
+      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==",
       "dev": true
     },
     "node_modules/pg-int8": {
@@ -2336,18 +2414,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
-      "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
+      "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
       "dev": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
-      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==",
       "dev": true
     },
     "node_modules/pg-types": {
@@ -2431,6 +2509,8 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
       "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -2484,9 +2564,20 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/randombytes": {
@@ -2503,6 +2594,8 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -2518,6 +2611,8 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2560,15 +2655,6 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
       "dev": true
-    },
-    "node_modules/require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -2680,25 +2766,6 @@
       "dev": true,
       "optional": true
     },
-    "node_modules/saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
-    },
     "node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -2787,7 +2854,9 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "optional": true,
+      "peer": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -2808,6 +2877,8 @@
           "url": "https://feross.org/support"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -2819,7 +2890,6 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -2830,7 +2900,6 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
       "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
@@ -2875,9 +2944,9 @@
       }
     },
     "node_modules/sqlite3": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.2.tgz",
-      "integrity": "sha512-D0Reg6pRWAFXFUnZKsszCI67tthFD8fGPewRddDCX6w4cYwz3MbvuwRICbL+YQjBAh9zbw+lJ/V9oC8nG5j6eg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.6.tgz",
+      "integrity": "sha512-olYkWoKFVNSSSQNvxVUfjiVbz3YtBwTJj+mfV5zpHmqW3sELx2Cf4QCdirMelhM5Zh+KDVaKgQHqCxrqiWHybw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3037,6 +3106,8 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -3048,13 +3119,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -3071,6 +3146,8 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -3096,6 +3173,8 @@
           "url": "https://feross.org/support"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -3106,6 +3185,8 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -3207,9 +3288,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "node_modules/tunnel-agent": {
@@ -3217,6 +3298,8 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -3225,28 +3308,26 @@
       }
     },
     "node_modules/typeorm": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.10.tgz",
-      "integrity": "sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.17.tgz",
+      "integrity": "sha512-UDjUEwIQalO9tWw9O2A4GU+sT3oyoUXheHJy4ft+RFdnRdQctdQ34L9SqE2p7LdwzafHx1maxT+bqXON+Qnmig==",
       "dev": true,
       "dependencies": {
-        "@sqltools/formatter": "^1.2.2",
-        "app-root-path": "^3.0.0",
+        "@sqltools/formatter": "^1.2.5",
+        "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "chalk": "^4.1.0",
+        "chalk": "^4.1.2",
         "cli-highlight": "^2.1.11",
-        "date-fns": "^2.28.0",
-        "debug": "^4.3.3",
-        "dotenv": "^16.0.0",
-        "glob": "^7.2.0",
-        "js-yaml": "^4.1.0",
-        "mkdirp": "^1.0.4",
+        "date-fns": "^2.29.3",
+        "debug": "^4.3.4",
+        "dotenv": "^16.0.3",
+        "glob": "^8.1.0",
+        "mkdirp": "^2.1.3",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2",
-        "xml2js": "^0.4.23",
-        "yargs": "^17.3.1"
+        "tslib": "^2.5.0",
+        "uuid": "^9.0.0",
+        "yargs": "^17.6.2"
       },
       "bin": {
         "typeorm": "cli.js",
@@ -3262,12 +3343,12 @@
       "peerDependencies": {
         "@google-cloud/spanner": "^5.18.0",
         "@sap/hana-client": "^2.12.25",
-        "better-sqlite3": "^7.1.2",
+        "better-sqlite3": "^7.1.2 || ^8.0.0",
         "hdb-pool": "^0.1.6",
         "ioredis": "^5.0.4",
-        "mongodb": "^3.6.0",
-        "mssql": "^7.3.0",
-        "mysql2": "^2.2.5",
+        "mongodb": "^5.2.0",
+        "mssql": "^9.1.1",
+        "mysql2": "^2.2.5 || ^3.0.1",
         "oracledb": "^5.1.0",
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
@@ -3346,10 +3427,44 @@
         "node": ">=12"
       }
     },
+    "node_modules/typeorm/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typeorm/node_modules/mkdirp": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typeorm/node_modules/yargs": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
-      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -3358,7 +3473,7 @@
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
         "node": ">=12"
@@ -3413,9 +3528,9 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -3513,28 +3628,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
-    },
-    "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dev": true,
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -3756,6 +3849,16 @@
         }
       }
     },
+    "@mongodb-js/saslprep": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "@npmcli/fs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
@@ -3844,8 +3947,23 @@
       "version": "18.11.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.8.tgz",
       "integrity": "sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A==",
+      "dev": true
+    },
+    "@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog==",
+      "dev": true
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "dev": true,
-      "peer": true
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
     },
     "abbrev": {
       "version": "1.1.1",
@@ -3998,6 +4116,8 @@
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
       "integrity": "sha512-S5zIU1Hink2AH4xPsN0W43T1/AJ5jrPh7Oy07ocuW/AKYYY02GWzz9NH0nbSMn/gw6fDZ5jZ1QsHt1BXAwJ6Lg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.0"
@@ -4020,18 +4140,10 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
-      }
-    },
-    "bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
       }
     },
     "brace-expansion": {
@@ -4059,9 +4171,9 @@
       "dev": true
     },
     "bson": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
+      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
       "dev": true
     },
     "buffer": {
@@ -4290,6 +4402,8 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "mimic-response": "^3.1.0"
       }
@@ -4298,18 +4412,14 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true
-    },
-    "denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
       "dev": true
     },
     "depd": {
@@ -4364,6 +4474,8 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -4398,13 +4510,17 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -4453,7 +4569,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "fs-minipass": {
       "version": "2.1.0",
@@ -4504,7 +4622,9 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "glob": {
       "version": "7.2.0",
@@ -4677,14 +4797,15 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "ip": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -4859,7 +4980,9 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "minimatch": {
       "version": "5.0.1",
@@ -4874,7 +4997,9 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "minipass": {
       "version": "3.3.4",
@@ -4958,7 +5083,9 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "mocha": {
       "version": "10.2.0",
@@ -4990,17 +5117,52 @@
       }
     },
     "mongodb": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
-      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.1.tgz",
+      "integrity": "sha512-wKyh4kZvm6NrCPH8AxyzXm3JBoEf4Xulo0aUWh3hCgwgYJxyQ1KLST86ZZaSWdj6/kxYUA3+YZuyADCE61CMSg==",
       "dev": true,
       "requires": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "@mongodb-js/saslprep": "^1.1.0",
+        "bson": "^5.4.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "dev": true,
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "dev": true,
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
       }
     },
     "ms": {
@@ -5050,7 +5212,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "negotiator": {
       "version": "0.6.3",
@@ -5064,6 +5228,8 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.28.0.tgz",
       "integrity": "sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "semver": "^7.3.5"
       }
@@ -5209,15 +5375,6 @@
         "wrappy": "1"
       }
     },
-    "optional-require": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-      "dev": true,
-      "requires": {
-        "require-at": "^1.0.6"
-      }
-    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5318,24 +5475,32 @@
       }
     },
     "pg": {
-      "version": "8.7.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.3.tgz",
-      "integrity": "sha512-HPmH4GH4H3AOprDJOazoIcpI49XFsHCe8xlrjHkWiapdbHK+HLtbm/GQzXYAZwmPju/kzKhjaSfMACG+8cgJcw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
+      "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
       "dev": true,
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.5.0",
-        "pg-pool": "^3.5.1",
-        "pg-protocol": "^1.5.0",
+        "pg-cloudflare": "^1.1.1",
+        "pg-connection-string": "^2.6.2",
+        "pg-pool": "^3.6.1",
+        "pg-protocol": "^1.6.0",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       }
     },
+    "pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "dev": true,
+      "optional": true
+    },
     "pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
+      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==",
       "dev": true
     },
     "pg-int8": {
@@ -5345,16 +5510,16 @@
       "dev": true
     },
     "pg-pool": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
-      "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
+      "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
       "dev": true,
       "requires": {}
     },
     "pg-protocol": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
-      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==",
       "dev": true
     },
     "pg-types": {
@@ -5417,6 +5582,8 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
       "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -5461,10 +5628,18 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -5480,6 +5655,8 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -5491,7 +5668,9 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -5531,12 +5710,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
-      "dev": true
-    },
-    "require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
       "dev": true
     },
     "require-directory": {
@@ -5604,22 +5777,6 @@
       "dev": true,
       "optional": true
     },
-    "saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "sparse-bitfield": "^3.0.3"
-      }
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
-    },
     "semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -5679,13 +5836,17 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "simple-get": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -5696,15 +5857,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "socks": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
       "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
@@ -5739,9 +5898,9 @@
       "dev": true
     },
     "sqlite3": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.2.tgz",
-      "integrity": "sha512-D0Reg6pRWAFXFUnZKsszCI67tthFD8fGPewRddDCX6w4cYwz3MbvuwRICbL+YQjBAh9zbw+lJ/V9oC8nG5j6eg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.6.tgz",
+      "integrity": "sha512-olYkWoKFVNSSSQNvxVUfjiVbz3YtBwTJj+mfV5zpHmqW3sELx2Cf4QCdirMelhM5Zh+KDVaKgQHqCxrqiWHybw==",
       "dev": true,
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.0",
@@ -5857,6 +6016,8 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
       "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -5868,7 +6029,9 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
           "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -5877,6 +6040,8 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -5890,6 +6055,8 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
           "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "buffer": "^5.5.0",
             "inherits": "^2.0.4",
@@ -5901,6 +6068,8 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
           "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.1.13"
@@ -5911,6 +6080,8 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -5982,9 +6153,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "tunnel-agent": {
@@ -5992,33 +6163,33 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
     },
     "typeorm": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.10.tgz",
-      "integrity": "sha512-VMKiM84EpJQ+Mz9xDIPqnfplWhyUy1d8ccaKdMY9obifxJOTFnv8GYVyPsGwG8Lk7Nb8MlttHyHWENGAhBA3WA==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.17.tgz",
+      "integrity": "sha512-UDjUEwIQalO9tWw9O2A4GU+sT3oyoUXheHJy4ft+RFdnRdQctdQ34L9SqE2p7LdwzafHx1maxT+bqXON+Qnmig==",
       "dev": true,
       "requires": {
-        "@sqltools/formatter": "^1.2.2",
-        "app-root-path": "^3.0.0",
+        "@sqltools/formatter": "^1.2.5",
+        "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "chalk": "^4.1.0",
+        "chalk": "^4.1.2",
         "cli-highlight": "^2.1.11",
-        "date-fns": "^2.28.0",
-        "debug": "^4.3.3",
-        "dotenv": "^16.0.0",
-        "glob": "^7.2.0",
-        "js-yaml": "^4.1.0",
-        "mkdirp": "^1.0.4",
+        "date-fns": "^2.29.3",
+        "debug": "^4.3.4",
+        "dotenv": "^16.0.3",
+        "glob": "^8.1.0",
+        "mkdirp": "^2.1.3",
         "reflect-metadata": "^0.1.13",
         "sha.js": "^2.4.11",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2",
-        "xml2js": "^0.4.23",
-        "yargs": "^17.3.1"
+        "tslib": "^2.5.0",
+        "uuid": "^9.0.0",
+        "yargs": "^17.6.2"
       },
       "dependencies": {
         "cliui": {
@@ -6032,10 +6203,29 @@
             "wrap-ansi": "^7.0.0"
           }
         },
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "mkdirp": {
+          "version": "2.1.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
+          "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
+          "dev": true
+        },
         "yargs": {
-          "version": "17.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
-          "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "dev": true,
           "requires": {
             "cliui": "^8.0.1",
@@ -6044,7 +6234,7 @@
             "require-directory": "^2.1.1",
             "string-width": "^4.2.3",
             "y18n": "^5.0.5",
-            "yargs-parser": "^21.0.0"
+            "yargs-parser": "^21.1.1"
           }
         },
         "yargs-parser": {
@@ -6088,9 +6278,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "dev": true
     },
     "v8-compile-cache-lib": {
@@ -6165,22 +6355,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
-    },
-    "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dev": true,
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true
     },
     "xtend": {

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -51,18 +51,18 @@
     "@foal/core": "^3.3.0"
   },
   "peerDependencies": {
-    "typeorm": "^0.3.10"
+    "typeorm": "^0.3.17"
   },
   "devDependencies": {
     "@types/mocha": "10.0.1",
     "mocha": "~10.2.0",
-    "mongodb": "~3.7.3",
+    "mongodb": "~5.8.1",
     "mysql": "~2.18.1",
-    "pg": "~8.7.3",
+    "pg": "~8.11.3",
     "rimraf": "~5.0.1",
-    "sqlite3": "~5.1.2",
+    "sqlite3": "~5.1.6",
     "ts-node": "~10.9.1",
-    "typeorm": "0.3.10",
+    "typeorm": "0.3.17",
     "typescript": "~4.9.5"
   }
 }

--- a/packages/typeorm/typings/mongodb/index.d.ts
+++ b/packages/typeorm/typings/mongodb/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'mongodb';


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Database dependencies need to be upgraded

# Solution and steps

- [x] Upgrade dependencies

# Changes

- No need to maintain to version of `mongodb` if using MongoDB store et TypeORM (use `mongodb@5`).
- Use `typeorm@0.3.17`
- The type `ObjectID` from `typeorm` is now called `ObjectId`.

# Dependencies

- `mongodb@5.8`
- `typeorm@0.3.17`
- `pg@8.11`