### PR TITLE
Make create-user generated with createapp work with MongoDB

### DIFF
--- a/packages/cli/src/generate/specs/app/src/scripts/create-user.ts
+++ b/packages/cli/src/generate/specs/app/src/scripts/create-user.ts
@@ -24,7 +24,7 @@ export async function main(args: any, services: ServiceManager, logger: Logger) 
 
     await user.save();
 
-    logger.info(`User created: ${user.id}`);
+    logger.info(`User created: ${JSON.stringify(user, null, 2)}`);
   } finally {
     await dataSource.destroy();
   }

--- a/packages/cli/src/generate/templates/app/src/scripts/create-user.ts
+++ b/packages/cli/src/generate/templates/app/src/scripts/create-user.ts
@@ -24,7 +24,7 @@ export async function main(args: any, services: ServiceManager, logger: Logger) 
 
     await user.save();
 
-    logger.info(`User created: ${user.id}`);
+    logger.info(`User created: ${JSON.stringify(user, null, 2)}`);
   } finally {
     await dataSource.destroy();
   }


### PR DESCRIPTION
# Issue

```
Error: src/scripts/create-user.ts(27,39): error TS2339: Property 'id' does not exist on type 'User'.
Error: Process completed with exit code 2.
```

It is actually named `_id` with MongoDB

# Solution and steps

- [x] Use a log that works with both.

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
