### PR TITLE
Improve `GoogleProvider` type and better support social auth for SPA

### DIFF
--- a/docs/blog/version-4.5-release-notes.md
+++ b/docs/blog/version-4.5-release-notes.md
@@ -43,6 +43,36 @@ export class SubscriptionService {
 
 ```
 
+## Social authentication for SPAs
+
+If you wish to manually manage the redirection to the consent page on the client side (which is often necessary when developing an SPA), you can now do so with the `createHttpResponseWithConsentPageUrl` method. It returns an `HttpResponseOK` whose body contains the URL of the consent page.
+
+```typescript
+export class AuthController {
+  @dependency
+  google: GoogleProvider;
+
+  @Get('/signin/google')
+  getConsentPageURL() {
+    return this.google.createHttpResponseWithConsentPageUrl();
+  }
+  
+  // ...
+
+}
+
+```
+
+## Google social authentification
+
+The typing of the `GoogleProvider` service has been improved. The `userInfo` property returned by `getUserInfo` is now typed with the values returned by the Google server.
+
+```typescript
+const { userInfo } = await this.googleProvider.getUserInfo(...);
+
+// userInfo.email, userInfo.family_name, etc
+```
+
 ## Logging improvements
 
 In previous versions, the util function `displayServerURL` and configuration errors printed logs on several lines, which was not appropriate for logging software.

--- a/docs/docs/authentication/social-auth.md
+++ b/docs/docs/authentication/social-auth.md
@@ -218,7 +218,7 @@ export class AuthController {
     cookie: true,
   })
   async handleGoogleRedirection(ctx: Context<User>) {
-    const { userInfo } = await this.google.getUserInfo<{ email: string }>(ctx);
+    const { userInfo } = await this.google.getUserInfo(ctx);
 
     if (!userInfo.email) {
       throw new Error('Google should have returned an email address.');
@@ -290,7 +290,7 @@ export class AuthController {
 
   @Get('/signin/google/callback')
   async handleGoogleRedirection(ctx: Context) {
-    const { userInfo } = await this.google.getUserInfo<{ email: string }>(ctx);
+    const { userInfo } = await this.google.getUserInfo(ctx);
 
     if (!userInfo.email) {
       throw new Error('Google should have returned an email address.');

--- a/docs/docs/authentication/social-auth.md
+++ b/docs/docs/authentication/social-auth.md
@@ -157,10 +157,12 @@ export class AuthController {
 
 You can also override in the `redirect` method the scopes you want:
 ```typescript
-return this.google.redirect({ scopes: [ 'email' ] });
+return this.google.createHttpResponseWithConsentPageUrl({ isRedirection: true, scopes: [ 'email' ] });
 ```
 
 Additional parameters can passed to the `redirect` and `getUserInfo` methods depending on the provider.
+
+> If you want to manage the redirection on the client side manually, don't specify the `isRedirection` option. In this case, the `createHttpResponseWithConsentPageUrl` method returns an `HttpResponseOK` whose body contains the URL of the consent page. The name of the body property is `consentPageUrl`.
 
 ## Techniques
 
@@ -442,11 +444,11 @@ Visit the [Google API Console](https://console.developers.google.com/apis/creden
 
 #### Redirection parameters
 
-The `redirect` method of the `GoogleProvider` accepts additional parameters. These parameters and their description are listed [here](https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters) and are all optional.
+The `createHttpResponseWithConsentPageUrl` method of the `GoogleProvider` accepts additional parameters. These parameters and their description are listed [here](https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters) and are all optional.
 
 *Example*
 ```typescript
-this.google.redirect({ /* ... */ }, {
+this.google.createHttpResponseWithConsentPageUrl({ /* ... */ }, {
   access_type: 'offline'
 })
 ```
@@ -463,11 +465,11 @@ Visit [Facebook's developer website](https://developers.facebook.com/) to create
 
 #### Redirection parameters
 
-The `redirect` method of the `FacebookProvider` accepts an additional `auth_type` parameter which is optional.
+The `createHttpResponseWithConsentPageUrl` method of the `FacebookProvider` accepts an additional `auth_type` parameter which is optional.
 
 *Example*
 ```typescript
-this.facebook.redirect({ /* ... */ }, {
+this.facebook.createHttpResponseWithConsentPageUrl({ /* ... */ }, {
   auth_type: 'rerequest'
 });
 ```
@@ -505,11 +507,11 @@ Additional documentation on Github's redirect URLs can be found [here](https://d
 
 #### Redirection parameters
 
-The `redirect` method of the `GithubProvider` accepts additional parameters. These parameters and their description are listed below and are all optional.
+The `createHttpResponseWithConsentPageUrl` method of the `GithubProvider` accepts additional parameters. These parameters and their description are listed below and are all optional.
 
 *Example*
 ```typescript
-this.github.redirect({ /* ... */ }, {
+this.github.createHttpResponseWithConsentPageUrl({ /* ... */ }, {
   allow_signup: false
 })
 ```

--- a/docs/docs/authentication/social-auth.md
+++ b/docs/docs/authentication/social-auth.md
@@ -137,7 +137,7 @@ export class AuthController {
   redirectToGoogle() {
     // Your "Login In with Google" button should point to this route.
     // The user will be redirected to Google auth page.
-    return this.google.redirect();
+    return this.google.createHttpResponseWithConsentPageUrl({ isRedirection: true });
   }
 
   @Get('/signin/google/callback')
@@ -210,7 +210,7 @@ export class AuthController {
 
   @Get('/signin/google')
   redirectToGoogle() {
-    return this.google.redirect();
+    return this.google.createHttpResponseWithConsentPageUrl({ isRedirection: true });
   }
 
   @Get('/signin/google/callback')
@@ -285,7 +285,7 @@ export class AuthController {
 
   @Get('/signin/google')
   redirectToGoogle() {
-    return this.google.redirect();
+    return this.google.createHttpResponseWithConsentPageUrl({ isRedirection: true });
   }
 
   @Get('/signin/google/callback')

--- a/docs/docs/tutorials/real-world-example-with-react/15-social-auth.md
+++ b/docs/docs/tutorials/real-world-example-with-react/15-social-auth.md
@@ -132,7 +132,7 @@ export class SocialAuthController {
 
   @Get('/google')
   redirectToGoogle() {
-    return this.google.redirect();
+    return this.google.createHttpResponseWithConsentPageUrl({ isRedirection: true });
   }
 
   @Get('/google/callback')

--- a/packages/acceptance-tests/src/docs/authentication/social-auth/adding-social-auth-controllers.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication/social-auth/adding-social-auth-controllers.feature.ts
@@ -19,7 +19,7 @@ describe('Feature: Adding social auth controllers', () => {
       redirectToGoogle() {
         // Your "Login In with Google" button should point to this route.
         // The user will be redirected to Google auth page.
-        return this.google.redirect();
+        return this.google.createHttpResponseWithConsentPageUrl({ isRedirection: true });
       }
 
       @Get('/signin/google/callback')

--- a/packages/acceptance-tests/src/docs/authentication/social-auth/using-social-auth-with-jwt.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication/social-auth/using-social-auth-with-jwt.feature.ts
@@ -56,7 +56,7 @@ describe('Feature: Using social auth with JWT', () => {
 
       @Get('/signin/google')
       redirectToGoogle() {
-        return this.google.redirect();
+        return this.google.createHttpResponseWithConsentPageUrl({ isRedirection: true });
       }
 
       @Get('/signin/google/callback')

--- a/packages/acceptance-tests/src/docs/authentication/social-auth/using-social-auth-with-jwt.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication/social-auth/using-social-auth-with-jwt.feature.ts
@@ -61,7 +61,7 @@ describe('Feature: Using social auth with JWT', () => {
 
       @Get('/signin/google/callback')
       async handleGoogleRedirection(ctx: Context) {
-        const { userInfo } = await this.google.getUserInfo<{ email: string }>(ctx);
+        const { userInfo } = await this.google.getUserInfo(ctx);
 
         if (!userInfo.email) {
           throw new Error('Google should have returned an email address.');

--- a/packages/acceptance-tests/src/docs/authentication/social-auth/using-social-auth-with-sessions.feature.ts
+++ b/packages/acceptance-tests/src/docs/authentication/social-auth/using-social-auth-with-sessions.feature.ts
@@ -59,7 +59,7 @@ describe('Feature: Using social auth with sessions', () => {
 
       @Get('/signin/google')
       redirectToGoogle() {
-        return this.google.redirect();
+        return this.google.createHttpResponseWithConsentPageUrl({ isRedirection: true });
       }
 
       @Get('/signin/google/callback')
@@ -67,7 +67,7 @@ describe('Feature: Using social auth with sessions', () => {
         cookie: true,
       })
       async handleGoogleRedirection(ctx: Context<User>) {
-        const { userInfo } = await this.google.getUserInfo<{ email: string }>(ctx);
+        const { userInfo } = await this.google.getUserInfo(ctx);
 
         if (!userInfo.email) {
           throw new Error('Google should have returned an email address.');

--- a/packages/examples/src/app/controllers/auth.controller.ts
+++ b/packages/examples/src/app/controllers/auth.controller.ts
@@ -32,7 +32,7 @@ export class AuthController {
 
   @Get('/signin/google')
   redirectToGoogle() {
-    return this.google.redirect();
+    return this.google.createHttpResponseWithConsentPageUrl({ isRedirection: true });
   }
 
   @Get('/signin/google/cb')
@@ -43,7 +43,7 @@ export class AuthController {
 
   @Get('/signin/facebook')
   redirectToFacebook() {
-    return this.facebook.redirect();
+    return this.facebook.createHttpResponseWithConsentPageUrl({ isRedirection: true });
   }
 
   @Get('/signin/facebook/cb')
@@ -54,7 +54,7 @@ export class AuthController {
 
   @Get('/signin/github')
   redirectToGithub() {
-    return this.github.redirect();
+    return this.github.createHttpResponseWithConsentPageUrl({ isRedirection: true });
   }
 
   @Get('/signin/github/cb')
@@ -65,7 +65,7 @@ export class AuthController {
 
   @Get('/signin/linkedin')
   redirectToLinkedIn() {
-    return this.linkedin.redirect();
+    return this.linkedin.createHttpResponseWithConsentPageUrl({ isRedirection: true });
   }
 
   @Get('/signin/linkedin/cb')
@@ -76,7 +76,7 @@ export class AuthController {
 
   @Get('/signin/twitter')
   redirectToTwitter() {
-    return this.twitter.redirect();
+    return this.twitter.createHttpResponseWithConsentPageUrl({ isRedirection: true });
   }
 
   @Get('/signin/twitter/cb')

--- a/packages/social/src/abstract-provider.service.ts
+++ b/packages/social/src/abstract-provider.service.ts
@@ -240,9 +240,9 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
 
   /**
    * Returns an HttpResponseOK or HttpResponseRedirect object to redirect the user to the social provider's authorization page.
-   * 
+   *
    * If the isRedirection parameter is undefined or set to false, the function returns an HttpResponseOK object. Its body contains the URL of the consent page.
-   * 
+   *
    * If the isRedirection parameter is set to true, the function returns an HttpResponseRedirect object.
    *
    * @param {{ scopes?: string[] }} [{ scopes }={}] - Custom scopes to override the default ones used by the provider.
@@ -311,7 +311,7 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
 
   /**
    * Returns an HttpResponseRedirect object to redirect the user to the social provider's authorization page.
-   * 
+   *
    * This function is deprecated. Use createHttpResponseWithConsentPageUrl instead with isRedirection set to true.
    *
    * @param {{ scopes?: string[] }} [{ scopes }={}] - Custom scopes to override the default ones used by the provider.

--- a/packages/social/src/abstract-provider.service.ts
+++ b/packages/social/src/abstract-provider.service.ts
@@ -3,7 +3,7 @@ import { URL, URLSearchParams } from 'url';
 import * as crypto from 'crypto';
 
 // 3p
-import { Config, Context, generateToken, HttpResponseRedirect, convertBase64ToBase64url, CookieOptions } from '@foal/core';
+import { Config, Context, generateToken, HttpResponseRedirect, convertBase64ToBase64url, CookieOptions, HttpResponseOK } from '@foal/core';
 import * as fetch from 'node-fetch';
 
 /**
@@ -239,14 +239,19 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
   abstract getUserInfoFromTokens(tokens: SocialTokens, params?: UserInfoParameters): any;
 
   /**
-   * Returns an HttpResponseRedirect object to use to redirect the user to the social provider's authorization page.
+   * Returns an HttpResponseOK or HttpResponseRedirect object to redirect the user to the social provider's authorization page.
+   * 
+   * If the isRedirection parameter is undefined or set to false, the function returns an HttpResponseOK object. Its body contains the URL of the consent page.
+   * 
+   * If the isRedirection parameter is set to true, the function returns an HttpResponseRedirect object.
    *
    * @param {{ scopes?: string[] }} [{ scopes }={}] - Custom scopes to override the default ones used by the provider.
+   * @param {{ isRedirection?: boolean }} [{ isRedirection }={}] - If true, the function returns an HttpResponseRedirect object. Otherwise, it returns an HttpResponseOK object.
    * @param {AuthParameters} [params] - Additional parameters (specific to the social provider).
-   * @returns {Promise<HttpResponseRedirect>} The HttpResponseRedirect object.
+   * @returns {Promise<HttpResponseOK | HttpResponseRedirect>} The HttpResponseOK or HttpResponseRedirect object.
    * @memberof AbstractProvider
    */
-  async redirect({ scopes }: { scopes?: string[] } = {}, params?: AuthParameters): Promise<HttpResponseRedirect> {
+  async createHttpResponseWithConsentPageUrl({ scopes, isRedirection }: { scopes?: string[], isRedirection?: boolean } = {}, params?: AuthParameters): Promise<HttpResponseOK | HttpResponseRedirect> {
     // Build the authorization URL.
     const url = new URL(this.authEndpoint);
     url.searchParams.set('response_type', 'code');
@@ -279,7 +284,7 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
       url.searchParams.set('code_challenge_method', this.useCodeVerifierAsCodeChallenge ? 'plain' : 'S256');
     }
 
-    const redirectResponse = new HttpResponseRedirect(url.href);
+    const response = isRedirection ? new HttpResponseRedirect(url.href) : new HttpResponseOK({ consentPageUrl: url.href });
 
     const cookieOptions: CookieOptions = {
       httpOnly: true,
@@ -296,12 +301,27 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
     // Add Code Challenge COOKIE for token request
     if (this.usePKCE) {
       // Encrypt this code_challenge cookie for security reasons
-      redirectResponse.setCookie(CODE_VERIFIER_COOKIE_NAME, this.encryptString(codeVerifier), cookieOptions);
+      response.setCookie(CODE_VERIFIER_COOKIE_NAME, this.encryptString(codeVerifier), cookieOptions);
     }
 
     // Return a redirection response with the state as cookie.
-    return redirectResponse
+    return response
       .setCookie(STATE_COOKIE_NAME, state, cookieOptions)
+  }
+
+  /**
+   * Returns an HttpResponseRedirect object to redirect the user to the social provider's authorization page.
+   * 
+   * This function is deprecated. Use createHttpResponseWithConsentPageUrl instead with isRedirection set to true.
+   *
+   * @param {{ scopes?: string[] }} [{ scopes }={}] - Custom scopes to override the default ones used by the provider.
+   * @param {AuthParameters} [params] - Additional parameters (specific to the social provider).
+   * @returns {Promise<HttpResponseRedirect>} The HttpResponseRedirect object.
+   * @memberof AbstractProvider
+   * @deprecated
+   */
+  async redirect({ scopes }: { scopes?: string[] } = {}, params?: AuthParameters): Promise<HttpResponseRedirect> {
+    return this.createHttpResponseWithConsentPageUrl({ scopes, isRedirection: true }, params) as Promise<HttpResponseRedirect>;
   }
 
   /**

--- a/packages/social/src/abstract-provider.service.ts
+++ b/packages/social/src/abstract-provider.service.ts
@@ -114,8 +114,9 @@ export interface ObjectType {
  * @class AbstractProvider
  * @template AuthParameters - Additional parameters to pass to the auth endpoint.
  * @template UserInfoParameters - Additional parameters to pass when retrieving user information.
+ * @template IUserInfo - Type of the user information.
  */
-export abstract class AbstractProvider<AuthParameters extends ObjectType, UserInfoParameters extends ObjectType> {
+export abstract class AbstractProvider<AuthParameters extends ObjectType, UserInfoParameters extends ObjectType, IUserInfo = any> {
 
   /**
    * Configuration paths from which the client ID, client secret and redirect URI must be retrieved.
@@ -379,7 +380,7 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
    * @returns {Promise<UserInfoAndTokens<UserInfo>>} The access token and the user information
    * @memberof AbstractProvider
    */
-  async getUserInfo<UserInfo>(ctx: Context, params?: UserInfoParameters): Promise<UserInfoAndTokens<UserInfo>> {
+  async getUserInfo<UserInfo extends IUserInfo>(ctx: Context, params?: UserInfoParameters): Promise<UserInfoAndTokens<UserInfo>> {
     const tokens = await this.getTokens(ctx);
     const userInfo = await this.getUserInfoFromTokens(tokens, params);
     return { userInfo, tokens };

--- a/packages/social/src/google-provider.service.ts
+++ b/packages/social/src/google-provider.service.ts
@@ -13,6 +13,28 @@ export interface GoogleAuthParams {
   hd?: string;
 }
 
+// https://developers.google.com/identity/openid-connect/openid-connect#an-id-tokens-payload
+export interface GoogleUserInfo {
+  aud: string;
+  exp: number;
+  iat: number;
+  iss: string;
+  sub: string;
+  at_hash?: string;
+  azp?: string;
+  email?: string;
+  email_verified?: boolean;
+  family_name?: string;
+  given_name?: string;
+  hd?: string;
+  locale?: string;
+  name?: string;
+  nonce?: string;
+  picture?: string;
+  profile?: string;
+  [name: string]: unknown;
+}
+
 export class InvalidJWTError extends Error {
   readonly name = 'InvalidJWTError';
 }
@@ -24,7 +46,7 @@ export class InvalidJWTError extends Error {
  * @class GoogleProvider
  * @extends {AbstractProvider<GoogleAuthParams, never>}
  */
-export class GoogleProvider extends AbstractProvider<GoogleAuthParams, never> {
+export class GoogleProvider extends AbstractProvider<GoogleAuthParams, never, GoogleUserInfo> {
   protected configPaths = {
     clientId: 'settings.social.google.clientId',
     clientSecret: 'settings.social.google.clientSecret',

--- a/packages/social/src/index.ts
+++ b/packages/social/src/index.ts
@@ -27,6 +27,7 @@ export {
   GoogleProvider,
   InvalidJWTError,
   GoogleAuthParams,
+  GoogleUserInfo,
 } from './google-provider.service';
 export {
   LinkedInProvider,


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

- The type of the `userInfo` property returned by `GoogleProvider.getUserInfo` is of type `any`.
- In social auth, Foal only allows to get the consent page through a redirection and not a 200 response. This is not handy when building a SPA.

# Solution and steps

- [x] Add type to `GoogleProvider.getUserInfo`.
- [x] Add a new `createHttpResponseWithConsentPageUrl` to get the consent page URL through an `HttpResponseOK`. This response includes the security cookie.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
