### PR TITLE
add: request type

### DIFF
--- a/packages/core/src/core/http/context.ts
+++ b/packages/core/src/core/http/context.ts
@@ -27,14 +27,14 @@ interface IncomingMessage extends Readable {
 }
 
 /**
- * Express Request interface.
+ * Express Request interface with customizable params/body types.
  *
  * @interface Request
  */
-interface Request extends IncomingMessage {
+export interface Request<body = any, params = any> extends IncomingMessage {
   app: any;
   baseUrl: string;
-  body: any;
+  body: body;
   cookies: any;
   fresh: boolean;
   // This line is present in @types/express but not in Express official documentation.
@@ -44,7 +44,7 @@ interface Request extends IncomingMessage {
   ips: string[];
   method: string;
   originalUrl: string;
-  params: any;
+  params: params;
   path: string;
   // The type is a string in @types/express.
   procotol: 'http'|'https';
@@ -114,8 +114,8 @@ interface Request extends IncomingMessage {
  * @class Context
  * @template User
  */
-export class Context<User = { [key: string]: any } | null, ContextState = { [key: string]: any }> {
-  readonly request: Request;
+export class Context<User = { [key: string]: any } | null, ContextState = { [key: string]: any }, CustomRequest extends Request = Request> {
+  readonly request: CustomRequest;
   session: Session | null;
 
   user: User;


### PR DESCRIPTION
# Issue
Closes #1269 

# Solution and steps
This exposes a custom request object and extends Foal's request object, thus allowing you to manually type your request params and body, to make typescript happy. Makes working with validation easier.

This works, but a better solution would just be to make ValidatePathParam and ValidateBody automatically type `ctx`.

Please let me know if this makes sense and I can add some docs.

Example Usage
```typescript
  @Get()
  @ValidatePathParam('versionId', { type: 'string', format: 'uuid' })
  async getDocumentVersionApprovers(ctx: Context<UserContext, object, Request<undefined, {versionId: string}>>) {
    const {
      request: {
        params: { versionId },
      },
      user,
    } = ctx;
```

# Checklist

- [ ] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
