### PR TITLE
Compile packages to ES2022 and not ES2021 anymore

### DIFF
--- a/packages/acceptance-tests/tsconfig.json
+++ b/packages/acceptance-tests/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -14,7 +14,7 @@
       "./typings"
     ],
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ],
     "jsx": "react"

--- a/packages/aws-s3/tsconfig.json
+++ b/packages/aws-s3/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "declaration": true,
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },

--- a/packages/cli/src/generate/specs/app/tsconfig.json
+++ b/packages/cli/src/generate/specs/app/tsconfig.json
@@ -8,10 +8,10 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "rootDir": "src",
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },

--- a/packages/cli/src/generate/templates/app/tsconfig.json
+++ b/packages/cli/src/generate/templates/app/tsconfig.json
@@ -8,10 +8,10 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "rootDir": "src",
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -14,7 +14,7 @@
       "./typings"
     ],
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -14,7 +14,7 @@
       "./typings"
     ],
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },

--- a/packages/examples/src/app/entities/user.entity.ts
+++ b/packages/examples/src/app/entities/user.entity.ts
@@ -6,9 +6,6 @@ import { UserWithPermissions } from '@foal/typeorm';
 @Entity()
 export class User extends UserWithPermissions {
 
-  @PrimaryGeneratedColumn()
-  id: number;
-
   @Column({ unique: true })
   email: string;
 

--- a/packages/examples/src/app/entities/user.entity.ts
+++ b/packages/examples/src/app/entities/user.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity } from 'typeorm';
 
 import { hashPassword } from '@foal/core';
 import { UserWithPermissions } from '@foal/typeorm';

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -3,14 +3,14 @@
     "outDir": "build",
     "sourceMap": true,
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
     "baseUrl": ".",
     // "declaration": true,
     "lib": [
-      "es2021",
+      "es2022",
       "dom",
       "ESNext.AsyncIterable"
     ]

--- a/packages/graphiql/tsconfig.json
+++ b/packages/graphiql/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "declaration": true,
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -14,7 +14,7 @@
       "./typings"
     ],
     "lib": [
-      "es2021",
+      "es2022",
       "dom",
       "ESNext.AsyncIterable"
     ]

--- a/packages/internal-test/tsconfig.json
+++ b/packages/internal-test/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "declaration": true,
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },

--- a/packages/jwks-rsa/tsconfig.json
+++ b/packages/jwks-rsa/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "declaration": true,
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },

--- a/packages/jwt/tsconfig.json
+++ b/packages/jwt/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -14,7 +14,7 @@
       "./typings"
     ],
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },

--- a/packages/mongodb/tsconfig.json
+++ b/packages/mongodb/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "declaration": true,
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ],
     "types": [

--- a/packages/password/tsconfig.json
+++ b/packages/password/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "declaration": true,
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ],
     "types": [

--- a/packages/redis/tsconfig.json
+++ b/packages/redis/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "declaration": true,
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ],
     "types": [

--- a/packages/social/tsconfig.json
+++ b/packages/social/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -14,7 +14,7 @@
       "./typings"
     ],
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },

--- a/packages/socket.io/tsconfig.json
+++ b/packages/socket.io/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "declaration": true,
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ],
     "types": [

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -14,7 +14,7 @@
       "./typings"
     ],
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },

--- a/packages/swagger/tsconfig.json
+++ b/packages/swagger/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -14,7 +14,7 @@
       "./typings"
     ],
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },

--- a/packages/typeorm/tsconfig.json
+++ b/packages/typeorm/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -14,7 +14,7 @@
       "./typings"
     ],
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },

--- a/packages/typestack/tsconfig.json
+++ b/packages/typestack/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "declaration": true,
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "./lib/",
     "baseUrl": ".",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2022",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -11,7 +11,7 @@
     "sourceMap": true,
     "declaration": true,
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ]
   },


### PR DESCRIPTION
# Issue

Version 4 of Foal supports Node 18 and 20. We can safely compile the code to ES2022 (ES2023 is currently not supported by tsc).

Ref: https://node.green

# Solution and steps

- [x] Change the `target` fields in `tsconfig.json`

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
