### PR TITLE
[CLI] Improve logging of script arguments validation errors

### DIFF
--- a/docs/docs/tutorials/simple-todo-list/4-the-shell-script-create-todo.md
+++ b/docs/docs/tutorials/simple-todo-list/4-the-shell-script-create-todo.md
@@ -71,4 +71,4 @@ foal run create-todo text="Write tests"
 
 > Note that if you try to create a new to-do without specifying the text argument, you'll get the error below.
 >
-> `Error: The command line arguments should have required property 'text'.`
+> `Script error: arguments must have required property 'text'.`

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/tutorials/simple-todo-list/4-the-shell-script-create-todo.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/tutorials/simple-todo-list/4-the-shell-script-create-todo.md
@@ -71,4 +71,4 @@ foal run create-todo text="Write tests"
 
 > Observe que si intenta crear una nueva tarea sin especificar el argumento del texto, obtendrá el siguiente error.
 >
-> `Error: The command line arguments should have required property 'text'.`
+> `Script error: arguments must have required property 'text'.`

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/tutorials/simple-todo-list/4-the-shell-script-create-todo.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/tutorials/simple-todo-list/4-the-shell-script-create-todo.md
@@ -71,4 +71,4 @@ foal run create-todo text="Write tests"
 
 > Notez que si vous essayez de créer une nouvelle tâche sans spécifier l'argument texte, vous obtiendrez l'erreur ci-dessous.
 >
-> `Error: The command line arguments should have required property 'text'.`
+> `Script error: arguments must have required property 'text'.`

--- a/docs/i18n/id/docusaurus-plugin-content-docs/current/tutorials/simple-todo-list/4-the-shell-script-create-todo.md
+++ b/docs/i18n/id/docusaurus-plugin-content-docs/current/tutorials/simple-todo-list/4-the-shell-script-create-todo.md
@@ -71,4 +71,4 @@ foal run create-todo text="Write tests"
 
 > Note that if you try to create a new to-do without specifying the text argument, you'll get the error below.
 >
-> `Error: The command line arguments should have required property 'text'.`
+> `Script error: arguments must have required property 'text'.`

--- a/packages/cli/src/run-script/run-script.ts
+++ b/packages/cli/src/run-script/run-script.ts
@@ -32,11 +32,15 @@ export async function runScript({ name }: { name: string }, argv: string[], log 
   const args = getCommandLineArguments(argv);
 
   if (schema) {
-    const ajv = new Ajv({ useDefaults: true });
+    const ajv = new Ajv({ useDefaults: true, allErrors: true });
     addFormats(ajv);
     if (!ajv.validate(schema, args)) {
       ajv.errors!.forEach(err => {
-        log(`Error: The command line arguments ${err.message}.`);
+        if (err.instancePath) {
+          log(`Script error: the value of "${err.instancePath.split('/')[1]}" ${err.message}.`);
+        } else {
+          log(`Script error: arguments ${err.message}.`);
+        }
       });
       return;
     }


### PR DESCRIPTION
# Issue

When running a shell script with invalid arguments, Foal does not display all the errors.

For example, with this schema and this command call, we only get the following log message:
```typescript
export const schema = {
  type: 'object', 
  properties: {
    email: { type: 'string', format: 'email', maxLength: 2 },
    password: { type: 'string' },
    n: { type: 'number', maximum: 10 }
  },
  required: ['password']
};
```

```bash
foal run my-script email=bar n=11
```

```
Error: The command line arguments must match format "email".
```

# Solution and steps

- [x] Improve the CLI so as to display all the errors (with a better description)

```
Script error: arguments must have required property 'password'.
Script error: the value of "email" must NOT have more than 2 characters.
Script error: the value of "email" must match format "email".
Script error: the value of "n" must be <= 10.
```

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
