### PR TITLE
Remove deprecated `AbstractProvider.redirect` method

### DIFF
--- a/docs/blog/version-5.0-release-notes.md
+++ b/docs/blog/version-5.0-release-notes.md
@@ -74,3 +74,4 @@ Version 5.0 of [Foal](https://foalts.org/) is out!
 
 - The deprecated hook `@Log` has been removed. Use the `Logger` service in a custom `@Hook` instead.
 - The command alias `npx foal run-script` has been removed. Use `npx foal run` instead.
+- The deprecated method `AbstractProvider.redirect` has been removed. Use `AbstractProvider.createHttpResponseWithConsentPageUrl({ isRedirection: true })` instead.

--- a/packages/social/src/abstract-provider.service.ts
+++ b/packages/social/src/abstract-provider.service.ts
@@ -309,21 +309,6 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
   }
 
   /**
-   * Returns an HttpResponseRedirect object to redirect the user to the social provider's authorization page.
-   *
-   * This function is deprecated. Use createHttpResponseWithConsentPageUrl instead with isRedirection set to true.
-   *
-   * @param {{ scopes?: string[] }} [{ scopes }={}] - Custom scopes to override the default ones used by the provider.
-   * @param {AuthParameters} [params] - Additional parameters (specific to the social provider).
-   * @returns {Promise<HttpResponseRedirect>} The HttpResponseRedirect object.
-   * @memberof AbstractProvider
-   * @deprecated
-   */
-  async redirect({ scopes }: { scopes?: string[] } = {}, params?: AuthParameters): Promise<HttpResponseRedirect> {
-    return this.createHttpResponseWithConsentPageUrl({ scopes, isRedirection: true }, params) as Promise<HttpResponseRedirect>;
-  }
-
-  /**
    * Function to use in the controller method that handles the provider redirection.
    *
    * It returns an access token.


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

The `AbstractProvider.redirect` method is deprecated and should be removed in the next major version.

# Solution and steps

- [x] Remove the method

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
