### PR TITLE
Improve logging in shell scripts

### DIFF
--- a/docs/blog/version-5.0-release-notes.md
+++ b/docs/blog/version-5.0-release-notes.md
@@ -82,7 +82,10 @@ Version 5.0 of [Foal](https://foalts.org/) is out!
       // ...
     }
     ```
-
+- Log context are supported.
+- When running a script, the script name as well as a script ID are added to the log context.
+- At the end of script execution, as with an HTTP request, a log is printed to indicate whether the execution was successful or unsuccessful.
+- Any error thrown in the `main` function is now logged with the framework logger.
 
 ## Removal of deprecated components
 

--- a/docs/blog/version-5.0-release-notes.md
+++ b/docs/blog/version-5.0-release-notes.md
@@ -76,9 +76,9 @@ Version 5.0 of [Foal](https://foalts.org/) is out!
 
 ## Shell scripts
 
-- The `main` function of shell scripts now receives an instance of `ServiceManager` as second argument:
+- The `main` function of shell scripts now receives an instance of `ServiceManager` as second argument and the logger as third argument:
     ```typescript
-    export async function main(args: any, services: ServiceManager) {
+    export async function main(args: any, services: ServiceManager, logger: Logger) {
       // ...
     }
     ```

--- a/docs/docs/authentication/user-class.md
+++ b/docs/docs/authentication/user-class.md
@@ -120,8 +120,6 @@ export async function main(args) {
     user.password = await hashPassword(args.password);
 
     console.log(await user.save());
-  } catch (error: any) {
-    console.error(error.message);
   } finally {
     await dataSource.destroy();
   }

--- a/docs/docs/authentication/user-class.md
+++ b/docs/docs/authentication/user-class.md
@@ -95,7 +95,7 @@ Go to `src/scripts/create-user.ts` and replace its content with the following li
 
 ```typescript
 // 3p
-import { hashPassword } from '@foal/core';
+import { hashPassword, Logger, ServiceManager } from '@foal/core';
 
 // App
 import { User } from '../app/entities';
@@ -111,7 +111,7 @@ export const schema = {
   type: 'object',
 };
 
-export async function main(args) {
+export async function main(args: any, services: ServiceManager, logger: Logger) {
   await dataSource.initialize();
 
   try {
@@ -119,7 +119,9 @@ export async function main(args) {
     user.email = args.email;
     user.password = await hashPassword(args.password);
 
-    console.log(await user.save());
+    await user.save();
+
+    logger.info(`User created: ${user.id}`)
   } finally {
     await dataSource.destroy();
   }

--- a/docs/docs/authorization/groups-and-permissions.md
+++ b/docs/docs/authorization/groups-and-permissions.md
@@ -73,8 +73,6 @@ export async function main(args: { codeName: string, name: string }) {
     console.log(
       await permission.save()
     );
-  } catch (error: any) {
-    console.log(error.message);
   } finally {
     await dataSource.destroy();
   }
@@ -168,8 +166,6 @@ export async function main(args: { codeName: string, name: string, permissions: 
     console.log(
       await group.save()
     );
-  } catch (error: any) {
-    console.log(error.message);
   } finally {
     await dataSource.destroy();
   }
@@ -277,8 +273,6 @@ export async function main(args) {
     console.log(
       await user.save()
     );
-  } catch (error: any) {
-    console.log(error.message);
   } finally {
     await dataSource.destroy();
   }

--- a/docs/docs/authorization/groups-and-permissions.md
+++ b/docs/docs/authorization/groups-and-permissions.md
@@ -47,6 +47,7 @@ npx foal generate script create-perm
 Replace the content of the new created file `src/scripts/create-perm.ts` with the following:
 ```typescript
 // 3p
+import { Logger, ServiceManager } from '@foal/core';
 import { Permission } from '@foal/typeorm';
 
 // App
@@ -62,7 +63,7 @@ export const schema = {
   type: 'object',
 };
 
-export async function main(args: { codeName: string, name: string }) {
+export async function main(args: { codeName: string, name: string }, services: ServiceManager, logger: Logger) {
   const permission = new Permission();
   permission.codeName = args.codeName;
   permission.name = args.name;
@@ -70,9 +71,9 @@ export async function main(args: { codeName: string, name: string }) {
   await dataSource.initialize();
 
   try {
-    console.log(
-      await permission.save()
-    );
+    await permission.save();
+
+    logger.info(`Permission created: ${permission.codeName}`);
   } finally {
     await dataSource.destroy();
   }
@@ -129,6 +130,7 @@ npx foal generate script create-group
 Replace the content of the new created file `src/scripts/create-group.ts` with the following:
 ```typescript
 // 3p
+import { Logger, ServiceManager } from '@foal/core';
 import { Group, Permission } from '@foal/typeorm';
 
 // App
@@ -145,7 +147,7 @@ export const schema = {
   type: 'object',
 };
 
-export async function main(args: { codeName: string, name: string, permissions: string[] }) {
+export async function main(args: { codeName: string, name: string, permissions: string[] }, services: ServiceManager, logger: Logger) {
   const group = new Group();
   group.permissions = [];
   group.codeName = args.codeName;
@@ -157,15 +159,14 @@ export async function main(args: { codeName: string, name: string, permissions: 
     for (const codeName of args.permissions) {
       const permission = await Permission.findOneBy({ codeName });
       if (!permission) {
-        console.log(`No permission with the code name "${codeName}" was found.`);
-        return;
+        throw new Error(`No permission with the code name "${codeName}" was found.`);
       }
       group.permissions.push(permission);
     }
 
-    console.log(
-      await group.save()
-    );
+    await group.save();
+
+    logger.info(`Group created: ${group.codeName}`);
   } finally {
     await dataSource.destroy();
   }
@@ -223,7 +224,7 @@ Replace the content of the new created file `src/scripts/create-user.ts` with th
 
 ```typescript
 // 3p
-import { hashPassword } from '@foal/core';
+import { hashPassword, Logger, ServiceManager } from '@foal/core';
 import { Group, Permission } from '@foal/typeorm';
 
 // App
@@ -242,7 +243,7 @@ export const schema = {
   type: 'object',
 };
 
-export async function main(args) {
+export async function main(args: any, services: ServiceManager, logger: Logger) {
   const user = new User();
   user.userPermissions = [];
   user.groups = [];
@@ -254,8 +255,7 @@ export async function main(args) {
   for (const codeName of args.userPermissions as string[]) {
     const permission = await Permission.findOneBy({ codeName });
     if (!permission) {
-      console.log(`No permission with the code name "${codeName}" was found.`);
-      return;
+      throw new Error(`No permission with the code name "${codeName}" was found.`);
     }
     user.userPermissions.push(permission);
   }
@@ -263,16 +263,15 @@ export async function main(args) {
   for (const codeName of args.groups as string[]) {
     const group = await Group.findOneBy({ codeName });
     if (!group) {
-      console.log(`No group with the code name "${codeName}" was found.`);
-      return;
+      throw new Error(`No group with the code name "${codeName}" was found.`);
     }
     user.groups.push(group);
   }
 
   try {
-    console.log(
-      await user.save()
-    );
+    await user.save();
+
+    logger.info(`User created: ${user.id}`);
   } finally {
     await dataSource.destroy();
   }

--- a/docs/docs/cli/shell-scripts.md
+++ b/docs/docs/cli/shell-scripts.md
@@ -17,20 +17,19 @@ Remove the content of `src/scripts/display-users.ts` and replace it with the cod
 
 ```typescript
 // 3p
-import { ServiceManager } from '@foal/core';
+import { Logger, ServiceManager } from '@foal/core';
 
 // App
 import { dataSource } from '../db';
 import { User } from '../app/entities';
-import { Logger } from '../app/services';
 
-export async function main(args: any, services: ServiceManager) {
+export async function main(args: any, services: ServiceManager, logger: Logger) {
   await dataSource.initialize();
 
   try {
     const users = await User.find();
-    const logger = services.get(Logger);
-    logger.log(users);
+
+    logger.info(`Users: ${JSON.stringify(users, null, 2)}`);
   } finally {
     dataSource.destroy();
   }

--- a/docs/docs/cli/shell-scripts.md
+++ b/docs/docs/cli/shell-scripts.md
@@ -86,7 +86,7 @@ export function main(args: any, services: ServiceManager) {
 
 ## Logging
 
-When a script is executed, a script ID is created and added to the log context. Like the request ID in an HTTP request, the script ID is added as a parameter to every log printed during script execution, including any errors. In this way, it is possible to aggregate all logs from a single script execution in a logging program.
+When a script is executed, the script name as well as a script ID are added to the log context. Like the request ID in an HTTP request, the script ID is added as a parameter to every log printed during script execution, including any errors. In this way, it is possible to aggregate all logs from a single script execution in a logging program.
 
 If you wish to access the logger in the script, it is passed as the third argument to the main function.
 

--- a/docs/docs/cli/shell-scripts.md
+++ b/docs/docs/cli/shell-scripts.md
@@ -11,7 +11,7 @@ A shell script file is divided into two parts: a `main` function, which contains
 *Example: src/scripts/create-user.ts*
 ```typescript
 // 3p
-import { Logger, ServiceManager } from '@foal/core';
+import { ServiceManager } from '@foal/core';
 
 // App
 import { dataSource } from '../db';

--- a/docs/docs/cli/shell-scripts.md
+++ b/docs/docs/cli/shell-scripts.md
@@ -2,19 +2,13 @@
 title: Shell Scripts
 ---
 
+Shell scripts are an easy way of executing a piece of code from the command line. They can be used in a variety of scenarios and can be a simple code snippet or be more complex and call application services.
 
-Sometimes we have to execute some tasks from the command line. These tasks can serve different purposes such as populating a database (user creation, etc) for instance. They often need to access some of the app classes and functions. This is when shell scripts come into play.
+## Structure
 
-## Create Scripts
+A shell script file is divided into two parts: a `main` function, which contains the code to be executed, and a `schema`, which parses and validates the arguments given on the command line and passes them on to the `main` function. The file must be located in the `src/scripts` directory.
 
-A shell script is just a TypeScript file located in the `src/scripts`. It must export a `main` function that is then called when running the script.
-
-Let's create a new one with the command line: `npx foal g script display-users`. A new file with a default template should appear in you `src/scripts` directory.
-
-## Write Scripts
-
-Remove the content of `src/scripts/display-users.ts` and replace it with the code below.
-
+*Example: src/scripts/create-user.ts*
 ```typescript
 // 3p
 import { Logger, ServiceManager } from '@foal/core';
@@ -23,13 +17,23 @@ import { Logger, ServiceManager } from '@foal/core';
 import { dataSource } from '../db';
 import { User } from '../app/entities';
 
-export async function main(args: any, services: ServiceManager, logger: Logger) {
+export const schema = {
+  type: 'object',
+  properties: {
+    email: { type: 'string' },
+  },
+  required: ['email'],
+  additionalProperties: false
+}
+
+export async function main(args: { email: string }) {
   await dataSource.initialize();
 
   try {
-    const users = await User.find();
+    const user = new User();
+    user.email = args.email;
 
-    logger.info(`Users: ${JSON.stringify(users, null, 2)}`);
+    await user.save();
   } finally {
     dataSource.destroy();
   }
@@ -37,26 +41,60 @@ export async function main(args: any, services: ServiceManager, logger: Logger) 
 
 ```
 
-As you can see, we can easily establish a connection to the database in the script as well as import some of the app components (the `User` in this case).
+## Generating, Building and Running Shell Scripts
 
-Encapsulating your code in a `main` function without calling it directly in the file has several benefits:
-- You can import and test your `main` function in a separate file.
-- Using a function lets you easily use async/await keywords when dealing with asynchronous code.
+To generate a new script, you can use the CLI `generate` command:
 
-## Build and Run Scripts
+```bash
+npx foal generate script create-user
+# or
+npx foal g script create-user
+```
 
-To run a script you first need to build it.
-
-```sh
+If you need to build the script once, run this command:
+```bash
 npm run build
 ```
 
-Then you can execute it with this command:
-
-```shell
-npx foal run my-script
+If you need to build and watch it in dev mode, use this command:
+```bash
+npm run dev
 ```
 
-> You can also provide additionnal arguments to your script (for example: `npx foal run my-script foo=1 bar='[ 3, 4 ]'`). The default template in the generated scripts shows you how to handle such behavior.
+Then you can run the script as follows:
+```bash
+npx foal run create-user email=foo@foalts.org
+```
 
-> If you want your script to recompile each time you save the file, you can run `npm run dev` in a separate terminal.
+## Accessing Services
+
+If you wish to access a service, you can use the `ServiceManager` instance passed as second argument to the `main` function.
+
+Example
+
+```typescript
+import { ServiceManager } from '@foal/core';
+
+import { MyService } from '../app/services';
+
+export function main(args: any, services: ServiceManager) {
+  const myService = services.get(MyService);
+
+  // Do something with myService.
+}
+```
+
+## Logging
+
+When a script is executed, a script ID is created and added to the log context. Like the request ID in an HTTP request, the script ID is added as a parameter to every log printed during script execution, including any errors. In this way, it is possible to aggregate all logs from a single script execution in a logging program.
+
+If you wish to access the logger in the script, it is passed as the third argument to the main function.
+
+```typescript
+import { Logger, ServiceManager } from '@foal/core';
+
+
+export function main(args: any, services: ServiceManager, logger: Logger) {
+  logger.info('Hello world!');
+}
+```

--- a/docs/docs/common/async-tasks.md
+++ b/docs/docs/common/async-tasks.md
@@ -48,11 +48,12 @@ export function main(args: any) {
 *scripts/schedule-jobs.ts*
 ```typescript
 // 3p
+import { Logger, ServiceManager } from '@foal/core';
 import { scheduleJob } from 'node-schedule';
 import { main as fetchMetrics } from './fetch-metrics';
 
-export async function main(args: any) {
-  console.log('Scheduling the job...');
+export async function main(args: any, services: ServiceManager, logger: Logger) {
+  logger.info('Scheduling the job...');
 
   // Run the fetch-metrics script every day at 10:00 AM.
   scheduleJob(
@@ -60,7 +61,7 @@ export async function main(args: any) {
     () => fetchMetrics(args)
   );
 
-  console.log('Job scheduled!');
+  logger.info('Job scheduled!');
 }
 
 ```

--- a/docs/docs/tutorials/real-world-example-with-react/4-the-shell-scripts.md
+++ b/docs/docs/tutorials/real-world-example-with-react/4-the-shell-scripts.md
@@ -42,8 +42,6 @@ export async function main(args: { email: string, password: string, name?: strin
 
   try {
     console.log(await user.save());
-  } catch (error: any) {
-    console.log(error.message);
   } finally {
     await dataSource.destroy();
   }
@@ -113,8 +111,6 @@ export async function main(args: { author: string, title: string, link: string }
 
   try {
     console.log(await story.save());
-  } catch (error: any) {
-    console.error(error);
   } finally {
     await dataSource.destroy();
   }

--- a/docs/docs/tutorials/real-world-example-with-react/4-the-shell-scripts.md
+++ b/docs/docs/tutorials/real-world-example-with-react/4-the-shell-scripts.md
@@ -14,7 +14,7 @@ Open the file and replace its content with the following:
 
 ```typescript
 // 3p
-import { hashPassword } from '@foal/core';
+import { hashPassword, Logger, ServiceManager } from '@foal/core';
 
 // App
 import { User } from '../app/entities';
@@ -31,7 +31,7 @@ export const schema = {
   type: 'object',
 };
 
-export async function main(args: { email: string, password: string, name?: string }) {
+export async function main(args: { email: string, password: string, name?: string }, services: ServiceManager, logger: Logger) {
   const user = new User();
   user.email = args.email;
   user.password = await hashPassword(args.password);
@@ -41,7 +41,9 @@ export async function main(args: { email: string, password: string, name?: strin
   await dataSource.initialize();
 
   try {
-    console.log(await user.save());
+    await user.save();
+
+    logger.info(`User created: ${user.id}`);
   } finally {
     await dataSource.destroy();
   }
@@ -85,6 +87,7 @@ npx foal generate script create-story
 Open the `create-story.ts` file and replace its content.
 
 ```typescript
+import { Logger, ServiceManager } from '@foal/core';
 import { Story, User } from '../app/entities';
 import { dataSource } from '../db';
 
@@ -99,7 +102,7 @@ export const schema = {
   type: 'object',
 };
 
-export async function main(args: { author: string, title: string, link: string }) {
+export async function main(args: { author: string, title: string, link: string }, services: ServiceManager, logger: Logger) {
   await dataSource.initialize();
 
   const user = await User.findOneByOrFail({ email: args.author });
@@ -110,7 +113,9 @@ export async function main(args: { author: string, title: string, link: string }
   story.link = args.link;
 
   try {
-    console.log(await story.save());
+    await store.save();
+
+    logger.info(`Story created: ${story.id}`);
   } finally {
     await dataSource.destroy();
   }

--- a/docs/docs/tutorials/simple-todo-list/4-the-shell-script-create-todo.md
+++ b/docs/docs/tutorials/simple-todo-list/4-the-shell-script-create-todo.md
@@ -22,6 +22,9 @@ A *shell script* is a piece of code intended to be called from the command line.
 Open the new generated file in the `src/scripts` directory and update its content.
 
 ```typescript
+// 3p
+import { Logger, ServiceManager } from '@foal/core';
+
 // App
 import { Todo } from '../app/entities';
 import { dataSource } from '../db';
@@ -34,7 +37,7 @@ export const schema = {
   type: 'object',
 };
 
-export async function main(args: { text: string }) {
+export async function main(args: { text: string }, services: ServiceManager, logger: Logger) {
   // Connect to the database.
   await dataSource.initialize();
 
@@ -44,7 +47,9 @@ export async function main(args: { text: string }) {
     todo.text = args.text;
 
     // Save the task in the database and then display it in the console.
-    console.log(await todo.save());
+    await todo.save();
+
+    logger.info(`Todo created: ${JSON.stringify(todo, null, 2)}`);
   } finally {
     // Close the connection to the database.
     await dataSource.destroy();

--- a/docs/docs/tutorials/simple-todo-list/4-the-shell-script-create-todo.md
+++ b/docs/docs/tutorials/simple-todo-list/4-the-shell-script-create-todo.md
@@ -45,8 +45,6 @@ export async function main(args: { text: string }) {
 
     // Save the task in the database and then display it in the console.
     console.log(await todo.save());
-  } catch (error: any) {
-    console.log(error.message);
   } finally {
     // Close the connection to the database.
     await dataSource.destroy();

--- a/packages/acceptance-tests/src/additional/shell-scripts/create-group.spec.ts
+++ b/packages/acceptance-tests/src/additional/shell-scripts/create-group.spec.ts
@@ -8,6 +8,7 @@ import Ajv from 'ajv';
 import { Group, Permission } from '@foal/typeorm';
 import { main as createGroup, schema } from './create-group';
 import { createAndInitializeDataSource } from '../../common';
+import { Logger, ServiceManager } from '@foal/core';
 
 describe('[Shell scripts] create-perm', () => {
 
@@ -35,7 +36,10 @@ describe('[Shell scripts] create-perm', () => {
       });
     }
 
-    await createGroup(args);
+    const services = new ServiceManager();
+    const logger = services.get(Logger);
+
+    await createGroup(args, services, logger);
 
     const dataSource = await createAndInitializeDataSource([ Permission, Group ], { dropSchema: false });
 

--- a/packages/acceptance-tests/src/additional/shell-scripts/create-group.ts
+++ b/packages/acceptance-tests/src/additional/shell-scripts/create-group.ts
@@ -34,8 +34,6 @@ export async function main(args: { codeName: string, name: string, permissions: 
     console.log(
       await group.save()
     );
-  } catch (error: any) {
-    console.log(error.message);
   } finally {
     await dataSource.destroy();
   }

--- a/packages/acceptance-tests/src/additional/shell-scripts/create-group.ts
+++ b/packages/acceptance-tests/src/additional/shell-scripts/create-group.ts
@@ -1,6 +1,7 @@
 // 3p
 import { Group, Permission } from '@foal/typeorm';
 import { createAndInitializeDataSource } from '../../common';
+import { Logger, ServiceManager } from '@foal/core';
 
 export const schema = {
   additionalProperties: false,
@@ -13,7 +14,7 @@ export const schema = {
   type: 'object',
 };
 
-export async function main(args: { codeName: string, name: string, permissions: string[] }) {
+export async function main(args: { codeName: string, name: string, permissions: string[] }, services: ServiceManager, logger: Logger) {
   const group = new Group();
   group.permissions = [];
   group.codeName = args.codeName;
@@ -25,15 +26,14 @@ export async function main(args: { codeName: string, name: string, permissions: 
     for (const codeName of args.permissions) {
       const permission = await Permission.findOneBy({ codeName });
       if (!permission) {
-        console.log(`No permission with the code name "${codeName}" was found.`);
-        return;
+        throw new Error(`No permission with the code name "${codeName}" was found.`);
       }
       group.permissions.push(permission);
     }
 
-    console.log(
-      await group.save()
-    );
+    await group.save();
+
+    logger.info(`Group created: ${group.codeName}`);
   } finally {
     await dataSource.destroy();
   }

--- a/packages/acceptance-tests/src/additional/shell-scripts/create-perm.spec.ts
+++ b/packages/acceptance-tests/src/additional/shell-scripts/create-perm.spec.ts
@@ -5,6 +5,7 @@ import Ajv from 'ajv';
 import { Permission } from '@foal/typeorm';
 import { main as createPerm, schema } from './create-perm';
 import { createAndInitializeDataSource } from '../../common';
+import { Logger, ServiceManager } from '@foal/core';
 
 describe('[Shell scripts] create-perm', () => {
 
@@ -28,7 +29,10 @@ describe('[Shell scripts] create-perm', () => {
       });
     }
 
-    await createPerm(args);
+    const services = new ServiceManager();
+    const logger = services.get(Logger);
+
+    await createPerm(args, services, logger);
 
     const dataSource = await createAndInitializeDataSource([ Permission ], { dropSchema: false });
 

--- a/packages/acceptance-tests/src/additional/shell-scripts/create-perm.ts
+++ b/packages/acceptance-tests/src/additional/shell-scripts/create-perm.ts
@@ -23,8 +23,6 @@ export async function main(args: { codeName: string, name: string }) {
     console.log(
       await permission.save()
     );
-  } catch (error: any) {
-    console.log(error.message);
   } finally {
     await dataSource.destroy();
   }

--- a/packages/acceptance-tests/src/additional/shell-scripts/create-perm.ts
+++ b/packages/acceptance-tests/src/additional/shell-scripts/create-perm.ts
@@ -1,6 +1,7 @@
 // 3p
 import { Permission } from '@foal/typeorm';
 import { createAndInitializeDataSource } from '../../common';
+import { Logger, ServiceManager } from '@foal/core';
 
 export const schema = {
   additionalProperties: false,
@@ -12,7 +13,7 @@ export const schema = {
   type: 'object',
 };
 
-export async function main(args: { codeName: string, name: string }) {
+export async function main(args: { codeName: string, name: string }, services: ServiceManager, logger: Logger) {
   const permission = new Permission();
   permission.codeName = args.codeName;
   permission.name = args.name;
@@ -20,9 +21,9 @@ export async function main(args: { codeName: string, name: string }) {
   const dataSource = await createAndInitializeDataSource([ Permission ], { dropSchema: false });
 
   try {
-    console.log(
-      await permission.save()
-    );
+    await permission.save();
+
+    logger.info(`Permission created: ${permission.codeName}`);
   } finally {
     await dataSource.destroy();
   }

--- a/packages/cli/src/generate/specs/app/src/scripts/create-user.ts
+++ b/packages/cli/src/generate/specs/app/src/scripts/create-user.ts
@@ -20,8 +20,6 @@ export async function main() {
     const user = new User();
 
     console.log(await user.save());
-  } catch (error: any) {
-    console.error(error.message);
   } finally {
     await dataSource.destroy();
   }

--- a/packages/cli/src/generate/specs/app/src/scripts/create-user.ts
+++ b/packages/cli/src/generate/specs/app/src/scripts/create-user.ts
@@ -1,3 +1,6 @@
+// 3p
+import { Logger, ServiceManager } from '@foal/core';
+
 // App
 import { User } from '../app/entities';
 import { dataSource } from '../db';
@@ -13,13 +16,15 @@ export const schema = {
   type: 'object',
 };
 
-export async function main() {
+export async function main(args: any, services: ServiceManager, logger: Logger) {
   await dataSource.initialize();
 
   try {
     const user = new User();
 
-    console.log(await user.save());
+    await user.save();
+
+    logger.info(`User created: ${user.id}`);
   } finally {
     await dataSource.destroy();
   }

--- a/packages/cli/src/generate/specs/script/test-foo-bar.ts
+++ b/packages/cli/src/generate/specs/script/test-foo-bar.ts
@@ -1,4 +1,4 @@
-import { ServiceManager } from '@foal/core';
+import { Logger, ServiceManager } from '@foal/core';
 
 export const schema = {
   additionalProperties: false,
@@ -11,6 +11,6 @@ export const schema = {
   type: 'object',
 };
 
-export async function main(args: any, services: ServiceManager) {
+export async function main(args: any, services: ServiceManager, logger: Logger) {
 
 }

--- a/packages/cli/src/generate/templates/app/src/scripts/create-user.ts
+++ b/packages/cli/src/generate/templates/app/src/scripts/create-user.ts
@@ -20,8 +20,6 @@ export async function main() {
     const user = new User();
 
     console.log(await user.save());
-  } catch (error: any) {
-    console.error(error.message);
   } finally {
     await dataSource.destroy();
   }

--- a/packages/cli/src/generate/templates/app/src/scripts/create-user.ts
+++ b/packages/cli/src/generate/templates/app/src/scripts/create-user.ts
@@ -1,3 +1,6 @@
+// 3p
+import { Logger, ServiceManager } from '@foal/core';
+
 // App
 import { User } from '../app/entities';
 import { dataSource } from '../db';
@@ -13,13 +16,15 @@ export const schema = {
   type: 'object',
 };
 
-export async function main() {
+export async function main(args: any, services: ServiceManager, logger: Logger) {
   await dataSource.initialize();
 
   try {
     const user = new User();
 
-    console.log(await user.save());
+    await user.save();
+
+    logger.info(`User created: ${user.id}`);
   } finally {
     await dataSource.destroy();
   }

--- a/packages/cli/src/generate/templates/script/script.ts
+++ b/packages/cli/src/generate/templates/script/script.ts
@@ -1,4 +1,4 @@
-import { ServiceManager } from '@foal/core';
+import { Logger, ServiceManager } from '@foal/core';
 
 export const schema = {
   additionalProperties: false,
@@ -11,6 +11,6 @@ export const schema = {
   type: 'object',
 };
 
-export async function main(args: any, services: ServiceManager) {
+export async function main(args: any, services: ServiceManager, logger: Logger) {
 
 }

--- a/packages/cli/src/run/run-script.spec.ts
+++ b/packages/cli/src/run/run-script.spec.ts
@@ -223,6 +223,38 @@ describe('execScript', () => {
     });
   });
 
+  it('should call the "main" function of build/scripts/my-script.js with a logger.', async () => {
+    mkdirIfDoesNotExist('build/scripts');
+    const scriptContent = `const { writeFileSync } = require('fs');
+    const { Logger } = require('@foal/core');
+    module.exports.main = function main(args, services, logger) {
+      const isLogger = logger instanceof Logger;
+      writeFileSync('my-script-temp', JSON.stringify({
+        isLogger
+      }), 'utf8');
+    }`;
+    writeFileSync('build/scripts/my-script.js', scriptContent, 'utf8');
+
+    delete require.cache[join(process.cwd(), `./build/scripts/my-script.js`)];
+
+    await execScript({ name: 'my-script' }, [
+      '/Users/loicpoullain/.nvm/versions/node/v8.11.3/bin/node',
+      '/Users/loicpoullain/.nvm/versions/node/v8.11.3/bin/foal',
+      'run',
+      'my-script',
+      'foo=bar',
+    ], services, logger);
+
+    if (!existsSync('my-script-temp')) {
+      throw new Error('The script was not executed');
+    }
+    const actual = JSON.parse(readFileSync('my-script-temp', 'utf8'));
+
+    deepStrictEqual(actual, {
+      isLogger: true,
+    });
+  });
+
   it('should catch and log errors thrown in the "main" function.', async () => {
     mkdirIfDoesNotExist('build/scripts');
     const scriptContent = `const { writeFileSync } = require('fs');
@@ -289,9 +321,9 @@ describe('execScript', () => {
       const scriptContent = `const { writeFileSync } = require('fs');
       module.exports.main = function main(args) {}`;
       writeFileSync('build/scripts/my-script.js', scriptContent, 'utf8');
-  
+
       delete require.cache[join(process.cwd(), `./build/scripts/my-script.js`)];
-  
+
       await execScript({ name: 'my-script' }, [
         '/Users/loicpoullain/.nvm/versions/node/v8.11.3/bin/node',
         '/Users/loicpoullain/.nvm/versions/node/v8.11.3/bin/foal',
@@ -312,9 +344,9 @@ describe('execScript', () => {
       const scriptContent = `const { writeFileSync } = require('fs');
       module.exports.main = function main(args) {}`;
       writeFileSync('build/scripts/my-script.js', scriptContent, 'utf8');
-  
+
       delete require.cache[join(process.cwd(), `./build/scripts/my-script.js`)];
-  
+
       await execScript({ name: 'my-script' }, [
         '/Users/loicpoullain/.nvm/versions/node/v8.11.3/bin/node',
         '/Users/loicpoullain/.nvm/versions/node/v8.11.3/bin/foal',
@@ -334,9 +366,9 @@ describe('execScript', () => {
         throw new Error('Hello world');
       }`;
       writeFileSync('build/scripts/my-script.js', scriptContent, 'utf8');
-  
+
       delete require.cache[join(process.cwd(), `./build/scripts/my-script.js`)];
-  
+
       await execScript({ name: 'my-script' }, [
         '/Users/loicpoullain/.nvm/versions/node/v8.11.3/bin/node',
         '/Users/loicpoullain/.nvm/versions/node/v8.11.3/bin/foal',

--- a/packages/cli/src/run/run-script.ts
+++ b/packages/cli/src/run/run-script.ts
@@ -1,5 +1,6 @@
 // std
 import { existsSync } from 'fs';
+import { randomUUID } from 'crypto';
 
 // 3p
 import Ajv from 'ajv';
@@ -31,6 +32,11 @@ export async function runScript({ name }: { name: string }, argv: string[]) {
 }
 
 export async function execScript({ name }: { name: string }, argv: string[], services: ServiceManager, logger: Logger) {
+  logger.addLogContext({
+    scriptId: randomUUID(),
+    scriptName: name
+  });
+
   if (!existsSync(`build/scripts/${name}.js`)) {
     if (existsSync(`src/scripts/${name}.ts`)) {
       logger.error(`Script "${name}" not found in build/scripts/ but found in src/scripts/. Did you forget to build it?`);

--- a/packages/cli/src/run/run-script.ts
+++ b/packages/cli/src/run/run-script.ts
@@ -74,7 +74,9 @@ export async function execScript({ name }: { name: string }, argv: string[], ser
 
   try {
     await main(args, services);
+    logger.info(`Script "${name}" completed.`);
   } catch (error: any) {
     logger.error(error.message, { error });
+    logger.error(`Script "${name}" failed.`);
   }
 }

--- a/packages/cli/src/run/run-script.ts
+++ b/packages/cli/src/run/run-script.ts
@@ -19,7 +19,7 @@ export async function runScript({ name }: { name: string }, argv: string[]) {
     const services = new ServiceManager();
     const logger = services.get(Logger);
 
-    await execScript({ name }, argv, services, logger);
+    logger.initLogContext(() => execScript({ name }, argv, services, logger).catch(error => console.error(error)))
   } catch (error: any) {
     if (error.code === 'MODULE_NOT_FOUND') {
       console.error('@foal/core module not found. Are you sure you are in a FoalTS project?');

--- a/packages/cli/src/run/run-script.ts
+++ b/packages/cli/src/run/run-script.ts
@@ -73,7 +73,7 @@ export async function execScript({ name }: { name: string }, argv: string[], ser
   }
 
   try {
-    await main(args, services);
+    await main(args, services, logger);
     logger.info(`Script "${name}" completed.`);
   } catch (error: any) {
     logger.error(error.message, { error });

--- a/packages/examples/src/scripts/create-user.ts
+++ b/packages/examples/src/scripts/create-user.ts
@@ -1,8 +1,9 @@
 // App
+import { Logger, ServiceManager } from '@foal/core';
 import { Permission, User } from '../app/entities';
 import { dataSource  } from '../db';
 
-export async function main() {
+export async function main(args: any, services: ServiceManager, logger: Logger) {
   await dataSource.initialize();
 
   const user = new User();
@@ -19,7 +20,12 @@ export async function main() {
 
   user.userPermissions = [ permission ];
 
-  console.log(await permission.save());
-  console.log(await user.save());
-  console.log(await user2.save());
+  await permission.save();
+  logger.info(`Permission created: ${permission.codeName}`);
+
+  await user.save();
+  logger.info(`User created: ${user.id} ${user.email}`);
+
+  await user2.save();
+  logger.info(`User created: ${user2.id} ${user2.email}`);
 }


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

- It is not possible to use a log context in shell scripts or any services called from a shell script.
- When reading logs, it is not possible to aggregate logs through the execution of a given script as for an HTTP request.
- When a script succeeds or fails, no message is logged.
- Errors thrown in shell scripts are logged using `console.error` and not the logger which is not handy. When running a shell script in production, we may want to print the logs using a JSON format for example.

# Solution and steps

- [x] Use `logger.error` instead of `console.error` in "npx foal run”
- [x] Allow to use log context in shell scripts
- [x] Add a script ID and the script name to log context when running a script
- [x] Log if script run completed or failed
- [x] Pass logger as third argument to the script

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
