### PR TITLE
Improve welcome page and remove link to Foal website

### DIFF
--- a/packages/cli/src/generate/specs/app/public/index.html
+++ b/packages/cli/src/generate/specs/app/public/index.html
@@ -10,40 +10,31 @@
       height: 100%
     }
     body {
-      margin: 0;
-      text-align: center;
-      font-family: Arial;
-      background-color: #282c34;
+      background-size: cover;
+      background-repeat: no-repeat;
+      background-image: url("data:image/svg+xml,%3Csvg%20id%3D%22visual%22%20viewBox%3D%220%200%20900%20600%22%20width%3D%22900%22%20height%3D%22600%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20version%3D%221.1%22%3E%3Cdefs%3E%3Cfilter%20id%3D%22blur1%22%20x%3D%22-10%25%22%20y%3D%22-10%25%22%20width%3D%22120%25%22%20height%3D%22120%25%22%3E%3CfeFlood%20flood-opacity%3D%220%22%20result%3D%22BackgroundImageFix%22%3E%3C%2FfeFlood%3E%3CfeBlend%20mode%3D%22normal%22%20in%3D%22SourceGraphic%22%20in2%3D%22BackgroundImageFix%22%20result%3D%22shape%22%3E%3C%2FfeBlend%3E%3CfeGaussianBlur%20stdDeviation%3D%22161%22%20result%3D%22effect1_foregroundBlur%22%3E%3C%2FfeGaussianBlur%3E%3C%2Ffilter%3E%3C%2Fdefs%3E%3Crect%20width%3D%22900%22%20height%3D%22600%22%20fill%3D%22%234FACF7%22%3E%3C%2Frect%3E%3Cg%20filter%3D%22url(%23blur1)%22%3E%3Ccircle%20cx%3D%22828%22%20cy%3D%22361%22%20fill%3D%22%230066FF%22%20r%3D%22357%22%3E%3C%2Fcircle%3E%3Ccircle%20cx%3D%22652%22%20cy%3D%22263%22%20fill%3D%22%234FACF7%22%20r%3D%22357%22%3E%3C%2Fcircle%3E%3Ccircle%20cx%3D%22832%22%20cy%3D%226%22%20fill%3D%22%230066FF%22%20r%3D%22357%22%3E%3C%2Fcircle%3E%3Ccircle%20cx%3D%22617%22%20cy%3D%22590%22%20fill%3D%22%230066FF%22%20r%3D%22357%22%3E%3C%2Fcircle%3E%3Ccircle%20cx%3D%223%22%20cy%3D%2218%22%20fill%3D%22%234FACF7%22%20r%3D%22357%22%3E%3C%2Fcircle%3E%3Ccircle%20cx%3D%2290%22%20cy%3D%22295%22%20fill%3D%22%230066FF%22%20r%3D%22357%22%3E%3C%2Fcircle%3E%3C%2Fg%3E%3C%2Fsvg%3E");
     }
-    .wrapper {
-      height: 95%;
+    body {
+      font-family: Arial, sans-serif;
       display: flex;
-      flex-direction: column;
       justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+      background-color: #f4f4f9;
+      color: white;
     }
     h1 {
-      color: white;
-      font-weight: bold;
-      margin-bottom: 40px;
-      letter-spacing: 2px;
+      font-size: 2.5rem;
+      margin-bottom: 0.5rem;
     }
-    a {
-      color: #4B89EC;
-      letter-spacing: 1px;
-      font-size: 1.3rem;
-      font-weight: bold;
+    p {
+      font-size: 1.2rem;
+      color: rgb(230, 238, 252);
     }
   </style>
 </head>
 <body>
-  <div class="wrapper">
-    <div>
-      <img src="logo.png" alt="FoalTS logo">
-    </div>
-    <h1>Welcome on board ✨</h1>
-    <div>
-      <a href="https://foalts.org/docs/tutorials/simple-todo-list/1-installation">Learn FoalTS</a>
-    </div> 
-  </div>
+  <h1>Your app is running!</h1>
 </body>
 </html>

--- a/packages/cli/src/generate/templates/app/public/index.html
+++ b/packages/cli/src/generate/templates/app/public/index.html
@@ -10,40 +10,31 @@
       height: 100%
     }
     body {
-      margin: 0;
-      text-align: center;
-      font-family: Arial;
-      background-color: #282c34;
+      background-size: cover;
+      background-repeat: no-repeat;
+      background-image: url("data:image/svg+xml,%3Csvg%20id%3D%22visual%22%20viewBox%3D%220%200%20900%20600%22%20width%3D%22900%22%20height%3D%22600%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20version%3D%221.1%22%3E%3Cdefs%3E%3Cfilter%20id%3D%22blur1%22%20x%3D%22-10%25%22%20y%3D%22-10%25%22%20width%3D%22120%25%22%20height%3D%22120%25%22%3E%3CfeFlood%20flood-opacity%3D%220%22%20result%3D%22BackgroundImageFix%22%3E%3C%2FfeFlood%3E%3CfeBlend%20mode%3D%22normal%22%20in%3D%22SourceGraphic%22%20in2%3D%22BackgroundImageFix%22%20result%3D%22shape%22%3E%3C%2FfeBlend%3E%3CfeGaussianBlur%20stdDeviation%3D%22161%22%20result%3D%22effect1_foregroundBlur%22%3E%3C%2FfeGaussianBlur%3E%3C%2Ffilter%3E%3C%2Fdefs%3E%3Crect%20width%3D%22900%22%20height%3D%22600%22%20fill%3D%22%234FACF7%22%3E%3C%2Frect%3E%3Cg%20filter%3D%22url(%23blur1)%22%3E%3Ccircle%20cx%3D%22828%22%20cy%3D%22361%22%20fill%3D%22%230066FF%22%20r%3D%22357%22%3E%3C%2Fcircle%3E%3Ccircle%20cx%3D%22652%22%20cy%3D%22263%22%20fill%3D%22%234FACF7%22%20r%3D%22357%22%3E%3C%2Fcircle%3E%3Ccircle%20cx%3D%22832%22%20cy%3D%226%22%20fill%3D%22%230066FF%22%20r%3D%22357%22%3E%3C%2Fcircle%3E%3Ccircle%20cx%3D%22617%22%20cy%3D%22590%22%20fill%3D%22%230066FF%22%20r%3D%22357%22%3E%3C%2Fcircle%3E%3Ccircle%20cx%3D%223%22%20cy%3D%2218%22%20fill%3D%22%234FACF7%22%20r%3D%22357%22%3E%3C%2Fcircle%3E%3Ccircle%20cx%3D%2290%22%20cy%3D%22295%22%20fill%3D%22%230066FF%22%20r%3D%22357%22%3E%3C%2Fcircle%3E%3C%2Fg%3E%3C%2Fsvg%3E");
     }
-    .wrapper {
-      height: 95%;
+    body {
+      font-family: Arial, sans-serif;
       display: flex;
-      flex-direction: column;
       justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+      background-color: #f4f4f9;
+      color: white;
     }
     h1 {
-      color: white;
-      font-weight: bold;
-      margin-bottom: 40px;
-      letter-spacing: 2px;
+      font-size: 2.5rem;
+      margin-bottom: 0.5rem;
     }
-    a {
-      color: #4B89EC;
-      letter-spacing: 1px;
-      font-size: 1.3rem;
-      font-weight: bold;
+    p {
+      font-size: 1.2rem;
+      color: rgb(230, 238, 252);
     }
   </style>
 </head>
 <body>
-  <div class="wrapper">
-    <div>
-      <img src="logo.png" alt="FoalTS logo">
-    </div>
-    <h1>Welcome on board ✨</h1>
-    <div>
-      <a href="https://foalts.org/docs/tutorials/simple-todo-list/1-installation">Learn FoalTS</a>
-    </div> 
-  </div>
+  <h1>Your app is running!</h1>
 </body>
 </html>


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

- The link in `index.html` to the official website pollutes the traffic analytics of the official website.
- The `index.html` content is not beautiful

# Solution and steps

- [x] Remove the link to the official website.
- [x] Improve page design. It's not great, though. If anyone has something better, don't hesitate to suggest something.

*Before*
<img width="1512" alt="Capture d’écran 2024-08-22 à 13 09 06" src="https://github.com/user-attachments/assets/6a119b78-a6bb-49b0-93d8-e1a034aa8c79">

*After*
<img width="1512" alt="Capture d’écran 2024-08-22 à 13 09 21" src="https://github.com/user-attachments/assets/30858368-a217-4af0-835f-f41415022897">


# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
