### PR TITLE
Compile to ES2023

### DIFF
--- a/docs/blog/version-5.0-release-notes.md
+++ b/docs/blog/version-5.0-release-notes.md
@@ -16,8 +16,19 @@ Version 5.0 of [Foal](https://foalts.org/) is out!
 
 ## Supported versions of Node and TypeScript
 
-- Support for Node 18 has been dropped and support for Node 22 has been added.
+- Support for Node 18 has been dropped and support for Node 22 has been added. Foal code is now compiled to ES2023.
 - The supported version of TypeScript is version 5. Update your `package.json` file accordingly.
+
+> If you're using the `GraphQLController` with the `resolvers` property, you need to add the `declare` keyword before the property name:
+> ```typescript
+> 
+> export class ApiController extends GraphQLController {
+>   schema = // ...
+>
+>   @dependency
+>   declare resolvers: RootResolverService;
+> }
+> ```
 
 ## Better typing
 

--- a/docs/docs/common/graphql.md
+++ b/docs/docs/common/graphql.md
@@ -194,7 +194,7 @@ export class ApiController extends GraphQLController {
   schema = // ...
 
   @dependency
-  resolvers: RootResolverService;
+  declare resolvers: RootResolverService;
 }
 ```
 

--- a/packages/acceptance-tests/tsconfig.json
+++ b/packages/acceptance-tests/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ],
     "jsx": "react"

--- a/packages/aws-s3/tsconfig.json
+++ b/packages/aws-s3/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },

--- a/packages/cli/src/generate/specs/app/tsconfig.json
+++ b/packages/cli/src/generate/specs/app/tsconfig.json
@@ -8,10 +8,10 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "rootDir": "src",
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },

--- a/packages/cli/src/generate/templates/app/tsconfig.json
+++ b/packages/cli/src/generate/templates/app/tsconfig.json
@@ -8,10 +8,10 @@
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "rootDir": "src",
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },

--- a/packages/examples/src/app/entities/user.entity.ts
+++ b/packages/examples/src/app/entities/user.entity.ts
@@ -6,9 +6,6 @@ import { UserWithPermissions } from '@foal/typeorm';
 @Entity()
 export class User extends UserWithPermissions {
 
-  @PrimaryGeneratedColumn()
-  id: number;
-
   @Column({ unique: true })
   email: string;
 

--- a/packages/examples/src/app/entities/user.entity.ts
+++ b/packages/examples/src/app/entities/user.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity } from 'typeorm';
 
 import { hashPassword } from '@foal/core';
 import { UserWithPermissions } from '@foal/typeorm';

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "build",
     "sourceMap": true,
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strictNullChecks": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom",
       "ESNext.AsyncIterable"
     ]

--- a/packages/graphiql/tsconfig.json
+++ b/packages/graphiql/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },

--- a/packages/graphql/src/acceptance-test.spec.ts
+++ b/packages/graphql/src/acceptance-test.spec.ts
@@ -70,7 +70,7 @@ describe('[Acceptance test] GraphQLController', () => {
       schema = buildSchema(typeDefs);
 
       @dependency
-      resolvers: AppResolver;
+      declare resolvers: AppResolver;
     }
 
     class AppController {
@@ -109,7 +109,7 @@ describe('[Acceptance test] GraphQLController', () => {
       schema = schemaFromTypeGlob('./test-dir/*.graphql');
 
       @dependency
-      resolvers: AppResolver;
+      declare resolvers: AppResolver;
     }
 
     class AppController {
@@ -158,7 +158,7 @@ describe('[Acceptance test] GraphQLController', () => {
       schema = buildSchema(typeDefs);
 
       @dependency
-      resolvers: Resolvers;
+      declare resolvers: Resolvers;
     }
 
     class AppController {

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom",
       "ESNext.AsyncIterable"
     ]

--- a/packages/internal-test/tsconfig.json
+++ b/packages/internal-test/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },

--- a/packages/jwks-rsa/tsconfig.json
+++ b/packages/jwks-rsa/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },

--- a/packages/jwt/tsconfig.json
+++ b/packages/jwt/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },

--- a/packages/mongodb/tsconfig.json
+++ b/packages/mongodb/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ],
     "types": [

--- a/packages/password/tsconfig.json
+++ b/packages/password/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ],
     "types": [

--- a/packages/redis/tsconfig.json
+++ b/packages/redis/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ],
     "types": [

--- a/packages/social/tsconfig.json
+++ b/packages/social/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },

--- a/packages/socket.io/tsconfig.json
+++ b/packages/socket.io/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ],
     "types": [

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },

--- a/packages/swagger/tsconfig.json
+++ b/packages/swagger/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },

--- a/packages/typeorm/tsconfig.json
+++ b/packages/typeorm/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },

--- a/packages/typestack/tsconfig.json
+++ b/packages/typestack/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "lib/",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -15,7 +15,7 @@
       "../../node_modules/@types",
     ],
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "./lib/",
     "baseUrl": ".",
     "module": "commonjs",
-    "target": "es2021",
+    "target": "es2023",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
@@ -11,7 +11,7 @@
     "sourceMap": true,
     "declaration": true,
     "lib": [
-      "es2021",
+      "es2023",
       "dom"
     ]
   },


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

There is no need to compile to ES2021 anymore as Foal v5 supports Node 20 & 22. See: https://node.green

# Solution and steps

- [x] Compile to ES2023

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
