### PR TITLE
Remove setting `loggerFormat` and add `logger.logHttpRequests`.

### DIFF
--- a/docs/blog/version-5.0-release-notes.md
+++ b/docs/blog/version-5.0-release-notes.md
@@ -68,6 +68,7 @@ Version 5.0 of [Foal](https://foalts.org/) is out!
 ## Logging
 
 - The `Logger.addLogContext(key, value)` method now accepts a record as parameter: `Logger.addLogContext(context)`. This makes the function's signature more consistent with other logging methods (`info`, `warn`, etc.) and allows multiple keys/values to be passed at once.
+- The deprecated `settings.loggerFormat` configuration has been removed. If you want to disable HTTP logging, set `settings.logger.logHttpRequests` to false instead.
 
 ## Removal of deprecated components
 

--- a/docs/docs/common/logging.md
+++ b/docs/docs/common/logging.md
@@ -216,12 +216,12 @@ When an error is thrown (or rejected) in a hook, controller or service and is no
 
 ### Disabling Error Logging
 
-In some scenarios, you might want to disable error logging. You can achieve this by setting the `allErrors` configuration option to false. 
+In some scenarios, you might want to disable error logging. You can achieve this by setting the `logErrors` configuration option to false. 
 
 ```json
 {
   "settings": {
-    "allErrors": false
+    "logErrors": false
   }
 }
 ```

--- a/docs/docs/common/logging.md
+++ b/docs/docs/common/logging.md
@@ -6,15 +6,6 @@ Foal provides an advanced built-in logger. This page shows how to use it.
 
 ## Recommended Configuration
 
-*config/default.json*
-```json
-{
-  "settings": {
-    "loggerFormat": "foal"
-  }
-}
-```
-
 *config/development.json*
 ```json
 {
@@ -143,7 +134,7 @@ If you wish to completly mask logs, you can use the `none` format.
 
 Each request received by Foal is logged with the INFO level.
 
-With the configuration key `settings.loggerFormat` set to `"foal"`, the messages start with `HTTP request -` and end with the request method and URL. The log parameters include the response status code and content length as well as the response time and the request method and URL.
+The messages start with `HTTP request -` and end with the request method and URL. The log parameters include the response status code and content length as well as the response time and the request method and URL.
 
 > Note: the query parameters are not logged to avoid logging sensitive data (such as an API key).
 
@@ -162,26 +153,16 @@ const app = await createApp({
 })
 ```
 
-### Formatting the log message (deprecated)
-
-If you wish to customize the HTTP log messages, you can set the value of the `loggerFormat.loggerFormat` configuration to a format supported by [morgan](https://www.npmjs.com/package/morgan). With this technique, no parameters will be logged though.
-
-```json
-{
-  "settings": {
-    "loggerFormat": "tiny"
-  }
-}
-```
-
 ### Disabling HTTP Request Logging
 
-In some scenarios and environments, you might want to disable HTTP request logging. You can achieve this by setting the `loggerFormat` configuration option to `none`. 
+In some scenarios and environments, you might want to disable HTTP request logging. You can achieve this by setting the `logger.logHttpRequests` configuration option to `false`. 
 
 ```json
 {
   "settings": {
-    "loggerFormat": "none"
+    "logger": {
+      "logHttpRequests": false
+    }
   }
 }
 ```

--- a/packages/acceptance-tests/config/default.yml
+++ b/packages/acceptance-tests/config/default.yml
@@ -1,2 +1,3 @@
 settings:
-  loggerFormat: none
+  logger:
+    logHttpRequests: false

--- a/packages/cli/src/generate/specs/app/config/default.json
+++ b/packages/cli/src/generate/specs/app/config/default.json
@@ -1,7 +1,6 @@
 {
   "port": "env(PORT)",
   "settings": {
-    "loggerFormat": "foal",
     "session": {
       "store": "@foal/typeorm"
     }

--- a/packages/cli/src/generate/specs/app/config/default.mongodb.json
+++ b/packages/cli/src/generate/specs/app/config/default.mongodb.json
@@ -1,8 +1,5 @@
 {
   "port": "env(PORT)",
-  "settings": {
-    "loggerFormat": "foal"
-  },
   "database": {
     "type": "mongodb",
     "url": "mongodb://localhost:27017/test-foo-bar"

--- a/packages/cli/src/generate/specs/app/config/default.mongodb.yml
+++ b/packages/cli/src/generate/specs/app/config/default.mongodb.yml
@@ -1,8 +1,5 @@
 port: env(PORT)
 
-settings:
-  loggerFormat: foal
-
 database:
   type: mongodb
   url: mongodb://localhost:27017/test-foo-bar

--- a/packages/cli/src/generate/specs/app/config/default.yml
+++ b/packages/cli/src/generate/specs/app/config/default.yml
@@ -1,7 +1,6 @@
 port: env(PORT)
 
 settings:
-  loggerFormat: foal
   session:
     store: '@foal/typeorm'
 

--- a/packages/cli/src/generate/specs/app/config/e2e.json
+++ b/packages/cli/src/generate/specs/app/config/e2e.json
@@ -1,6 +1,8 @@
 {
   "settings": {
-    "loggerFormat": "none"
+    "logger": {
+      "logHttpRequests": false
+    }
   },
   "database": {
     "database": "./e2e_db.sqlite3",

--- a/packages/cli/src/generate/specs/app/config/e2e.mongodb.json
+++ b/packages/cli/src/generate/specs/app/config/e2e.mongodb.json
@@ -1,6 +1,8 @@
 {
   "settings": {
-    "loggerFormat": "none"
+    "logger": {
+      "logHttpRequests": false
+    }
   },
   "database": {
     "url": "mongodb://localhost:27017/e2e-test-foo-bar"

--- a/packages/cli/src/generate/specs/app/config/e2e.mongodb.yml
+++ b/packages/cli/src/generate/specs/app/config/e2e.mongodb.yml
@@ -1,5 +1,6 @@
 settings:
-  loggerFormat: 'none'
+  logger:
+    logHttpRequests: false
 
 database:
   url: mongodb://localhost:27017/e2e-test-foo-bar

--- a/packages/cli/src/generate/specs/app/config/e2e.yml
+++ b/packages/cli/src/generate/specs/app/config/e2e.yml
@@ -1,5 +1,6 @@
 settings:
-  loggerFormat: 'none'
+  logger:
+    logHttpRequests: false
 
 database:
   database: './e2e_db.sqlite3'

--- a/packages/cli/src/generate/templates/app/config/default.json
+++ b/packages/cli/src/generate/templates/app/config/default.json
@@ -1,7 +1,6 @@
 {
   "port": "env(PORT)",
   "settings": {
-    "loggerFormat": "foal",
     "session": {
       "store": "@foal/typeorm"
     }

--- a/packages/cli/src/generate/templates/app/config/default.mongodb.json
+++ b/packages/cli/src/generate/templates/app/config/default.mongodb.json
@@ -1,8 +1,5 @@
 {
   "port": "env(PORT)",
-  "settings": {
-    "loggerFormat": "foal"
-  },
   "database": {
     "type": "mongodb",
     "url": "mongodb://localhost:27017//* kebabName */"

--- a/packages/cli/src/generate/templates/app/config/default.mongodb.yml
+++ b/packages/cli/src/generate/templates/app/config/default.mongodb.yml
@@ -1,8 +1,5 @@
 port: env(PORT)
 
-settings:
-  loggerFormat: foal
-
 database:
   type: mongodb
   url: mongodb://localhost:27017//* kebabName */

--- a/packages/cli/src/generate/templates/app/config/default.yml
+++ b/packages/cli/src/generate/templates/app/config/default.yml
@@ -1,7 +1,6 @@
 port: env(PORT)
 
 settings:
-  loggerFormat: foal
   session:
     store: '@foal/typeorm'
 

--- a/packages/cli/src/generate/templates/app/config/e2e.json
+++ b/packages/cli/src/generate/templates/app/config/e2e.json
@@ -1,6 +1,8 @@
 {
   "settings": {
-    "loggerFormat": "none"
+    "logger": {
+      "logHttpRequests": false
+    }
   },
   "database": {
     "database": "./e2e_db.sqlite3",

--- a/packages/cli/src/generate/templates/app/config/e2e.mongodb.json
+++ b/packages/cli/src/generate/templates/app/config/e2e.mongodb.json
@@ -1,6 +1,8 @@
 {
   "settings": {
-    "loggerFormat": "none"
+    "logger": {
+      "logHttpRequests": false
+    }
   },
   "database": {
     "url": "mongodb://localhost:27017/e2e-/* kebabName */"

--- a/packages/cli/src/generate/templates/app/config/e2e.mongodb.yml
+++ b/packages/cli/src/generate/templates/app/config/e2e.mongodb.yml
@@ -1,5 +1,6 @@
 settings:
-  loggerFormat: 'none'
+  logger:
+    logHttpRequests: false
 
 database:
   url: mongodb://localhost:27017/e2e-/* kebabName */

--- a/packages/cli/src/generate/templates/app/config/e2e.yml
+++ b/packages/cli/src/generate/templates/app/config/e2e.yml
@@ -1,5 +1,6 @@
 settings:
-  loggerFormat: 'none'
+  logger:
+    logHttpRequests: false
 
 database:
   database: './e2e_db.sqlite3'

--- a/packages/core/src/express/create-app.ts
+++ b/packages/core/src/express/create-app.ts
@@ -122,12 +122,8 @@ export async function createApp(
   });
 
   // Log requests.
-  const loggerFormat = Config.get(
-    'settings.loggerFormat',
-    'string',
-    '[:date] ":method :url HTTP/:http-version" :status - :response-time ms'
-  );
-  if (loggerFormat === 'foal') {
+  const shouldLogHttpRequests = Config.get('settings.logger.logHttpRequests', 'boolean', true);
+  if (shouldLogHttpRequests) {
     const getHttpLogParams = options.getHttpLogParams || getHttpLogParamsDefault;
     app.use(morgan(
       (tokens: any, req: any, res: any) => JSON.stringify(getHttpLogParams(tokens, req, res)),
@@ -140,9 +136,6 @@ export async function createApp(
         },
       }
     ))
-  } else if (loggerFormat !== 'none') {
-    logger.warn('[CONFIG] Using another format than "foal" for "settings.loggerFormat" is deprecated.');
-    app.use(morgan(loggerFormat));
   }
 
   app.use(protectionHeaders);

--- a/packages/examples/config/default.yml
+++ b/packages/examples/config/default.yml
@@ -3,7 +3,6 @@ port: 3001
 settings:
   openapi:
     useHooks: true
-  loggerFormat: foal
   session:
     secret: 'my secret'
   staticPath: 'public/'

--- a/packages/social/src/abstract-provider.service.spec.ts
+++ b/packages/social/src/abstract-provider.service.spec.ts
@@ -166,7 +166,7 @@ describe('AbstractProvider', () => {
     Config.set('settings.social.example.clientId', clientId);
     Config.set('settings.social.example.clientSecret', clientSecret);
     Config.set('settings.social.example.redirectUri', redirectUri);
-    Config.set('settings.loggerFormat', 'none');
+    Config.set('settings.logger.logHttpRequests', false);
 
     provider = createService(ConcreteProvider);
   });
@@ -175,6 +175,7 @@ describe('AbstractProvider', () => {
     Config.remove('settings.social.example.clientId');
     Config.remove('settings.social.example.clientSecret');
     Config.remove('settings.social.example.redirectUri');
+    Config.remove('settings.logger.logHttpRequests');
     Config.remove('settings.social.cookie.secure');
     Config.remove('settings.social.cookie.domain');
   });
@@ -734,7 +735,7 @@ describe('Abstract Provider With PKCE', () => {
     Config.set('settings.social.example.clientId', clientId);
     Config.set('settings.social.example.clientSecret', clientSecret);
     Config.set('settings.social.example.redirectUri', redirectUri);
-    Config.set('settings.loggerFormat', 'none');
+    Config.set('settings.logger.logHttpRequests', false);
 
     provider = createService(ConcreteProvider);
   });
@@ -743,6 +744,7 @@ describe('Abstract Provider With PKCE', () => {
     Config.remove('settings.social.example.clientId');
     Config.remove('settings.social.example.clientSecret');
     Config.remove('settings.social.example.redirectUri');
+    Config.remove('settings.logger.logHttpRequests');
     Config.remove('settings.social.cookie.secure');
     Config.remove('settings.social.cookie.domain');
   });
@@ -934,7 +936,7 @@ describe('Abstract Provider With PKCE and Plain Method', () => {
     Config.set('settings.social.example.clientId', clientId);
     Config.set('settings.social.example.clientSecret', clientSecret);
     Config.set('settings.social.example.redirectUri', redirectUri);
-    Config.set('settings.loggerFormat', 'none');
+    Config.set('settings.logger.logHttpRequests', false);
 
     provider = createService(ConcreteProvider);
   });
@@ -943,6 +945,7 @@ describe('Abstract Provider With PKCE and Plain Method', () => {
     Config.remove('settings.social.example.clientId');
     Config.remove('settings.social.example.clientSecret');
     Config.remove('settings.social.example.redirectUri');
+    Config.remove('settings.logger.logHttpRequests');
     Config.remove('settings.social.cookie.secure');
     Config.remove('settings.social.cookie.domain');
   });

--- a/packages/social/src/facebook-provider.service.spec.ts
+++ b/packages/social/src/facebook-provider.service.spec.ts
@@ -23,11 +23,11 @@ describe('FacebookProvider', () => {
 
     beforeEach(() => {
       provider = createService(FacebookProvider2);
-      Config.set('settings.loggerFormat', 'none');
+      Config.set('settings.logger.logHttpRequests', false);
     });
 
     afterEach(() => {
-      Config.remove('settings.loggerFormat');
+      Config.remove('settings.logger.logHttpRequests');
       if (server) {
         server.close();
       }

--- a/packages/social/src/github-provider.service.spec.ts
+++ b/packages/social/src/github-provider.service.spec.ts
@@ -23,11 +23,11 @@ describe('GithubProvider', () => {
 
     beforeEach(() => {
       provider = createService(GithubProvider2);
-      Config.set('settings.loggerFormat', 'none');
+      Config.set('settings.logger.logHttpRequests', false);
     });
 
     afterEach(() => {
-      Config.remove('settings.loggerFormat');
+      Config.remove('settings.logger.logHttpRequests');
       if (server) {
         server.close();
       }

--- a/packages/social/src/linkedin-provider.service.spec.ts
+++ b/packages/social/src/linkedin-provider.service.spec.ts
@@ -21,11 +21,11 @@ describe('LinkedInProvider', () => {
 
     beforeEach(() => {
       provider = createService(LinkedInProvider2);
-      Config.set('settings.loggerFormat', 'none');
+      Config.set('settings.logger.logHttpRequests', false);
     });
 
     afterEach(() => {
-      Config.remove('settings.loggerFormat');
+      Config.remove('settings.logger.logHttpRequests');
       if (server) {
         server.close();
       }

--- a/packages/social/src/twitter-provider.service.spec.ts
+++ b/packages/social/src/twitter-provider.service.spec.ts
@@ -23,11 +23,11 @@ describe('TwitterProvider', () => {
 
     beforeEach(() => {
       provider = createService(TwitterProvider2);
-      Config.set('settings.loggerFormat', 'none');
+      Config.set('settings.logger.logHttpRequests', false);
     });
 
     afterEach(() => {
-      Config.remove('settings.loggerFormat');
+      Config.remove('settings.logger.logHttpRequests');
       if (server) {
         server.close();
       }

--- a/packages/storage/src/parse-and-validate-files.hook.spec.ts
+++ b/packages/storage/src/parse-and-validate-files.hook.spec.ts
@@ -21,7 +21,7 @@ interface Actual {
 describe('ParseAndValidateFiles', () => {
 
   beforeEach(() => {
-    Config.set('settings.loggerFormat', 'none');
+    Config.set('settings.logger.logHttpRequests', false);
     Config.set('settings.disk.driver', 'local');
 
     Config.set('settings.disk.local.directory', 'uploaded');
@@ -31,7 +31,7 @@ describe('ParseAndValidateFiles', () => {
   });
 
   afterEach(() => {
-    Config.remove('settings.loggerFormat');
+    Config.remove('settings.logger.logHttpRequests');
     Config.remove('settings.disk.driver');
 
     Config.remove('settings.disk.local.directory');


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

- The use of `settings.loggerFormat` is deprecated. It should be removed in a major release.
- To support `loggerFormat: none` to disable HTTP logging, a new setting must be introduced with consistency with `settings.logger.logSocketioMessages`

# Solution and steps

- [x] Remove `settings.loggerFormat`.
- [x] Add `settings.logger.logHttpRequests`.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
