### PR TITLE
Remove `node-fetch` dependency

### DIFF
--- a/docs/docs/tutorials/real-world-example-with-react/15-social-auth.md
+++ b/docs/docs/tutorials/real-world-example-with-react/15-social-auth.md
@@ -66,7 +66,7 @@ if (!(await verifyPassword(password, user.password))) {
 Now that the password problem is solved, you can install the packages and provide your social credentials in the configuration.
 
 ```bash
-npm install @foal/social node-fetch@2
+npm install @foal/social
 ```
 
 *config/default.json*
@@ -114,7 +114,6 @@ Open the file and add two new routes.
 import { Context, dependency, Get, HttpResponseRedirect } from '@foal/core';
 import { GoogleProvider } from '@foal/social';
 import { User } from '../../entities';
-import * as fetch from 'node-fetch';
 import { Disk } from '@foal/storage';
 
 interface GoogleUserInfo {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15282,8 +15282,7 @@
         "ajv-formats": "~2.1.1",
         "cli-spinner": "~0.2.10",
         "colors": "1.4.0",
-        "commander": "~12.1.0",
-        "node-fetch": "~2.7.0"
+        "commander": "~12.1.0"
       },
       "bin": {
         "foal": "lib/index.js"
@@ -15304,25 +15303,6 @@
         "url": "https://github.com/sponsors/LoicPoullain"
       }
     },
-    "packages/cli/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "packages/cli/node_modules/rimraf": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
@@ -15339,25 +15319,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/cli/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "packages/cli/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "packages/cli/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "packages/core": {
@@ -15952,8 +15913,7 @@
       "version": "4.5.0",
       "license": "MIT",
       "dependencies": {
-        "@foal/core": "^4.5.0",
-        "node-fetch": "~2.7.0"
+        "@foal/core": "^4.5.0"
       },
       "devDependencies": {
         "@types/mocha": "10.0.7",
@@ -15972,25 +15932,6 @@
         "url": "https://github.com/sponsors/LoicPoullain"
       }
     },
-    "packages/social/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "packages/social/node_modules/rimraf": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
@@ -16007,25 +15948,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/social/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "packages/social/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "packages/social/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "packages/socket.io": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,8 +61,7 @@
     "ajv-formats": "~2.1.1",
     "cli-spinner": "~0.2.10",
     "colors": "1.4.0",
-    "commander": "~12.1.0",
-    "node-fetch": "~2.7.0"
+    "commander": "~12.1.0"
   },
   "devDependencies": {
     "@types/mocha": "10.0.7",

--- a/packages/cli/src/generate/generators/upgrade/upgrade.ts
+++ b/packages/cli/src/generate/generators/upgrade/upgrade.ts
@@ -1,6 +1,3 @@
-// 3p
-import * as fetch from 'node-fetch';
-
 // FoalTS
 import { FileSystem } from '../../file-system';
 import { installDependencies, logger } from '../../utils';

--- a/packages/cli/typings/node-fetch/index.d.ts
+++ b/packages/cli/typings/node-fetch/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'node-fetch';

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -52,8 +52,7 @@
     "lib/"
   ],
   "dependencies": {
-    "@foal/core": "^4.5.0",
-    "node-fetch": "~2.7.0"
+    "@foal/core": "^4.5.0"
   },
   "devDependencies": {
     "@types/mocha": "10.0.7",

--- a/packages/social/src/abstract-provider.service.ts
+++ b/packages/social/src/abstract-provider.service.ts
@@ -4,7 +4,6 @@ import * as crypto from 'crypto';
 
 // 3p
 import { Config, Context, generateToken, HttpResponseRedirect, convertBase64ToBase64url, CookieOptions, HttpResponseOK } from '@foal/core';
-import * as fetch from 'node-fetch';
 
 /**
  * Tokens returned by an OAuth2 authorization server.

--- a/packages/social/src/facebook-provider.service.ts
+++ b/packages/social/src/facebook-provider.service.ts
@@ -1,9 +1,6 @@
 // std
 import { URL } from 'url';
 
-// 3p
-import * as fetch from 'node-fetch';
-
 // FoalTS
 import { AbstractProvider, SocialTokens } from './abstract-provider.service';
 import { UserInfoError } from './user-info.error';

--- a/packages/social/src/github-provider.service.ts
+++ b/packages/social/src/github-provider.service.ts
@@ -1,6 +1,3 @@
-// 3p
-import * as fetch from 'node-fetch';
-
 // FoalTS
 import { AbstractProvider, SocialTokens } from './abstract-provider.service';
 import { UserInfoError } from './user-info.error';

--- a/packages/social/src/linkedin-provider.service.ts
+++ b/packages/social/src/linkedin-provider.service.ts
@@ -1,9 +1,6 @@
 // std
 import { URL } from 'url';
 
-// 3p
-import * as fetch from 'node-fetch';
-
 // FoalTS
 import { AbstractProvider, SocialTokens } from './abstract-provider.service';
 import { UserInfoError } from './user-info.error';

--- a/packages/social/src/twitter-provider.service.ts
+++ b/packages/social/src/twitter-provider.service.ts
@@ -1,5 +1,3 @@
-// 3p
-import * as fetch from 'node-fetch';
 
 // FoalTS
 import { AbstractProvider, SocialTokens } from './abstract-provider.service';

--- a/packages/social/typings/node-fetch/index.d.ts
+++ b/packages/social/typings/node-fetch/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'node-fetch';


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

Starting from Node 20 and 22, all tests pass by replacing `node-fetch` dependency with the native Node fetch API. Thus, the dependency can be removed.

See also #1267

# Solution and steps

- [x] Remove `node-fetch` dependency.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.

# Dependencies

- `@foal/cli`
  - `node-fetch` removed
- `@foal/social`
  - `node-fetch` removed