### PR TITLE
Use fs native API with promises

### DIFF
--- a/packages/cli/src/rmdir/rmdir.util.ts
+++ b/packages/cli/src/rmdir/rmdir.util.ts
@@ -1,7 +1,5 @@
 // std
-import { readdir, rmdir as fsRmdir, stat, unlink } from 'fs';
-import { join } from 'path';
-import { promisify } from 'util';
+import { rm, readdir } from 'node:fs/promises';
 
 /**
  * Remove a directory and all its contents, including any subdirectories and files.
@@ -13,7 +11,7 @@ import { promisify } from 'util';
 export async function rmdir(path: string): Promise<void> {
   let contents: string[];
   try {
-    contents = await promisify(readdir)(path);
+    contents = await readdir(path);
   } catch (error: any) {
     if (error.code === 'ENOENT') {
       return;
@@ -21,16 +19,5 @@ export async function rmdir(path: string): Promise<void> {
     throw error;
   }
 
-  await Promise.all(contents.map(content => {
-    const subPath = join(path, content);
-    return promisify(stat)(subPath)
-      .then(stats => {
-        if (stats.isDirectory()) {
-          return rmdir(subPath);
-        }
-        return promisify(unlink)(subPath);
-      });
-  }));
-
-  await promisify(fsRmdir)(path);
+  await rm(path, { recursive: true });
 }

--- a/packages/cli/src/rmdir/rmdir.util.ts
+++ b/packages/cli/src/rmdir/rmdir.util.ts
@@ -9,9 +9,8 @@ import { rm, readdir } from 'node:fs/promises';
  * @returns {Promise<void>}
  */
 export async function rmdir(path: string): Promise<void> {
-  let contents: string[];
   try {
-    contents = await readdir(path);
+    await readdir(path);
   } catch (error: any) {
     if (error.code === 'ENOENT') {
       return;

--- a/packages/core/src/common/templates/render-error.ts
+++ b/packages/core/src/common/templates/render-error.ts
@@ -1,7 +1,6 @@
 // std
-import { readFile } from 'fs';
+import { readFile } from 'node:fs/promises';
 import { basename, join } from 'path';
-import { promisify } from 'util';
 
 // FoalTS
 import { Config, Context, HttpResponseInternalServerError } from '../../core';
@@ -23,7 +22,7 @@ export async function renderError(error: Error, ctx: Context): Promise<HttpRespo
   + '<h1>500 - INTERNAL SERVER ERROR</h1></body></html>';
 
   if (Config.get('settings.debug', 'boolean')) {
-    const template = await promisify(readFile)(join(__dirname, '500.debug.html'), 'utf8');
+    const template = await readFile(join(__dirname, '500.debug.html'), 'utf8');
 
     const rex = /at (.*) \((.*):(\d+):(\d+)\)/;
     const [ , , path, line, column ] = Array.from(rex.exec(error.stack || '') || []);

--- a/packages/core/src/common/templates/render.ts
+++ b/packages/core/src/common/templates/render.ts
@@ -1,9 +1,8 @@
 // std
-import { readFile } from 'fs';
+import { readFile } from 'node:fs/promises';
 import { join } from 'path';
 
 // FoalTS
-import { promisify } from 'util';
 import { Config, HttpResponseOK } from '../../core';
 
 /**
@@ -38,7 +37,7 @@ export function renderToString(template: string, locals: any): string {
  */
 export async function render(templatePath: string, locals: object = {}, dirname?: string): Promise<HttpResponseOK> {
   const path = dirname ? join(dirname, templatePath) : templatePath;
-  const template = await promisify(readFile)(path, 'utf8');
+  const template = await readFile(path, 'utf8');
 
   const templateEngine = Config.get('settings.templateEngine', 'string');
   if (templateEngine) {

--- a/packages/core/src/common/utils/is-in-file.util.ts
+++ b/packages/core/src/common/utils/is-in-file.util.ts
@@ -1,6 +1,5 @@
 // std
-import { readFile } from 'fs';
-import { promisify } from 'util';
+import { readFile } from 'node:fs/promises';
 
 /**
  * Generate a function checking if a string is included in a text file.
@@ -11,7 +10,7 @@ import { promisify } from 'util';
  */
 export function isInFile(path: string): (content: string) => Promise<boolean> {
   return async (content: string) => {
-    const fileContent = await promisify(readFile)(path, 'utf8');
+    const fileContent = await readFile(path, 'utf8');
     return fileContent.includes(content);
   };
 }

--- a/packages/graphiql/src/graphiql.controller.spec.ts
+++ b/packages/graphiql/src/graphiql.controller.spec.ts
@@ -1,7 +1,7 @@
 // std
 import { ok, strictEqual } from 'assert';
-import { stat, readFileSync } from 'fs';
-import { promisify } from 'util';
+import { readFileSync } from 'fs';
+import { stat } from 'node:fs/promises';
 import { join } from 'path';
 
 // 3p
@@ -103,7 +103,7 @@ describe('GraphiQLController', () => {
         strictEqual(response.stream, true);
 
         const filePath = join(__dirname, 'static', filename);
-        const stats = await promisify(stat)(filePath);
+        const stats = await stat(filePath);
         strictEqual(response.getHeader('Content-Length'), stats.size.toString());
 
         const content = await streamToBuffer(response.body);

--- a/packages/graphiql/src/graphiql.controller.ts
+++ b/packages/graphiql/src/graphiql.controller.ts
@@ -1,7 +1,7 @@
 // std
-import { createReadStream, readFile, stat } from 'fs';
+import { createReadStream } from 'fs';
+import { readFile, stat } from 'node:fs/promises';
 import { join } from 'path';
-import { promisify } from 'util';
 
 // 3p
 import { Context, Get, HttpResponseMovedPermanently, HttpResponseOK, renderToString } from '@foal/core';
@@ -43,7 +43,7 @@ export class GraphiQLController {
       return new HttpResponseMovedPermanently(ctx.request.path + '/');
     }
 
-    const template = await promisify(readFile)(join(__dirname, 'templates/index.html'), 'utf8');
+    const template = await readFile(join(__dirname, 'templates/index.html'), 'utf8');
 
     const page = renderToString(template, {
       options: JSON.stringify(this.options),
@@ -77,7 +77,7 @@ export class GraphiQLController {
     const filePath = join(__dirname, 'static', filename);
 
     const stream = createReadStream(filePath);
-    const stats = await promisify(stat)(filePath);
+    const stats = await stat(filePath);
 
     return new HttpResponseOK(stream, { stream: true })
       .setHeader('Content-Type', contentType)

--- a/packages/graphql/src/schema-from-type-paths.ts
+++ b/packages/graphql/src/schema-from-type-paths.ts
@@ -1,6 +1,5 @@
-import { readFile } from 'fs';
+import { readFile } from 'node:fs/promises';
 import { GraphQLSchema } from 'graphql';
-import { promisify } from 'util';
 import { schemaFromTypeDefs } from './schema-from-type-defs';
 
 /**
@@ -12,7 +11,7 @@ import { schemaFromTypeDefs } from './schema-from-type-defs';
  */
 export async function schemaFromTypePaths(...paths: string[]): Promise<GraphQLSchema> {
   const files = await Promise.all(
-    paths.map(path => promisify(readFile)(path, 'utf8'))
+    paths.map(path => readFile(path, 'utf8'))
   );
   return schemaFromTypeDefs(...files);
 }

--- a/packages/password/src/is-common.util.ts
+++ b/packages/password/src/is-common.util.ts
@@ -1,5 +1,5 @@
 // std
-import { readFile } from 'fs';
+import { readFile } from 'node:fs/promises';
 import { join } from 'path';
 import { promisify } from 'util';
 import { gunzip, InputType } from 'zlib';
@@ -15,7 +15,7 @@ let list: string[];
  */
 export async function isCommon(password: string): Promise<boolean> {
   if (!list) {
-    const fileContent = await promisify(readFile)(join(__dirname, './10-million-password-list-top-10000.txt.gz'));
+    const fileContent = await readFile(join(__dirname, './10-million-password-list-top-10000.txt.gz'));
     list =  (await promisify<InputType, Buffer>(gunzip)(fileContent)).toString().split('\n');
   }
   return list.includes(password);

--- a/packages/storage/src/local-disk.service.ts
+++ b/packages/storage/src/local-disk.service.ts
@@ -1,5 +1,6 @@
 // std
-import { createReadStream, createWriteStream, readFile, stat, unlink, writeFile } from 'fs';
+import { createReadStream, createWriteStream } from 'fs';
+import { readFile, stat, writeFile, unlink } from 'node:fs/promises';
 import { join } from 'path';
 import { pipeline, Readable } from 'stream';
 import { promisify } from 'util';
@@ -33,7 +34,7 @@ export class LocalDisk extends Disk {
     const path = join(dirname, name);
 
     if (content instanceof Buffer) {
-      await promisify(writeFile)(this.getPath(path), content);
+      await writeFile(this.getPath(path), content);
     } else {
       await promisify(pipeline)(content, createWriteStream(this.getPath(path)));
     }
@@ -46,11 +47,11 @@ export class LocalDisk extends Disk {
     content: C
   ): Promise<{ file: C extends 'buffer' ? Buffer : C extends 'stream' ? Readable : never; size: number; }> {
     try {
-      const { size } = await promisify(stat)(this.getPath(path));
+      const { size } = await stat(this.getPath(path));
 
       if (content === 'buffer') {
         return {
-          file: await promisify(readFile)(this.getPath(path)) as any,
+          file: await readFile(this.getPath(path)) as any,
           size
         };
       }
@@ -76,7 +77,7 @@ export class LocalDisk extends Disk {
 
   async readSize(path: string): Promise<number> {
     try {
-      const { size } = await promisify(stat)(this.getPath(path));
+      const { size } = await stat(this.getPath(path));
       return size;
     } catch (error: any) {
       if (error.code === 'ENOENT') {
@@ -90,7 +91,7 @@ export class LocalDisk extends Disk {
 
   async delete(path: string): Promise<void> {
     try {
-      await promisify(unlink)(this.getPath(path));
+      await unlink(this.getPath(path));
     } catch (error: any) {
       if (error.code === 'ENOENT') {
         throw new FileDoesNotExist(path);

--- a/packages/swagger/src/swagger-controller.spec.ts
+++ b/packages/swagger/src/swagger-controller.spec.ts
@@ -1,8 +1,8 @@
 // std
 import { deepStrictEqual, ok, strictEqual } from 'assert';
-import { readFileSync, stat } from 'fs';
+import { readFileSync } from 'fs';
+import { stat }from 'node:fs/promises';
 import { join } from 'path';
-import { promisify } from 'util';
 
 // 3p
 import {
@@ -369,7 +369,7 @@ describe('SwaggerController', () => {
         strictEqual(response.stream, true);
 
         const filePath = `./node_modules/swagger-ui-dist/${filename}`;
-        const stats = await promisify(stat)(filePath);
+        const stats = await stat(filePath);
         strictEqual(response.getHeader('Content-Length'), stats.size.toString());
 
         const content = await streamToBuffer(response.body);

--- a/packages/swagger/src/swagger-controller.ts
+++ b/packages/swagger/src/swagger-controller.ts
@@ -1,7 +1,7 @@
 // std
-import { createReadStream, readFile, stat } from 'fs';
+import { createReadStream } from 'fs';
+import { readFile, stat } from 'node:fs/promises';
 import { join } from 'path';
-import { promisify } from 'util';
 
 // 3p
 import {
@@ -101,14 +101,14 @@ export abstract class SwaggerController {
       return new HttpResponseMovedPermanently(ctx.request.path + '/');
     }
 
-    const page = await promisify(readFile)(join(__dirname, 'index.html'), 'utf8');
+    const page = await readFile(join(__dirname, 'index.html'), 'utf8');
     return new HttpResponseOK(page)
       .setHeader('Content-Type', 'text/html; charset=utf-8');
   }
 
   @Get('/main.js')
   async main(ctx: Context) {
-    const template = await promisify(readFile)(join(__dirname, 'main.tpl.js'), 'utf8');
+    const template = await readFile(join(__dirname, 'main.tpl.js'), 'utf8');
     let body = '';
 
     if (!Array.isArray(this.options)) {
@@ -156,7 +156,7 @@ export abstract class SwaggerController {
     const filePath = join(getAbsoluteFSPath(), filename);
 
     const stream = createReadStream(filePath);
-    const stats = await promisify(stat)(filePath);
+    const stats = await stat(filePath);
 
     return new HttpResponseOK(stream, { stream: true })
       .setHeader('Content-Type', contentType)


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Some old code has been promisified in order to work with NodeJS API. In latest versions of Node, async functions are natively available with promises. Foal should use these functions directly instead.

# Solution and steps

- [x] Use `node:fs/promises`

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
