### PR TITLE
Upgrade to TS v5

### DIFF
--- a/.github/CONTRIBUTING.MD
+++ b/.github/CONTRIBUTING.MD
@@ -136,7 +136,7 @@ All of major releases are supported for at least 18 months.
 
 | Release | Status | Active Start | Maintenance Start | End-of-life | Node versions | TS min version |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| 5.x | *Active* | TODO |  |  | 20, 22 | 4.9 |
+| 5.x | *Active* | TODO |  |  | 20, 22 | 5.5 |
 | 4.x | *Maintenance* | 2023-09-06 | TODO | TODO | 18, 20 | 4.9 |
 | 3.x | *End-of-Life* | 2022-10-28 | 2023-09-06 | 2024-03-06 | 16, 18 | 4.7 |
 | 2.x | *End-of-Life* | 2020-12-03 | 2022-10-28 | 2023-04-30 | 10, 12, 14 | 4.0 |

--- a/docs/blog/version-5.0-release-notes.md
+++ b/docs/blog/version-5.0-release-notes.md
@@ -14,9 +14,10 @@ Version 5.0 of [Foal](https://foalts.org/) is out!
 
 <!--truncate-->
 
-## Supported versions of Node
+## Supported versions of Node and TypeScript
 
 - Support for Node 18 has been dropped and support for Node 22 has been added.
+- The supported version of TypeScript is version 5. Update your `package.json` file accordingly.
 
 ## Better typing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "lerna": "~8.1.7",
         "mocha": "~10.7.0",
         "tslint": "~6.1.3",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -14462,16 +14462,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "devOptional": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uc.micro": {
@@ -15220,7 +15221,7 @@
         "@types/supertest": "6.0.2",
         "mocha": "~10.7.0",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -15246,7 +15247,7 @@
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -15294,7 +15295,7 @@
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -15346,7 +15347,7 @@
         "supertest": "~7.0.0",
         "ts-node": "~10.9.2",
         "twig": "~1.17.1",
-        "typescript": "~4.9.5",
+        "typescript": "~5.5.4",
         "yamljs": "~0.3.0"
       },
       "engines": {
@@ -15401,7 +15402,7 @@
         "copy": "~0.3.2",
         "mocha": "~10.7.0",
         "supervisor": "~0.12.0",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -15426,7 +15427,7 @@
         "react-dom": "~18.2.0",
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -15471,7 +15472,7 @@
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
         "type-graphql": "2.0.0-beta.3",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -15675,7 +15676,7 @@
       "devDependencies": {
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -15717,7 +15718,7 @@
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -15761,7 +15762,7 @@
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -15802,7 +15803,7 @@
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -15840,7 +15841,7 @@
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -15881,7 +15882,7 @@
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -15923,7 +15924,7 @@
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -15968,7 +15969,7 @@
         "rimraf": "~5.0.5",
         "socket.io-client": "~4.7.5",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -16014,7 +16015,7 @@
         "rimraf": "~5.0.5",
         "supertest": "~7.0.0",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -16056,7 +16057,7 @@
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -16100,7 +16101,7 @@
         "sqlite3": "~5.1.7",
         "ts-node": "~10.9.2",
         "typeorm": "0.3.17",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -16147,7 +16148,7 @@
         "mocha": "~10.7.0",
         "rimraf": "~5.0.5",
         "ts-node": "~10.9.2",
-        "typescript": "~4.9.5"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "lerna": "~8.1.7",
     "mocha": "~10.7.0",
     "tslint": "~6.1.3",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/acceptance-tests/package.json
+++ b/packages/acceptance-tests/package.json
@@ -54,6 +54,6 @@
     "@types/supertest": "6.0.2",
     "mocha": "~10.7.0",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/aws-s3/package.json
+++ b/packages/aws-s3/package.json
@@ -55,6 +55,6 @@
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -70,6 +70,6 @@
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -41,6 +41,6 @@
     "eslint": "~8.48.0",
     "@typescript-eslint/eslint-plugin": "~6.5.0",
     "@typescript-eslint/parser": "~6.5.0",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/cli/src/generate/specs/app/package.mongodb.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.json
@@ -37,6 +37,6 @@
     "eslint": "~8.48.0",
     "@typescript-eslint/eslint-plugin": "~6.5.0",
     "@typescript-eslint/parser": "~6.5.0",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
@@ -38,6 +38,6 @@
     "eslint": "~8.48.0",
     "@typescript-eslint/eslint-plugin": "~6.5.0",
     "@typescript-eslint/parser": "~6.5.0",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/cli/src/generate/specs/app/package.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.yaml.json
@@ -42,6 +42,6 @@
     "eslint": "~8.48.0",
     "@typescript-eslint/eslint-plugin": "~6.5.0",
     "@typescript-eslint/parser": "~6.5.0",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -41,6 +41,6 @@
     "eslint": "~8.48.0",
     "@typescript-eslint/eslint-plugin": "~6.5.0",
     "@typescript-eslint/parser": "~6.5.0",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/cli/src/generate/templates/app/package.mongodb.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.json
@@ -37,6 +37,6 @@
     "eslint": "~8.48.0",
     "@typescript-eslint/eslint-plugin": "~6.5.0",
     "@typescript-eslint/parser": "~6.5.0",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,7 @@
     "supertest": "~7.0.0",
     "ts-node": "~10.9.2",
     "twig": "~1.17.1",
-    "typescript": "~4.9.5",
+    "typescript": "~5.5.4",
     "yamljs": "~0.3.0"
   }
 }

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -66,6 +66,6 @@
     "copy": "~0.3.2",
     "mocha": "~10.7.0",
     "supervisor": "~0.12.0",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/graphiql/package.json
+++ b/packages/graphiql/package.json
@@ -51,6 +51,6 @@
     "react-dom": "~18.2.0",
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -53,7 +53,7 @@
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",
     "type-graphql": "2.0.0-beta.3",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   },
   "peerDependencies": {
     "graphql": "^16.9.0"

--- a/packages/internal-test/package.json
+++ b/packages/internal-test/package.json
@@ -40,6 +40,6 @@
   "devDependencies": {
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/jwks-rsa/package.json
+++ b/packages/jwks-rsa/package.json
@@ -57,6 +57,6 @@
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -51,6 +51,6 @@
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -54,6 +54,6 @@
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/password/package.json
+++ b/packages/password/package.json
@@ -46,6 +46,6 @@
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -50,6 +50,6 @@
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -62,6 +62,6 @@
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/socket.io/package.json
+++ b/packages/socket.io/package.json
@@ -52,7 +52,7 @@
     "rimraf": "~5.0.5",
     "socket.io-client": "~4.7.5",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   },
   "dependencies": {
     "@foal/core": "^4.5.0",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -58,6 +58,6 @@
     "rimraf": "~5.0.5",
     "supertest": "~7.0.0",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -53,6 +53,6 @@
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -62,6 +62,6 @@
     "sqlite3": "~5.1.7",
     "ts-node": "~10.9.2",
     "typeorm": "0.3.17",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }

--- a/packages/typestack/package.json
+++ b/packages/typestack/package.json
@@ -60,6 +60,6 @@
     "mocha": "~10.7.0",
     "rimraf": "~5.0.5",
     "ts-node": "~10.9.2",
-    "typescript": "~4.9.5"
+    "typescript": "~5.5.4"
   }
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

We need to upgrade to the latest major version of TS which is v5.

# Solution and steps

- [x] Upgrade to TS v5.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
