### PR TITLE
Make `Context.state` type to `{}` by default

### DIFF
--- a/docs/blog/version-5.0-release-notes.md
+++ b/docs/blog/version-5.0-release-notes.md
@@ -18,7 +18,40 @@ Version 5.0 of [Foal](https://foalts.org/) is out!
 
 - Support for Node 18 has been dropped and support for Node 22 has been added.
 
-## Removal of depreacted components
+## Better typing
 
-- The deprecated hook `@Log` has been removed. To replace it, you can use the `Logger` service in a custom `@Hook`.
+- The default type of `Context.state` is now `{}`. This way, you'll get a compilation error if you forget to specify a type for the state.
+
+    ```typescript
+    // Version 4
+    class MyController {
+      @Get('/foobar')
+      foobar(ctx: Context) {
+        // Does not throw.
+        console.log(ctx.state.shoppingCart);
+      }
+    }
+
+    // Version 5
+    class MyController {
+      @Get('/foobar')
+      foobar(ctx: Context) {
+        // Throws a compilation error: Property 'shoppingCart' does not exist on type '{}'.ts(2339)
+        console.log(ctx.state.shoppingCart);
+      }
+    }
+
+    // Version 5 (without error)
+    class MyController {
+      @Get('/foobar')
+      foobar(ctx: Context<any, { shoppingCart: object }>) {
+        console.log(ctx.state.shoppingCart);
+      }
+    }
+
+    ```
+
+## Removal of deprecated components
+
+- The deprecated hook `@Log` has been removed. Use the `Logger` service in a custom `@Hook` instead.
 - The command alias `npx foal run-script` has been removed. Use `npx foal run` instead.

--- a/docs/docs/architecture/controllers.md
+++ b/docs/docs/architecture/controllers.md
@@ -100,7 +100,7 @@ It has seven properties:
 | Name | Type | Description |
 | --- | --- | --- |
 | `request` | `Request` | Gives information about the HTTP request. |
-| `state` | `{ [key: string]: any }` | Object which can be used to forward data accross several hooks (see [Hooks](./hooks.md)). |
+| `state` | `{ [key: string]: any } = {}` | Object which can be used to forward data accross several hooks (see [Hooks](./hooks.md)). |
 | `user` | `{ [key: string]: any }`\|`null` | The current user (see [Authentication](../authentication/quick-start.md)). | 
 | `session`| `Session`\|`null` | The session object if you use sessions. |
 | `files` | `FileList` | A list of file paths or buffers if you uploaded files (see [Upload and download files](../common/file-storage/upload-and-download-files.md)). |

--- a/docs/docs/architecture/hooks.md
+++ b/docs/docs/architecture/hooks.md
@@ -465,7 +465,7 @@ import { Context, Get, Hook, HttpResponseOK, UserRequired } from '@foal/core';
 import { Org } from '../entities';
 
 function AddOrgToContext() {
-  return Hook(async ctx => {
+  return Hook(async (ctx: Context<any, { org: Org }>) => {
     if (ctx.user) {
       ctx.state.org = await Org.findOneByOrFail({ id: ctx.user.orgId });
     }
@@ -477,7 +477,7 @@ export class ApiController {
   @Get('/org-name')
   @UserRequired()
   @AddOrgToContext()
-  readOrgName(ctx: Context) {
+  readOrgName(ctx: Context<any, { org: Org }>) {
     return new HttpResponseOK(ctx.state.org.name);
   }
 

--- a/packages/acceptance-tests/src/docs/architecture/hooks/forwarding-data-between-hooks.feature.ts
+++ b/packages/acceptance-tests/src/docs/architecture/hooks/forwarding-data-between-hooks.feature.ts
@@ -21,7 +21,7 @@ describe('Feature: Forwarding data betweens hooks', () => {
     /* ======================= DOCUMENTATION BEGIN ======================= */
 
     function AddOrgToContext() {
-      return Hook(async ctx => {
+      return Hook(async (ctx: Context<any, { org: Org }>) => {
         if (ctx.user) {
           ctx.state.org = await Org.findOneByOrFail({ id: ctx.user.orgId });
         }
@@ -33,7 +33,7 @@ describe('Feature: Forwarding data betweens hooks', () => {
       @Get('/org-name')
       @UserRequired()
       @AddOrgToContext()
-      readOrgName(ctx: Context) {
+      readOrgName(ctx: Context<any, { org: Org }>) {
         return new HttpResponseOK(ctx.state.org.name);
       }
 

--- a/packages/core/src/core/http/context.ts
+++ b/packages/core/src/core/http/context.ts
@@ -114,7 +114,7 @@ interface Request extends IncomingMessage {
  * @class Context
  * @template User
  */
-export class Context<User = { [key: string]: any } | null, ContextState = { [key: string]: any }> {
+export class Context<User = { [key: string]: any } | null, ContextState extends { [key: string]: any } = {}> {
   readonly request: Request;
   session: Session | null;
 

--- a/packages/socket.io/src/architecture/websocket-context.ts
+++ b/packages/socket.io/src/architecture/websocket-context.ts
@@ -17,7 +17,7 @@ import { Session } from '@foal/core';
  * @template ContextSession
  * @template ContextState
  */
-export class WebsocketContext<User = { [key: string]: any } | null, ContextState = { [key: string]: any }> {
+export class WebsocketContext<User = { [key: string]: any } | null, ContextState extends { [key: string]: any } = {}> {
   readonly socket: Socket;
   session: Session | null;
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

When using `Context.state`, if we forget to provide a value for the generic type, the property works as if it was of type `any` which is not type-safe.

# Solution and steps

- [x] Make `Context.state` default type to "{}" to make it necessary to provide a value for the generic type.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
