### PR TITLE
Upgrade command: Version prefix

### DIFF
--- a/packages/cli/src/generate/file-system.ts
+++ b/packages/cli/src/generate/file-system.ts
@@ -16,6 +16,9 @@ import { dirname, join, parse } from 'path';
 // 3p
 import { cyan, green } from 'colors/safe';
 
+// npm
+import { PackageVersionPrefix } from './generators/upgrade/package-version-prefix';
+
 function rmDirAndFiles(path: string) {
   const files = readdirSync(path);
   for (const file of files) {
@@ -476,13 +479,13 @@ export class FileSystem {
    *
    * @returns {this}
    */
-  setOrUpdateProjectDependency(name: string, version: string): this {
+  setOrUpdateProjectDependency(name: string, version: string, prefix: PackageVersionPrefix): this {
     const initialCurrentDir = this.currentDir;
 
     this.cdProjectRootDir();
     const pkg = JSON.parse(readFileSync(this.parse('package.json'), 'utf8'));
 
-    pkg.dependencies[name] = version;
+    pkg.dependencies[name] = `${prefix}${version}`;
 
     writeFileSync(this.parse('package.json'), JSON.stringify(pkg, null, 2));
 
@@ -495,9 +498,9 @@ export class FileSystem {
    *
    * @returns {this}
    */
-  setOrUpdateProjectDependencyOnlyIf(condition: boolean, name: string, version: string): this {
+  setOrUpdateProjectDependencyOnlyIf(condition: boolean, name: string, version: string, prefix: PackageVersionPrefix): this {
     if (condition) {
-      this.setOrUpdateProjectDependency(name, version);
+      this.setOrUpdateProjectDependency(name, version, prefix);
     }
     return this;
   }
@@ -523,13 +526,13 @@ export class FileSystem {
    *
    * @returns {this}
    */
-  setOrUpdateProjectDevDependency(name: string, version: string): this {
+  setOrUpdateProjectDevDependency(name: string, version: string, prefix: PackageVersionPrefix): this {
     const initialCurrentDir = this.currentDir;
 
     this.cdProjectRootDir();
     const pkg = JSON.parse(readFileSync(this.parse('package.json'), 'utf8'));
 
-    pkg.devDependencies[name] = version;
+    pkg.devDependencies[name] = `${prefix}${version}`;
 
     writeFileSync(this.parse('package.json'), JSON.stringify(pkg, null, 2));
 

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -46,7 +46,7 @@ export async function createApp({ name, autoInstall, initRepo, mongodb = false, 
     .copy('app/gitignore', '.gitignore')
     .renderOnlyIf(!mongodb, 'app/package.json', 'package.json', locals)
     .renderOnlyIf(mongodb, 'app/package.mongodb.json', 'package.json', locals)
-    .setOrUpdateProjectDependencyOnlyIf(yaml, 'yamljs', '~0.3.0')
+    .setOrUpdateProjectDependencyOnlyIf(yaml, 'yamljs', '0.3.0', '~')
     .copy('app/tsconfig.app.json', 'tsconfig.app.json')
     .copy('app/tsconfig.e2e.json', 'tsconfig.e2e.json')
     .copy('app/tsconfig.json', 'tsconfig.json')

--- a/packages/cli/src/generate/generators/upgrade/package-version-prefix.ts
+++ b/packages/cli/src/generate/generators/upgrade/package-version-prefix.ts
@@ -1,0 +1,1 @@
+export type PackageVersionPrefix = '' | '^' | '~';

--- a/packages/cli/src/generate/generators/upgrade/upgrade.spec.ts
+++ b/packages/cli/src/generate/generators/upgrade/upgrade.spec.ts
@@ -19,8 +19,8 @@ describe('upgrade', () => {
 
       const actualDependencies = fs.getProjectDependencies();
       const expectedDependencies = [
-        { name: '@foal/core', version: '3.0.0' },
-        { name: '@foal/foobar', version: '3.0.0' },
+        { name: '@foal/core', version: '^3.0.0' },
+        { name: '@foal/foobar', version: '^3.0.0' },
         { name: 'another-dependency', version: '^1.0.0' }
       ];
       deepStrictEqual(actualDependencies, expectedDependencies);
@@ -34,7 +34,7 @@ describe('upgrade', () => {
 
         const actualDevDependencies = fs.getProjectDevDependencies();
         const expectedDevDependencies = [
-          { name: '@foal/cli', version: '3.0.0' },
+          { name: '@foal/cli', version: '^3.0.0' },
           { name: 'another-dependency2', version: '^2.0.0' }
         ];
         deepStrictEqual(actualDevDependencies, expectedDevDependencies);
@@ -50,8 +50,8 @@ describe('upgrade', () => {
 
       const actualDependencies = fs.getProjectDependencies();
       const expectedDependencies = [
-        { name: '@foal/core', version: '3.0.0' },
-        { name: '@foal/foobar', version: '3.0.0' },
+        { name: '@foal/core', version: '^3.0.0' },
+        { name: '@foal/foobar', version: '^3.0.0' },
         { name: 'another-dependency', version: '^1.0.0' }
       ];
       deepStrictEqual(actualDependencies, expectedDependencies);
@@ -65,7 +65,7 @@ describe('upgrade', () => {
 
         const actualDevDependencies = fs.getProjectDevDependencies();
         const expectedDevDependencies = [
-          { name: '@foal/cli', version: '3.0.0' },
+          { name: '@foal/cli', version: '^3.0.0' },
           { name: 'another-dependency2', version: '^2.0.0' }
         ];
         deepStrictEqual(actualDevDependencies, expectedDevDependencies);

--- a/packages/cli/src/generate/generators/upgrade/upgrade.ts
+++ b/packages/cli/src/generate/generators/upgrade/upgrade.ts
@@ -26,14 +26,14 @@ export async function upgrade(
   const dependencies = fs.getProjectDependencies();
   for (const dependency of dependencies) {
     if (dependency.name.startsWith('@foal/')) {
-      fs.setOrUpdateProjectDependency(dependency.name, version);
+      fs.setOrUpdateProjectDependency(dependency.name, version, '^');
     }
   }
 
   const devDependencies = fs.getProjectDevDependencies();
   for (const devDependency of devDependencies) {
     if (devDependency.name.startsWith('@foal/')) {
-      fs.setOrUpdateProjectDevDependency(devDependency.name, version);
+      fs.setOrUpdateProjectDevDependency(devDependency.name, version, '^');
     }
   }
 


### PR DESCRIPTION
When you create a new FoalTS project, all @foal dependencies begins with the '^' prefix. I think maybe it's a good idea to keep it.

See the [NPM](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#dependencies) docs and [semver](https://docs.npmjs.com/cli/v6/using-npm/semver) docs:

> ~version “Approximately equivalent to version”, will update you to all future patch versions, without incrementing the minor  version. ~1.2.3 will use releases from 1.2.3 to <1.3.0.
> 
> ^version “Compatible with version”, will update you to all future minor/patch versions, without incrementing the major version. ^1.2.3 will use releases from 1.2.3 to <2.0.0.

<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue
Version prefix is lost after upgrading Foal with the command `foal upgrade`.

# Solution and steps

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
