### PR TITLE
Upgrade TypeORM peer dependency to v0.3.20

### DIFF
--- a/docs/blog/version-5.0-release-notes.md
+++ b/docs/blog/version-5.0-release-notes.md
@@ -30,6 +30,10 @@ Version 5.0 of [Foal](https://foalts.org/) is out!
 > }
 > ```
 
+## TypeORM upgrade
+
+- The minimum required version of TypeORM is v0.3.20.
+
 ## Better typing
 
 - The default type of `Context.state` is now `{}`. This way, you'll get a compilation error if you forget to specify a type for the state.

--- a/docs/docs/authentication/session-tokens.md
+++ b/docs/docs/authentication/session-tokens.md
@@ -71,7 +71,7 @@ module.exports = {
 #### TypeORMStore
 
 ```
-npm install typeorm@0.3.17 @foal/typeorm
+npm install typeorm@0.3.20 @foal/typeorm
 ```
 
 This store uses the default TypeORM connection whose configuration is usually specified in `config/default.{json|yml|js}`.

--- a/docs/docs/databases/typeorm/introduction.md
+++ b/docs/docs/databases/typeorm/introduction.md
@@ -59,7 +59,7 @@ When creating a new project, an `SQLite` database is used by default as it does 
 ### Packages
 
 ```
-npm install typeorm@0.3.17 @foal/typeorm
+npm install typeorm@0.3.20 @foal/typeorm
 ```
 
 Two packages are required to use TypeORM with FoalTS:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1001,6 +1001,7 @@
       "version": "7.24.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
       "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -6144,6 +6145,7 @@
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -6163,6 +6165,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.6",
@@ -7512,7 +7520,6 @@
       "version": "10.3.12",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.12.tgz",
       "integrity": "sha512-TCNv8vJ+xz4QiqTpfOJA7HvYv+tNIRHKfUWw/q+v2jdgN4ebz+KY9tGx5J4rHP0o84mNP+ApH66HRX8us3Khqg==",
-      "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.3.6",
@@ -7546,7 +7553,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -7555,7 +7561,6 @@
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
       "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -8593,7 +8598,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
       "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -11137,7 +11141,6 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.2.tgz",
       "integrity": "sha512-7xTavNy5RQXnsjANvVvMkEjvloOinkAjv/Z6Ildz9v2RinZ4SBKTWFOVRbaF8p0vpHnyjV/UwNDdKuUv6M5qcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -11153,7 +11156,6 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
       "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
-      "dev": true,
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -12096,7 +12098,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
     },
     "node_modules/replace-ext": {
       "version": "0.0.1",
@@ -14238,21 +14241,22 @@
       "dev": true
     },
     "node_modules/typeorm": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.17.tgz",
-      "integrity": "sha512-UDjUEwIQalO9tWw9O2A4GU+sT3oyoUXheHJy4ft+RFdnRdQctdQ34L9SqE2p7LdwzafHx1maxT+bqXON+Qnmig==",
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.20.tgz",
+      "integrity": "sha512-sJ0T08dV5eoZroaq9uPKBoNcGslHBR4E4y+EBHs//SiGbblGe7IeduP/IH4ddCcj0qp3PHwDwGnuvqEAnKlq/Q==",
+      "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
         "chalk": "^4.1.2",
         "cli-highlight": "^2.1.11",
-        "date-fns": "^2.29.3",
+        "dayjs": "^1.11.9",
         "debug": "^4.3.4",
         "dotenv": "^16.0.3",
-        "glob": "^8.1.0",
+        "glob": "^10.3.10",
         "mkdirp": "^2.1.3",
-        "reflect-metadata": "^0.1.13",
+        "reflect-metadata": "^0.2.1",
         "sha.js": "^2.4.11",
         "tslib": "^2.5.0",
         "uuid": "^9.0.0",
@@ -14264,7 +14268,7 @@
         "typeorm-ts-node-esm": "cli-ts-node-esm.js"
       },
       "engines": {
-        "node": ">= 12.9.0"
+        "node": ">=16.13.0"
       },
       "funding": {
         "url": "https://opencollective.com/typeorm"
@@ -14272,13 +14276,13 @@
       "peerDependencies": {
         "@google-cloud/spanner": "^5.18.0",
         "@sap/hana-client": "^2.12.25",
-        "better-sqlite3": "^7.1.2 || ^8.0.0",
+        "better-sqlite3": "^7.1.2 || ^8.0.0 || ^9.0.0",
         "hdb-pool": "^0.1.6",
         "ioredis": "^5.0.4",
-        "mongodb": "^5.2.0",
-        "mssql": "^9.1.1",
+        "mongodb": "^5.8.0",
+        "mssql": "^9.1.1 || ^10.0.1",
         "mysql2": "^2.2.5 || ^3.0.1",
-        "oracledb": "^5.1.0",
+        "oracledb": "^6.3.0",
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
         "pg-query-stream": "^4.0.0",
@@ -14342,14 +14346,6 @@
         }
       }
     },
-    "node_modules/typeorm/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/typeorm/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -14388,35 +14384,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/typeorm/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/typeorm/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/typeorm/node_modules/mkdirp": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
@@ -14430,11 +14397,6 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/typeorm/node_modules/reflect-metadata": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
-      "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A=="
     },
     "node_modules/typeorm/node_modules/yargs": {
       "version": "17.7.2",
@@ -15210,7 +15172,7 @@
         "sqlite3": "~5.1.7",
         "superagent": "~9.0.1",
         "supertest": "~7.0.0",
-        "typeorm": "0.3.17",
+        "typeorm": "0.3.20",
         "yamljs": "~0.3.0"
       },
       "devDependencies": {
@@ -15391,7 +15353,7 @@
         "graphql": "~16.9.0",
         "source-map-support": "~0.5.21",
         "sqlite3": "~5.1.7",
-        "typeorm": "0.3.17",
+        "typeorm": "0.3.20",
         "yamljs": "~0.3.0"
       },
       "devDependencies": {
@@ -16100,7 +16062,7 @@
         "rimraf": "~5.0.5",
         "sqlite3": "~5.1.7",
         "ts-node": "~10.9.2",
-        "typeorm": "0.3.17",
+        "typeorm": "0.3.20",
         "typescript": "~5.5.4"
       },
       "engines": {
@@ -16110,7 +16072,7 @@
         "url": "https://github.com/sponsors/LoicPoullain"
       },
       "peerDependencies": {
-        "typeorm": "^0.3.17"
+        "typeorm": "^0.3.20"
       }
     },
     "packages/typeorm/node_modules/rimraf": {

--- a/packages/acceptance-tests/package.json
+++ b/packages/acceptance-tests/package.json
@@ -43,7 +43,7 @@
     "sqlite3": "~5.1.7",
     "superagent": "~9.0.1",
     "supertest": "~7.0.0",
-    "typeorm": "0.3.17",
+    "typeorm": "0.3.20",
     "yamljs": "~0.3.0"
   },
   "devDependencies": {

--- a/packages/cli/src/generate/specs/app/package.json
+++ b/packages/cli/src/generate/specs/app/package.json
@@ -28,7 +28,7 @@
     "@foal/typeorm": "^4.0.0",
     "source-map-support": "~0.5.21",
     "sqlite3": "~5.1.7",
-    "typeorm": "0.3.17"
+    "typeorm": "0.3.20"
   },
   "devDependencies": {
     "@foal/cli": "^4.0.0",

--- a/packages/cli/src/generate/specs/app/package.mongodb.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.json
@@ -24,7 +24,7 @@
     "@foal/core": "^4.0.0",
     "mongodb": "~5.9.2",
     "source-map-support": "~0.5.21",
-    "typeorm": "0.3.17"
+    "typeorm": "0.3.20"
   },
   "devDependencies": {
     "@foal/cli": "^4.0.0",

--- a/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.mongodb.yaml.json
@@ -24,7 +24,7 @@
     "@foal/core": "^4.0.0",
     "mongodb": "~5.9.2",
     "source-map-support": "~0.5.21",
-    "typeorm": "0.3.17",
+    "typeorm": "0.3.20",
     "yamljs": "~0.3.0"
   },
   "devDependencies": {

--- a/packages/cli/src/generate/specs/app/package.yaml.json
+++ b/packages/cli/src/generate/specs/app/package.yaml.json
@@ -28,7 +28,7 @@
     "@foal/typeorm": "^4.0.0",
     "source-map-support": "~0.5.21",
     "sqlite3": "~5.1.7",
-    "typeorm": "0.3.17",
+    "typeorm": "0.3.20",
     "yamljs": "~0.3.0"
   },
   "devDependencies": {

--- a/packages/cli/src/generate/templates/app/package.json
+++ b/packages/cli/src/generate/templates/app/package.json
@@ -28,7 +28,7 @@
     "@foal/typeorm": "^4.0.0",
     "source-map-support": "~0.5.21",
     "sqlite3": "~5.1.7",
-    "typeorm": "0.3.17"
+    "typeorm": "0.3.20"
   },
   "devDependencies": {
     "@foal/cli": "^4.0.0",

--- a/packages/cli/src/generate/templates/app/package.mongodb.json
+++ b/packages/cli/src/generate/templates/app/package.mongodb.json
@@ -24,7 +24,7 @@
     "@foal/core": "^4.0.0",
     "mongodb": "~5.9.2",
     "source-map-support": "~0.5.21",
-    "typeorm": "0.3.17"
+    "typeorm": "0.3.20"
   },
   "devDependencies": {
     "@foal/cli": "^4.0.0",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -55,7 +55,7 @@
     "graphql": "~16.9.0",
     "source-map-support": "~0.5.21",
     "sqlite3": "~5.1.7",
-    "typeorm": "0.3.17",
+    "typeorm": "0.3.20",
     "yamljs": "~0.3.0"
   },
   "devDependencies": {

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -50,7 +50,7 @@
     "@foal/core": "^4.5.0"
   },
   "peerDependencies": {
-    "typeorm": "^0.3.17"
+    "typeorm": "^0.3.20"
   },
   "devDependencies": {
     "@types/mocha": "10.0.7",
@@ -61,7 +61,7 @@
     "rimraf": "~5.0.5",
     "sqlite3": "~5.1.7",
     "ts-node": "~10.9.2",
-    "typeorm": "0.3.17",
+    "typeorm": "0.3.20",
     "typescript": "~5.5.4"
   }
 }


### PR DESCRIPTION
# Issue

TypeORM needs to be upgraded to latest version in v5.

# Solution and steps

- [x] Upgrade to TypeORM v0.3.20

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
