### PR TITLE
Add support for Node 22 and drop support for Node 18

### DIFF
--- a/.github/CONTRIBUTING.MD
+++ b/.github/CONTRIBUTING.MD
@@ -136,7 +136,8 @@ All of major releases are supported for at least 18 months.
 
 | Release | Status | Active Start | Maintenance Start | End-of-life | Node versions | TS min version |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| 4.x | *Active* | 2023-09-06 |  |  | 18, 20 | 4.9 |
+| 5.x | *Active* | TODO |  |  | 20, 22 | 4.9 |
+| 4.x | *Maintenance* | 2023-09-06 | TODO | TODO | 18, 20 | 4.9 |
 | 3.x | *End-of-Life* | 2022-10-28 | 2023-09-06 | 2024-03-06 | 16, 18 | 4.7 |
 | 2.x | *End-of-Life* | 2020-12-03 | 2022-10-28 | 2023-04-30 | 10, 12, 14 | 4.0 |
 | 1.x | *End-of-Life* | 2019-07-11 | 2020-12-03 | 2021-05-31 | 8, 10 | 3.5 |

--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [18, 20]
+        node-version: [20, 22]
     
     services:
       mongodb:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: '18.x'
+          node-version: '20.x'
       - name: Test Build
         run: |
           cd docs
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: '18.x'
+          node-version: '20.x'
       - name: Add key to allow access to repository
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20, 22]
 
     env:
       SETTINGS_AWS_ACCESS_KEY_ID: ${{ secrets.SETTINGS_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,6 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Use npm version 9.6
-      run: npm install -g npm@9.6
     - name: Install project and package dependencies
       run: npm install
     - name: Build packages

--- a/docs/blog/version-5.0-release-notes.md
+++ b/docs/blog/version-5.0-release-notes.md
@@ -14,6 +14,10 @@ Version 5.0 of [Foal](https://foalts.org/) is out!
 
 <!--truncate-->
 
+## Supported versions of Node
+
+- Support for Node 18 has been dropped and support for Node 22 has been added.
+
 ## Removal of depreacted components
 
 - The deprecated hook `@Log` has been removed. To replace it, you can use the `Logger` service in a custom `@Hook`.

--- a/docs/docs/tutorials/simple-todo-list/1-installation.md
+++ b/docs/docs/tutorials/simple-todo-list/1-installation.md
@@ -8,7 +8,7 @@ In this tutorial you will learn how to create a basic web application with FoalT
 
 > **Requirements:**
 >
-> [Node.js](https://nodejs.org/en/) 18 or greater
+> [Node.js](https://nodejs.org/en/) 20 or greater
 
 ## Create a New Project
 

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/tutorials/simple-todo-list/1-installation.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/tutorials/simple-todo-list/1-installation.md
@@ -8,7 +8,7 @@ En este tutorial aprenderá a crear una aplicación web básica con FoalTS. La a
 
 > **Requisitos:**
 >
-> [Node.js](https://nodejs.org/en/) 18 o superior
+> [Node.js](https://nodejs.org/en/) 20 o superior
 
 ## Crear un Nuevo Proyecto
 

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/tutorials/simple-todo-list/1-installation.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/tutorials/simple-todo-list/1-installation.md
@@ -8,7 +8,7 @@ Dans ce tutoriel, vous apprendrez comment créer une application web de base ave
 
 > **Configuration requise:**
 >
-> [Node.js](https://nodejs.org/en/) 18 ou supérieur
+> [Node.js](https://nodejs.org/en/) 20 ou supérieur
 
 ## Créer un Nouveau Projet
 

--- a/docs/i18n/id/docusaurus-plugin-content-docs/current/tutorials/simple-todo-list/1-installation.md
+++ b/docs/i18n/id/docusaurus-plugin-content-docs/current/tutorials/simple-todo-list/1-installation.md
@@ -8,7 +8,7 @@ Pada tutorial kali ini kita akan coba membuat aplikasi web dengan Foal. Aplikasi
 
 > **Yang diperlukan:**
 >
-> [Node.js](https://nodejs.org/en/) versi 18 ke atas
+> [Node.js](https://nodejs.org/en/) versi 20 ke atas
 
 ## Memulai Proyek Baru
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4259,9 +4259,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.18.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.6.tgz",
-      "integrity": "sha512-wf3Vz+jCmOQ2HV1YUJuCWdL64adYxumkrxtc+H1VUQlnQI04+5HtH+qZCOE21lBE7gIrt+CwX2Wv8Acrw5Ak6w=="
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -7508,6 +7512,7 @@
       "version": "10.3.12",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.12.tgz",
       "integrity": "sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==",
+      "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.3.6",
@@ -7541,6 +7546,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -7549,6 +7555,7 @@
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
       "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -8586,6 +8593,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
       "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -9764,9 +9772,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
-      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -10935,6 +10944,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/pacote": {
       "version": "18.0.6",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-18.0.6.tgz",
@@ -11122,6 +11137,7 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
       "integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -11137,6 +11153,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
       "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "dev": true,
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -14493,6 +14510,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
     "node_modules/unique-filename": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
@@ -15191,7 +15214,7 @@
       },
       "devDependencies": {
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "@types/react": "18.2.63",
         "@types/react-dom": "18.2.20",
         "@types/supertest": "6.0.2",
@@ -15200,7 +15223,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15218,7 +15241,7 @@
       },
       "devDependencies": {
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "copy": "~0.3.2",
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
@@ -15226,7 +15249,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15267,7 +15290,7 @@
       },
       "devDependencies": {
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "copyfiles": "~2.4.1",
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
@@ -15275,7 +15298,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15352,7 +15375,7 @@
       "devDependencies": {
         "@foal/internal-test": "^4.5.0",
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "@types/supertest": "6.0.2",
         "ajv-errors": "~3.0.0",
         "ejs": "~3.1.10",
@@ -15366,7 +15389,7 @@
         "yamljs": "~0.3.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15412,7 +15435,7 @@
       "devDependencies": {
         "@foal/cli": "^4.5.0",
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "concurrently": "~8.2.2",
         "copy": "~0.3.2",
         "mocha": "~10.7.0",
@@ -15420,7 +15443,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15435,7 +15458,7 @@
       },
       "devDependencies": {
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "graphiql": "~3.1.1",
         "mocha": "~10.7.0",
         "react": "~18.2.0",
@@ -15445,7 +15468,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15476,11 +15499,11 @@
       "dependencies": {
         "@foal/core": "^4.5.0",
         "ajv": "~8.17.0",
-        "glob": "~10.3.10"
+        "glob": "~11.0.0"
       },
       "devDependencies": {
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "graphql": "~16.9.0",
         "graphql-request": "~6.1.0",
         "mocha": "~10.7.0",
@@ -15490,13 +15513,103 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
       },
       "peerDependencies": {
         "graphql": "^16.9.0"
+      }
+    },
+    "packages/graphql/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/graphql/node_modules/glob": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
+      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/graphql/node_modules/jackspeak": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.1.tgz",
+      "integrity": "sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "packages/graphql/node_modules/lru-cache": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz",
+      "integrity": "sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/graphql/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/graphql/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/graphql/node_modules/rimraf": {
@@ -15517,6 +15630,83 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "packages/graphql/node_modules/rimraf/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/graphql/node_modules/rimraf/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "packages/graphql/node_modules/rimraf/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "packages/graphql/node_modules/rimraf/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/graphql/node_modules/rimraf/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/internal-test": {
       "name": "@foal/internal-test",
       "version": "4.5.0",
@@ -15527,7 +15717,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15562,14 +15752,14 @@
         "@foal/core": "^4.5.0",
         "@foal/jwt": "^4.5.0",
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15606,14 +15796,14 @@
       },
       "devDependencies": {
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15654,7 +15844,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15684,7 +15874,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "copy": "~0.3.2",
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
@@ -15692,7 +15882,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15726,14 +15916,14 @@
       },
       "devDependencies": {
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15767,7 +15957,7 @@
       },
       "devDependencies": {
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "copy": "~0.3.2",
         "jsonwebtoken": "~9.0.2",
         "mocha": "~10.7.0",
@@ -15776,7 +15966,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15850,7 +16040,7 @@
       "devDependencies": {
         "@socket.io/redis-adapter": "~8.3.0",
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "mocha": "~10.7.0",
         "redis": "~4.6.15",
         "rimraf": "~5.0.5",
@@ -15859,7 +16049,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15895,7 +16085,7 @@
       "devDependencies": {
         "@foal/internal-test": "^4.5.0",
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "@types/supertest": "6.0.2",
         "copy": "~0.3.2",
         "mocha": "~10.7.0",
@@ -15905,7 +16095,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15939,7 +16129,7 @@
       },
       "devDependencies": {
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "copy": "~0.3.2",
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
@@ -15947,7 +16137,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -15991,7 +16181,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"
@@ -16027,7 +16217,7 @@
       },
       "devDependencies": {
         "@types/mocha": "10.0.7",
-        "@types/node": "18.18.6",
+        "@types/node": "20.14.8",
         "@types/validator": "13.12.0",
         "class-transformer": "~0.5.1",
         "class-validator": "~0.14.1",
@@ -16038,7 +16228,7 @@
         "typescript": "~4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/LoicPoullain"

--- a/packages/acceptance-tests/package.json
+++ b/packages/acceptance-tests/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@foal/core": "^4.5.0",
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "@types/react": "18.2.63",
     "@types/react-dom": "18.2.20",
     "@types/supertest": "6.0.2",

--- a/packages/aws-s3/package.json
+++ b/packages/aws-s3/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "copy": "~0.3.2",
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",

--- a/packages/aws-s3/src/s3-disk.service.spec.ts
+++ b/packages/aws-s3/src/s3-disk.service.spec.ts
@@ -11,7 +11,7 @@ import { S3 } from '@aws-sdk/client-s3';
 import { S3Disk } from './s3-disk.service';
 
 // Isolate each job with a different S3 bucket.
-const bucketName = `foal-test-${process.env.NODE_VERSION?.slice(0,2) || 18}`;
+const bucketName = `foal-test-${process.env.NODE_VERSION?.slice(0,2) || 20}`;
 
 async function rmObjectsIfExist(s3: S3) {
   const response = await s3.listObjects({

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "bin": {
     "foal": "./lib/index.js"
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "copyfiles": "~2.4.1",
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",

--- a/packages/cli/src/generate/file-system.spec.ts
+++ b/packages/cli/src/generate/file-system.spec.ts
@@ -117,19 +117,11 @@ describe('FileSystem', () => {
         if (!(error instanceof ClientError)) {
           throw new Error('The error thrown should be an instance of ClientError.');
         }
-        try {
-          // Node 18
-          strictEqual(
-            error.message,
-            'The file package.json is not a valid JSON. Unexpected token h in JSON at position 0'
-          );
-        } catch {
-          // Node 20
-          strictEqual(
-            error.message,
-            `The file package.json is not a valid JSON. Unexpected token 'h', "hello" is not valid JSON`
-          );
-        }
+
+        strictEqual(
+          error.message,
+          `The file package.json is not a valid JSON. Unexpected token 'h', "hello" is not valid JSON`
+        );
       }
     });
 

--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -21,7 +21,7 @@
     "revertmigration": "npx typeorm migration:revert -d build/db"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@foal/core": "^4.0.0",
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@foal/cli": "^4.0.0",
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "concurrently": "~8.2.2",
     "mocha": "~10.7.0",
     "supertest": "~7.0.0",

--- a/packages/cli/src/generate/specs/app/package.mongodb.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint --ext ts --fix src"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@foal/core": "^4.0.0",
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@foal/cli": "^4.0.0",
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "concurrently": "~8.2.2",
     "mocha": "~10.7.0",
     "supertest": "~7.0.0",

--- a/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint --ext ts --fix src"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@foal/core": "^4.0.0",
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@foal/cli": "^4.0.0",
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "concurrently": "~8.2.2",
     "mocha": "~10.7.0",
     "supertest": "~7.0.0",

--- a/packages/cli/src/generate/specs/app/package.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.yaml.json
@@ -21,7 +21,7 @@
     "revertmigration": "npx typeorm migration:revert -d build/db"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@foal/core": "^4.0.0",
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@foal/cli": "^4.0.0",
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "concurrently": "~8.2.2",
     "mocha": "~10.7.0",
     "supertest": "~7.0.0",

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -21,7 +21,7 @@
     "revertmigration": "npx typeorm migration:revert -d build/db"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@foal/core": "^4.0.0",
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@foal/cli": "^4.0.0",
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "concurrently": "~8.2.2",
     "mocha": "~10.7.0",
     "supertest": "~7.0.0",

--- a/packages/cli/src/generate/templates/app/package.mongodb.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint --ext ts --fix src"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@foal/core": "^4.0.0",
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@foal/cli": "^4.0.0",
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "concurrently": "~8.2.2",
     "mocha": "~10.7.0",
     "supertest": "~7.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@foal/internal-test": "^4.5.0",
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "@types/supertest": "6.0.2",
     "ajv-errors": "~3.0.0",
     "ejs": "~3.1.10",

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -581,11 +581,13 @@ describe('createApp', () => {
       .expect(400)
       .then(response => {
         try {
+          // Node 22
           deepStrictEqual(response.body, {
             body: '{ \"foo\": \"bar\", }',
-            message: 'Unexpected token } in JSON at position 16'
+            message: 'Expected double-quoted property name in JSON at position 16 (line 1 column 17)'
           });
         } catch (error) {
+          // Node 20
           deepStrictEqual(response.body, {
             body: '{ \"foo\": \"bar\", }',
             message: 'Expected double-quoted property name in JSON at position 16'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@
 try {
   const version = process.versions.node;
   const NODE_CURRENT_MAJOR_VERSION = parseInt(version.split('.')[0], 10);
-  const NODE_MINIMUM_MAJOR_VERSION = 18;
+  const NODE_MINIMUM_MAJOR_VERSION = 20;
   if (NODE_CURRENT_MAJOR_VERSION < NODE_MINIMUM_MAJOR_VERSION) {
     console.warn(`[Warning] You are using version ${version} of Node. FoalTS requires at least version ${NODE_MINIMUM_MAJOR_VERSION}.`);
   }

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@foal/cli": "^4.5.0",
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "concurrently": "~8.2.2",
     "copy": "~0.3.2",
     "mocha": "~10.7.0",

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "graphiql": "~3.1.1",
     "mocha": "~10.7.0",
     "react": "~18.2.0",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -42,11 +42,11 @@
   "dependencies": {
     "@foal/core": "^4.5.0",
     "ajv": "~8.17.0",
-    "glob": "~10.3.10"
+    "glob": "~11.0.0"
   },
   "devDependencies": {
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "graphql": "~16.9.0",
     "graphql-request": "~6.1.0",
     "mocha": "~10.7.0",

--- a/packages/graphql/src/graphql.controller.spec.ts
+++ b/packages/graphql/src/graphql.controller.spec.ts
@@ -136,10 +136,10 @@ describe('GraphQLController', () => {
         }
 
         try {
-          // Node 18
+          // Node 22
           strictEqual(
             response.body,
-            'The "variables" URL parameter is not a valid JSON-encoded string: Unexpected end of JSON input'
+            `The "variables" URL parameter is not a valid JSON-encoded string: Expected property name or '}' in JSON at position 1 (line 1 column 2)`
           );
         } catch {
           // Node 20
@@ -503,10 +503,10 @@ describe('GraphQLController', () => {
           }
 
           try {
-            // Node 18
+            // Node 22
             strictEqual(
               response.body,
-              'The "variables" URL parameter is not a valid JSON-encoded string: Unexpected end of JSON input'
+              `The "variables" URL parameter is not a valid JSON-encoded string: Expected property name or '}' in JSON at position 1 (line 1 column 2)`
             );
           } catch (error) {
             // Node 20

--- a/packages/internal-test/package.json
+++ b/packages/internal-test/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jwks-rsa/package.json
+++ b/packages/jwks-rsa/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -53,7 +53,7 @@
     "@foal/core": "^4.5.0",
     "@foal/jwt": "^4.5.0",
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",

--- a/packages/jwt/src/http/jwt.hook.spec.ts
+++ b/packages/jwt/src/http/jwt.hook.spec.ts
@@ -302,33 +302,15 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
         throw new Error('response should be instance of HttpResponseUnauthorized');
       }
 
-      try {
-        // Node 18
-        deepStrictEqual(response.body, {
-          code: 'invalid_token',
-          description: 'Unexpected token R in JSON at position 27'
-        });
-      } catch {
-        // Node 20
-        deepStrictEqual(response.body, {
-          code: 'invalid_token',
-          description: `Unexpected token 'R', ...\"0\",\"name\":RJohn Doe\"\"... is not valid JSON`
-        });
-      }
+      deepStrictEqual(response.body, {
+        code: 'invalid_token',
+        description: `Unexpected token 'R', ...\"0\",\"name\":RJohn Doe\"\"... is not valid JSON`
+      });
 
-      try {
-        // Node 18
-        strictEqual(
-          response.getHeader('WWW-Authenticate'),
-          'error="invalid_token", error_description="Unexpected token R in JSON at position 27"'
-        );
-      } catch {
-        // Node 20
-        strictEqual(
-          response.getHeader('WWW-Authenticate'),
-          `error="invalid_token", error_description="Unexpected token 'R', ...\"0\",\"name\":RJohn Doe\"\"... is not valid JSON"`
-        );
-      }
+      strictEqual(
+        response.getHeader('WWW-Authenticate'),
+        `error="invalid_token", error_description="Unexpected token 'R', ...\"0\",\"name\":RJohn Doe\"\"... is not valid JSON"`
+      );
     });
 
     it('should return an HttpResponseUnauthorized object if options.secretOrPublicKey throws an'

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -41,7 +41,7 @@
   ],
   "devDependencies": {
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "copy": "~0.3.2",
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "copy": "~0.3.2",
     "jsonwebtoken": "~9.0.2",
     "mocha": "~10.7.0",

--- a/packages/social/src/google-provider.service.spec.ts
+++ b/packages/social/src/google-provider.service.spec.ts
@@ -47,8 +47,8 @@ describe('GoogleProvider', () => {
           throw error;
         }
         try {
-          // Node 18
-          strictEqual(error.message, 'The ID token returned by Google is not a valid JWT: Unexpected end of JSON input.');
+          // Node 22
+          strictEqual(error.message, `The ID token returned by Google is not a valid JWT: Expected property name or '}' in JSON at position 1 (line 1 column 2).`);
         } catch {
           // Node 20
           strictEqual(error.message, `The ID token returned by Google is not a valid JWT: Expected property name or '}' in JSON at position 1.`);

--- a/packages/socket.io/package.json
+++ b/packages/socket.io/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@socket.io/redis-adapter": "~8.3.0",
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "mocha": "~10.7.0",
     "redis": "~4.6.15",
     "rimraf": "~5.0.5",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@foal/internal-test": "^4.5.0",
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "@types/supertest": "6.0.2",
     "copy": "~0.3.2",
     "mocha": "~10.7.0",

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "copy": "~0.3.2",
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/typestack/package.json
+++ b/packages/typestack/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/sponsors/LoicPoullain"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@types/mocha": "10.0.7",
-    "@types/node": "18.18.6",
+    "@types/node": "20.14.8",
     "@types/validator": "13.12.0",
     "class-transformer": "~0.5.1",
     "class-validator": "~0.14.1",


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

- Node 18 will reach end-of-life on April 2025: https://nodejs.org/en/about/previous-releases.
- Node 22 is available.

# Solution and steps

- [x] Drop support for Node 18.
- [x] Add support for Node 22.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.

# Dependencies

- `@foal/graphql`
  - `glob@11`
