### PR TITLE
Make `addLogContext` accept a record with multiple params

### DIFF
--- a/docs/blog/version-5.0-release-notes.md
+++ b/docs/blog/version-5.0-release-notes.md
@@ -65,6 +65,10 @@ Version 5.0 of [Foal](https://foalts.org/) is out!
 
 - The return value of the social services `getUserInfoFromTokens` method is now typed.
 
+## Logging
+
+- The `Logger.addLogContext(key, value)` method now accepts a record as argument: `Logger.addLogContext(params)`. This makes the function's signature more consistent with other logging methods (`info`, `warn`, etc.) and allows multiple parameters to be passed at once.
+
 ## Removal of deprecated components
 
 - The deprecated hook `@Log` has been removed. Use the `Logger` service in a custom `@Hook` instead.

--- a/docs/blog/version-5.0-release-notes.md
+++ b/docs/blog/version-5.0-release-notes.md
@@ -67,7 +67,7 @@ Version 5.0 of [Foal](https://foalts.org/) is out!
 
 ## Logging
 
-- The `Logger.addLogContext(key, value)` method now accepts a record as argument: `Logger.addLogContext(params)`. This makes the function's signature more consistent with other logging methods (`info`, `warn`, etc.) and allows multiple parameters to be passed at once.
+- The `Logger.addLogContext(key, value)` method now accepts a record as parameter: `Logger.addLogContext(context)`. This makes the function's signature more consistent with other logging methods (`info`, `warn`, etc.) and allows multiple keys/values to be passed at once.
 
 ## Removal of deprecated components
 

--- a/docs/docs/common/logging.md
+++ b/docs/docs/common/logging.md
@@ -260,7 +260,7 @@ This mecanism helps filter logs of a specific request or specific user in a logg
 
 If needed, you call also add manually custom parameters to the logger context with this fonction:
 ```typescript
-logger.addLogContext('myKey', 'myValue');
+logger.addLogContext({ myKey: 'myValue' });
 ```
 
 ## Transports

--- a/packages/core/src/core/logging/logger.spec.ts
+++ b/packages/core/src/core/logging/logger.spec.ts
@@ -22,11 +22,11 @@ describe('Logger', () => {
 
         const logger = new Logger();
         logger.initLogContext(() => {
-          logger.addLogContext('foo', 'bar');
+          logger.addLogContext({ foo: 'bar', jane: 'doe'});
           logger.log('error', 'Hello world', {});
         });
         logger.initLogContext(() => {
-          logger.addLogContext('foo2', 'bar2');
+          logger.addLogContext({ foo2: 'bar2' });
           logger.log('error', 'Hello world 2', {});
         });
 
@@ -36,6 +36,7 @@ describe('Logger', () => {
 
         strictEqual(loggedMessage.includes('[ERROR]'), true);
         strictEqual(loggedMessage.includes('foo: "bar"'), true);
+        strictEqual(loggedMessage.includes('jane: "doe"'), true);
         notStrictEqual(loggedMessage.includes('foo2: "bar2"'), true);
 
         const loggedMessage2 = consoleMock.calls[1].arguments[0];
@@ -43,6 +44,7 @@ describe('Logger', () => {
         strictEqual(loggedMessage2.includes('[ERROR]'), true);
         strictEqual(loggedMessage2.includes('foo2: "bar2"'), true);
         notStrictEqual(loggedMessage2.includes('foo: "bar"'), true);
+        notStrictEqual(loggedMessage2.includes('jane: "doe"'), true);
       });
 
       it('should let given params override the context.', () => {
@@ -50,7 +52,7 @@ describe('Logger', () => {
 
         const logger = new Logger();
         logger.initLogContext(() => {
-          logger.addLogContext('foo', 'bar');
+          logger.addLogContext({ foo: 'bar' });
           logger.log('error', 'Hello world', { foo: 'bar2' });
         });
 
@@ -68,7 +70,7 @@ describe('Logger', () => {
         const consoleMock = mock.method(console, 'log', () => {}).mock;
 
         const logger = new Logger();
-        logger.addLogContext('foo', 'bar');
+        logger.addLogContext({ foo: 'bar' });
 
         strictEqual(consoleMock.callCount(), 1);
 

--- a/packages/core/src/core/logging/logger.ts
+++ b/packages/core/src/core/logging/logger.ts
@@ -19,13 +19,13 @@ export class Logger {
     this.asyncLocalStorage.run({}, callback);
   }
 
-  addLogContext(name: string, value: any): void {
+  addLogContext(params: Record<string, any>): void {
     const store = this.asyncLocalStorage.getStore();
     if (!store) {
       this.log('warn', 'Impossible to add log context information. The logger context has not been initialized.');
       return;
     }
-    store[name] = value;
+    Object.assign(store, params);
   }
 
   log(

--- a/packages/core/src/core/logging/logger.ts
+++ b/packages/core/src/core/logging/logger.ts
@@ -19,13 +19,13 @@ export class Logger {
     this.asyncLocalStorage.run({}, callback);
   }
 
-  addLogContext(params: Record<string, any>): void {
+  addLogContext(context: Record<string, any>): void {
     const store = this.asyncLocalStorage.getStore();
     if (!store) {
       this.log('warn', 'Impossible to add log context information. The logger context has not been initialized.');
       return;
     }
-    Object.assign(store, params);
+    Object.assign(store, context);
   }
 
   log(

--- a/packages/core/src/express/create-app.spec.ts
+++ b/packages/core/src/express/create-app.spec.ts
@@ -887,7 +887,7 @@ describe('createApp', () => {
       @Get('/')
       @Hook((ctx, services) => {
         const logger = services.get(Logger);
-        logger.addLogContext('foo', 'bar');
+        logger.addLogContext({ foo: 'bar' });
       })
       getA(ctx: Context) {
         this.logger.info('Hello world');
@@ -995,9 +995,8 @@ describe('createApp', () => {
 
     strictEqual(loggerMock.callCount(), 1);
 
-    const [key, value] = loggerMock.calls[0].arguments;
+    const args = loggerMock.calls[0].arguments;
 
-    strictEqual(key, 'requestId');
-    strictEqual(value, requestId);
+    deepStrictEqual(args, [{ requestId }]);
   });
 });

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -116,7 +116,7 @@ export async function createApp(
     const requestId = req.get('x-request-id') || randomUUID();
 
     req.id = requestId;
-    logger.addLogContext('requestId', requestId);
+    logger.addLogContext({ requestId });
 
     next();
   });

--- a/packages/core/src/sessions/http/use-sessions.hook.spec.ts
+++ b/packages/core/src/sessions/http/use-sessions.hook.spec.ts
@@ -615,7 +615,7 @@ describe('UseSessions', () => {
 
         strictEqual(loggerMock.callCount(), 1);
 
-        deepStrictEqual(loggerMock.calls[0].arguments, ['userId', null]);
+        deepStrictEqual(loggerMock.calls[0].arguments, [{ userId: null }]);
       });
 
     });
@@ -632,7 +632,7 @@ describe('UseSessions', () => {
 
         strictEqual(loggerMock.callCount(), 1);
 
-        deepStrictEqual(loggerMock.calls[0].arguments, ['userId', userId]);
+        deepStrictEqual(loggerMock.calls[0].arguments, [{ userId }]);
       });
 
       context('given options.user is not defined', () => {

--- a/packages/core/src/sessions/http/use-sessions.hook.ts
+++ b/packages/core/src/sessions/http/use-sessions.hook.ts
@@ -144,7 +144,7 @@ export function UseSessions(options: UseSessionOptions = {}): HookDecorator {
     /* Set ctx.user */
 
     const logger = services.get(Logger);
-    logger.addLogContext('userId', session.userId);
+    logger.addLogContext({ userId: session.userId });
 
     if (session.userId !== null && options.user) {
       const userId = checkUserIdType(session.userId, options.userIdType);

--- a/packages/jwt/src/http/jwt.hook.spec.ts
+++ b/packages/jwt/src/http/jwt.hook.spec.ts
@@ -632,7 +632,7 @@ export function testSuite(JWT: typeof JWTOptional|typeof JWTRequired, required: 
       strictEqual(loggerMock.callCount(), 1);
       deepStrictEqual(
         loggerMock.calls[0].arguments,
-        ['userId', 123],
+        [{ userId: 123 }],
       );
     })
 

--- a/packages/jwt/src/http/jwt.hook.ts
+++ b/packages/jwt/src/http/jwt.hook.ts
@@ -201,7 +201,7 @@ export function JWT(required: boolean, options: JWTOptions, verifyOptions: Verif
     const userId = checkAndConvertUserIdType(payload.sub, options.userIdType);
 
     const logger = services.get(Logger);
-    logger.addLogContext('userId', userId);
+    logger.addLogContext({ userId });
 
     const user = await options.user(userId as never, services);
     if (!user) {

--- a/packages/socket.io/src/socketio-controller.service.spec.ts
+++ b/packages/socket.io/src/socketio-controller.service.spec.ts
@@ -431,7 +431,7 @@ describe('SocketIOController', () => {
           @EventName('create user')
           @WebsocketHook((ctx, services) => {
             const logger = services.get(Logger);
-            logger.addLogContext('foo', 'bar');
+            logger.addLogContext({ foo: 'bar' });
           })
           createUser(ctx: WebsocketContext, payload: any) {
             this.logger.info('Hello world');
@@ -474,12 +474,14 @@ describe('SocketIOController', () => {
         const payload = {};
         await new Promise(resolve => clientSocket.emit('create user', payload, resolve));
 
-        strictEqual(loggerMock.callCount(), 2);
+        strictEqual(loggerMock.callCount(), 1);
 
         const actualParameters = loggerMock.calls.map(call => call.arguments);
         const expectedParameters = [
-          ['socketId', socketId],
-          ['messageId', messageId]
+          [{
+            socketId,
+            messageId,
+          }]
         ];
 
         deepStrictEqual(actualParameters, expectedParameters);

--- a/packages/socket.io/src/socketio-controller.service.ts
+++ b/packages/socket.io/src/socketio-controller.service.ts
@@ -72,8 +72,11 @@ export abstract class SocketIOController implements ISocketIOController {
         socket.on(route.eventName, async (payload, cb) => {
           this.logger.initLogContext(async () => {
             const messageId = randomUUID();
-            this.logger.addLogContext('socketId', socket.id);
-            this.logger.addLogContext('messageId', messageId);
+
+            this.logger.addLogContext({
+              socketId: socket.id,
+              messageId,
+            });
 
             if (typeof payload === 'function') {
               cb = payload;


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

- The signature of the method `Logger.addLogContext` is different from the other logging methods (`info`, `warn`, etc) in the way to pass the context (key/value vs record).
- When we want to add merge a object to the log context, it is tedious to do it because we need to call the method for each key.

# Solution and steps

- [x] Convert the method signature from `Logger.addLogContext(key, value)` to `Logger.addLogContext(context)`

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
