### PR TITLE
Upgrade command: Keep `package.json` version prefix 

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "scripts": {
-    "test": "npm run test:generators && npm run test:run-script && npm run test:create-secret && npm run test:rmdir && npm run test:fs",
+    "test": "npm run test:generators && npm run test:run-script && npm run test:create-secret && npm run test:rmdir && npm run test:fs && npm run test:utils",
     "test:fs": "mocha --file \"./src/test.ts\" --require ts-node/register \"./src/generate/file-system.spec.ts\"",
     "dev:test:fs": "mocha --file \"./src/test.ts\" --require ts-node/register --watch --extension ts \"./src/generate/file-system.spec.ts\"",
     "test:generators": "mocha --file \"./src/test.ts\" --require ts-node/register \"./src/generate/generators/**/*.spec.ts\"",
@@ -16,6 +16,8 @@
     "dev:test:run-script": "mocha --file \"./src/test.ts\" --require ts-node/register --watch --extension ts \"./src/run-script/**/*.spec.ts\"",
     "test:create-secret": "mocha --file \"./src/test.ts\" --require ts-node/register \"./src/create-secret/**/*.spec.ts\"",
     "dev:test:create-secret": "mocha --file \"./src/test.ts\" --require ts-node/register --watch --extension ts \"./src/create-secret/**/*.spec.ts\"",
+    "test:utils": "mocha --file \"./src/test.ts\" --require ts-node/register \"./src/generate/utils/**/*.spec.ts\"",
+    "dev:test:utils": "mocha --file \"./src/test.ts\" --require ts-node/register --watch --extension ts \"./src/generate/utils/**/*.spec.ts\"",
     "build": "rimraf lib && tsc -p tsconfig-build.json && copyfiles -a -u 3 \"src/generate/templates/**/*\" lib/generate/templates",
     "prepublish": "npm run build"
   },

--- a/packages/cli/src/generate/file-system.spec.ts
+++ b/packages/cli/src/generate/file-system.spec.ts
@@ -952,11 +952,11 @@ describe('FileSystem', () => {
     });
 
     it('should return itself.', () => {
-      strictEqual(fs.setOrUpdateProjectDependency('foo', '1.0.0'), fs);
+      strictEqual(fs.setOrUpdateProjectDependency('foo', '1.0.0', { prefix: '' }), fs);
     });
 
     it('should add the dependency if it does not exist.', () => {
-      fs.setOrUpdateProjectDependency('foo', '1.0.0');
+      fs.setOrUpdateProjectDependency('foo', '1.0.0', { prefix: '~' });
 
       const fileContent = readFileSync('package.json', 'utf8');
       const pkg = JSON.parse(fileContent);
@@ -964,18 +964,18 @@ describe('FileSystem', () => {
       deepStrictEqual(pkg.dependencies, {
         '@foal/core': '~1.0.1',
         'bar': '~2.2.0',
-        'foo': '1.0.0'
+        'foo': '~1.0.0'
       });
     });
 
     it('should update the dependency if it already exists.', () => {
-      fs.setOrUpdateProjectDependency('@foal/core', '2.0.0');
+      fs.setOrUpdateProjectDependency('@foal/core', '2.0.0', { prefix: '^', keepExistingPrefix: true });
 
       const fileContent = readFileSync('package.json', 'utf8');
       const pkg = JSON.parse(fileContent);
 
       deepStrictEqual(pkg.dependencies, {
-        '@foal/core': '2.0.0',
+        '@foal/core': '~2.0.0',
         'bar': '~2.2.0'
       });
 
@@ -1006,12 +1006,12 @@ describe('FileSystem', () => {
     });
 
     it('should return itself.', () => {
-      strictEqual(fs.setOrUpdateProjectDependency('foo', '1.0.0'), fs);
+      strictEqual(fs.setOrUpdateProjectDependency('foo', '1.0.0', { prefix: '' }), fs);
     });
 
     context('given the condition is true', () => {
       it('should add the dependency if it does not exist.', () => {
-        fs.setOrUpdateProjectDependencyOnlyIf(true, 'foo', '1.0.0');
+        fs.setOrUpdateProjectDependencyOnlyIf(true, 'foo', '1.0.0', { prefix: '' });
 
         const fileContent = readFileSync('package.json', 'utf8');
         const pkg = JSON.parse(fileContent);
@@ -1026,7 +1026,7 @@ describe('FileSystem', () => {
 
     context('given the condition is false', () => {
       it('should not add the dependency if it does not exist.', () => {
-        fs.setOrUpdateProjectDependencyOnlyIf(false, 'foo', '1.0.0');
+        fs.setOrUpdateProjectDependencyOnlyIf(false, 'foo', '1.0.0', { prefix: '' });
 
         const fileContent = readFileSync('package.json', 'utf8');
         const pkg = JSON.parse(fileContent);
@@ -1108,11 +1108,11 @@ describe('FileSystem', () => {
     });
 
     it('should return itself.', () => {
-      strictEqual(fs.setOrUpdateProjectDevDependency('foo', '1.0.0'), fs);
+      strictEqual(fs.setOrUpdateProjectDevDependency('foo', '1.0.0', { prefix: '' }), fs);
     });
 
     it('should add the dependency if it does not exist.', () => {
-      fs.setOrUpdateProjectDevDependency('foo', '1.0.0');
+      fs.setOrUpdateProjectDevDependency('foo', '1.0.0', { prefix: '' });
 
       const fileContent = readFileSync('package.json', 'utf8');
       const pkg = JSON.parse(fileContent);
@@ -1125,13 +1125,13 @@ describe('FileSystem', () => {
     });
 
     it('should update the dependency if it already exists.', () => {
-      fs.setOrUpdateProjectDevDependency('@foal/cli', '2.0.0');
+      fs.setOrUpdateProjectDevDependency('@foal/cli', '2.0.0', { prefix: '', keepExistingPrefix: true });
 
       const fileContent = readFileSync('package.json', 'utf8');
       const pkg = JSON.parse(fileContent);
 
       deepStrictEqual(pkg.devDependencies, {
-        '@foal/cli': '2.0.0',
+        '@foal/cli': '~2.0.0',
         'bar': '~2.2.0'
       });
 

--- a/packages/cli/src/generate/file-system.ts
+++ b/packages/cli/src/generate/file-system.ts
@@ -16,6 +16,9 @@ import { dirname, join, parse } from 'path';
 // 3p
 import { cyan, green } from 'colors/safe';
 
+// npm
+import { PackageVersionPrefix } from './generators/upgrade/package-version-prefix';
+
 function rmDirAndFiles(path: string) {
   const files = readdirSync(path);
   for (const file of files) {
@@ -476,13 +479,13 @@ export class FileSystem {
    *
    * @returns {this}
    */
-  setOrUpdateProjectDependency(name: string, version: string): this {
+  setOrUpdateProjectDependency(name: string, version: string, prefix: PackageVersionPrefix): this {
     const initialCurrentDir = this.currentDir;
 
     this.cdProjectRootDir();
     const pkg = JSON.parse(readFileSync(this.parse('package.json'), 'utf8'));
 
-    pkg.dependencies[name] = version;
+    pkg.dependencies[name] = `${prefix}${version}`;
 
     writeFileSync(this.parse('package.json'), JSON.stringify(pkg, null, 2));
 
@@ -495,9 +498,9 @@ export class FileSystem {
    *
    * @returns {this}
    */
-  setOrUpdateProjectDependencyOnlyIf(condition: boolean, name: string, version: string): this {
+  setOrUpdateProjectDependencyOnlyIf(condition: boolean, name: string, version: string, prefix: PackageVersionPrefix): this {
     if (condition) {
-      this.setOrUpdateProjectDependency(name, version);
+      this.setOrUpdateProjectDependency(name, version, prefix);
     }
     return this;
   }
@@ -523,13 +526,13 @@ export class FileSystem {
    *
    * @returns {this}
    */
-  setOrUpdateProjectDevDependency(name: string, version: string): this {
+  setOrUpdateProjectDevDependency(name: string, version: string, prefix: PackageVersionPrefix): this {
     const initialCurrentDir = this.currentDir;
 
     this.cdProjectRootDir();
     const pkg = JSON.parse(readFileSync(this.parse('package.json'), 'utf8'));
 
-    pkg.devDependencies[name] = version;
+    pkg.devDependencies[name] = `${prefix}${version}`;
 
     writeFileSync(this.parse('package.json'), JSON.stringify(pkg, null, 2));
 

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -46,7 +46,7 @@ export async function createApp({ name, autoInstall, initRepo, mongodb = false, 
     .copy('app/gitignore', '.gitignore')
     .renderOnlyIf(!mongodb, 'app/package.json', 'package.json', locals)
     .renderOnlyIf(mongodb, 'app/package.mongodb.json', 'package.json', locals)
-    .setOrUpdateProjectDependencyOnlyIf(yaml, 'yamljs', '~0.3.0')
+    .setOrUpdateProjectDependencyOnlyIf(yaml, 'yamljs', '0.3.0', '~')
     .copy('app/tsconfig.app.json', 'tsconfig.app.json')
     .copy('app/tsconfig.e2e.json', 'tsconfig.e2e.json')
     .copy('app/tsconfig.json', 'tsconfig.json')

--- a/packages/cli/src/generate/generators/app/create-app.ts
+++ b/packages/cli/src/generate/generators/app/create-app.ts
@@ -46,7 +46,7 @@ export async function createApp({ name, autoInstall, initRepo, mongodb = false, 
     .copy('app/gitignore', '.gitignore')
     .renderOnlyIf(!mongodb, 'app/package.json', 'package.json', locals)
     .renderOnlyIf(mongodb, 'app/package.mongodb.json', 'package.json', locals)
-    .setOrUpdateProjectDependencyOnlyIf(yaml, 'yamljs', '0.3.0', '~')
+    .setOrUpdateProjectDependencyOnlyIf(yaml, 'yamljs', '0.3.0', { prefix: '~', keepExistingPrefix: false })
     .copy('app/tsconfig.app.json', 'tsconfig.app.json')
     .copy('app/tsconfig.e2e.json', 'tsconfig.e2e.json')
     .copy('app/tsconfig.json', 'tsconfig.json')

--- a/packages/cli/src/generate/generators/upgrade/package-version-prefix.ts
+++ b/packages/cli/src/generate/generators/upgrade/package-version-prefix.ts
@@ -1,1 +1,0 @@
-export type PackageVersionPrefix = '' | '^' | '~';

--- a/packages/cli/src/generate/generators/upgrade/package-version-prefix.ts
+++ b/packages/cli/src/generate/generators/upgrade/package-version-prefix.ts
@@ -1,0 +1,1 @@
+export type PackageVersionPrefix = '' | '^' | '~';

--- a/packages/cli/src/generate/generators/upgrade/upgrade.spec.ts
+++ b/packages/cli/src/generate/generators/upgrade/upgrade.spec.ts
@@ -19,8 +19,8 @@ describe('upgrade', () => {
 
       const actualDependencies = fs.getProjectDependencies();
       const expectedDependencies = [
-        { name: '@foal/core', version: '3.0.0' },
-        { name: '@foal/foobar', version: '3.0.0' },
+        { name: '@foal/core', version: '^3.0.0' },
+        { name: '@foal/foobar', version: '^3.0.0' },
         { name: 'another-dependency', version: '^1.0.0' }
       ];
       deepStrictEqual(actualDependencies, expectedDependencies);
@@ -34,7 +34,7 @@ describe('upgrade', () => {
 
         const actualDevDependencies = fs.getProjectDevDependencies();
         const expectedDevDependencies = [
-          { name: '@foal/cli', version: '3.0.0' },
+          { name: '@foal/cli', version: '^3.0.0' },
           { name: 'another-dependency2', version: '^2.0.0' }
         ];
         deepStrictEqual(actualDevDependencies, expectedDevDependencies);
@@ -50,8 +50,8 @@ describe('upgrade', () => {
 
       const actualDependencies = fs.getProjectDependencies();
       const expectedDependencies = [
-        { name: '@foal/core', version: '3.0.0' },
-        { name: '@foal/foobar', version: '3.0.0' },
+        { name: '@foal/core', version: '^3.0.0' },
+        { name: '@foal/foobar', version: '^3.0.0' },
         { name: 'another-dependency', version: '^1.0.0' }
       ];
       deepStrictEqual(actualDependencies, expectedDependencies);
@@ -65,7 +65,7 @@ describe('upgrade', () => {
 
         const actualDevDependencies = fs.getProjectDevDependencies();
         const expectedDevDependencies = [
-          { name: '@foal/cli', version: '3.0.0' },
+          { name: '@foal/cli', version: '^3.0.0' },
           { name: 'another-dependency2', version: '^2.0.0' }
         ];
         deepStrictEqual(actualDevDependencies, expectedDevDependencies);

--- a/packages/cli/src/generate/generators/upgrade/upgrade.ts
+++ b/packages/cli/src/generate/generators/upgrade/upgrade.ts
@@ -26,14 +26,14 @@ export async function upgrade(
   const dependencies = fs.getProjectDependencies();
   for (const dependency of dependencies) {
     if (dependency.name.startsWith('@foal/')) {
-      fs.setOrUpdateProjectDependency(dependency.name, version);
+      fs.setOrUpdateProjectDependency(dependency.name, version, '^');
     }
   }
 
   const devDependencies = fs.getProjectDevDependencies();
   for (const devDependency of devDependencies) {
     if (devDependency.name.startsWith('@foal/')) {
-      fs.setOrUpdateProjectDevDependency(devDependency.name, version);
+      fs.setOrUpdateProjectDevDependency(devDependency.name, version, '^');
     }
   }
 

--- a/packages/cli/src/generate/generators/upgrade/upgrade.ts
+++ b/packages/cli/src/generate/generators/upgrade/upgrade.ts
@@ -26,14 +26,14 @@ export async function upgrade(
   const dependencies = fs.getProjectDependencies();
   for (const dependency of dependencies) {
     if (dependency.name.startsWith('@foal/')) {
-      fs.setOrUpdateProjectDependency(dependency.name, version, '^');
+      fs.setOrUpdateProjectDependency(dependency.name, version, { prefix: '^', keepExistingPrefix: true });
     }
   }
 
   const devDependencies = fs.getProjectDevDependencies();
   for (const devDependency of devDependencies) {
     if (devDependency.name.startsWith('@foal/')) {
-      fs.setOrUpdateProjectDevDependency(devDependency.name, version, '^');
+      fs.setOrUpdateProjectDevDependency(devDependency.name, version, { prefix: '^', keepExistingPrefix: true });
     }
   }
 

--- a/packages/cli/src/generate/utils/node-dependencies.spec.ts
+++ b/packages/cli/src/generate/utils/node-dependencies.spec.ts
@@ -1,0 +1,68 @@
+import { deepStrictEqual, strictEqual } from 'assert';
+import { INpmPackage, NodeDependencies } from './node-dependencies';
+
+describe('NodeDependencies', () => {
+  let manager: NodeDependencies;
+  const npmPackage: INpmPackage = {
+    dependencies: {
+      '@foal/core': '^4.4.0',
+      'foo': '1.1.0',
+      'lat': 'latest'
+    },
+    devDependencies: {
+      '@foal/cli': '^4.4.0'
+    }
+  };
+
+  it('should not affect the original npmPackage object', () => {
+    const dependenciesForTest = { ...npmPackage.devDependencies };
+
+    manager = new NodeDependencies(dependenciesForTest);
+    manager.setOrUpdate('mocha', '1.0.0', '^', true);
+
+    deepStrictEqual(npmPackage.devDependencies, dependenciesForTest);
+  });
+
+  it('should keep the prefix if keepExistingPrefix is true', () => {
+    manager = new NodeDependencies(npmPackage.dependencies);
+    manager.setOrUpdate('@foal/core', '5.0.0', '', true);
+
+    const result = manager.getDependencies()['@foal/core'];
+    const expected = '^5.0.0';
+
+    strictEqual(expected, result);
+  });
+
+  it('should override the prefix if keepExistingPrefix is true but the prefix is not supported', () => {
+    manager = new NodeDependencies(npmPackage.dependencies);
+    manager.setOrUpdate('lat', '5.0.0', '^', true);
+
+    const result = manager.getDependencies()['lat'];
+    const expected = '^5.0.0';
+
+    strictEqual(expected, result);
+  });
+
+  it('should override the prefix if keepExistingPrefix is false', () => {
+    manager = new NodeDependencies(npmPackage.dependencies);
+    manager.setOrUpdate('@foal/core', '5.0.0', '', false);
+
+    const result = manager.getDependencies()['@foal/core'];
+    const expected = '5.0.0';
+
+    strictEqual(expected, result);
+  });
+
+  it('should use the prefix if the package does not exists', () => {
+    manager = new NodeDependencies(npmPackage.dependencies);
+    manager.setOrUpdate('@foal/mongodb', '4.4.0', '^', true);
+    manager.setOrUpdate('@foal/password', '4.4.0', '^', false);
+
+    const mongoPackage = manager.getDependencies()['@foal/mongodb'];
+    const passwordPackage = manager.getDependencies()['@foal/password'];
+    const expected = '^4.4.0';
+
+    strictEqual(expected, mongoPackage);
+    strictEqual(expected, passwordPackage);
+  });
+});

--- a/packages/cli/src/generate/utils/node-dependencies.ts
+++ b/packages/cli/src/generate/utils/node-dependencies.ts
@@ -1,0 +1,54 @@
+export type NpmPackageVersionPrefix = '' | '^' | '~';
+
+const supportedPrefixes = ['^', '~'];
+
+export interface INpmPackage {
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+}
+
+export interface IPrefixSettings {
+  prefix: NpmPackageVersionPrefix;
+  keepExistingPrefix?: boolean;
+}
+
+export class NodeDependencies {
+  private dependencies: Record<string, string>;
+
+  constructor(packageDependencies: Record<string, string>) {
+    this.dependencies = { ...packageDependencies };
+  }
+
+  getDependencies(): Record<string, string> {
+    return { ...this.dependencies };
+  }
+
+  /**
+   * Installs a dependency if it does not exists.
+   * Updates a dependency if it exists.
+   * @param name Dependency name.
+   * @param version New version.
+   * @param prefix New or default prefix.
+   * @param keepExistingPrefix Keeps the version prefix.
+   */
+  setOrUpdate(name: string, version: string, prefix: string, keepExistingPrefix: boolean): void {
+    if (!this.exists(name) || !keepExistingPrefix) {
+      this.dependencies[name] = `${prefix}${version}`;
+    }
+    else if (this.isPrefixed(name)) {
+      const existingPrefix = this.dependencies[name][0];
+      this.dependencies[name] = `${existingPrefix}${version}`;
+    }
+    else {
+      this.dependencies[name] = `${prefix}${version}`;
+    }
+  }
+
+  private isPrefixed(name: string): boolean {
+    return supportedPrefixes.includes(this.dependencies[name][0]);
+  }
+
+  private exists(name: string): boolean {
+    return !!this.dependencies[name];
+  }
+}


### PR DESCRIPTION
When you create a new FoalTS project, all @foal dependencies begins with the '^' prefix. I think maybe it's a good idea to keep it.

See the [NPM](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#dependencies) docs and [semver](https://docs.npmjs.com/cli/v6/using-npm/semver) docs:

> ~version “Approximately equivalent to version”, will update you to all future patch versions, without incrementing the minor  version. ~1.2.3 will use releases from 1.2.3 to <1.3.0.
> 
> ^version “Compatible with version”, will update you to all future minor/patch versions, without incrementing the major version. ^1.2.3 will use releases from 1.2.3 to <2.0.0.

<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue
Version prefix is lost after upgrading Foal with the command `foal upgrade`.

# Solution and steps

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
