### PR TITLE
Better display errors thrown in "main()"

### DIFF
--- a/docs/docs/databases/other-orm/prisma.md
+++ b/docs/docs/databases/other-orm/prisma.md
@@ -99,7 +99,7 @@ async function main() {
 }
 
 main()
-  .catch(err => { console.error(err.stack); process.exit(1); })
+  .catch(err => { console.error(err); process.exit(1); })
   .finally(() => { prisma.$disconnect().catch(err => console.error(err)) });
 ```
 

--- a/docs/docs/security/rate-limiting.md
+++ b/docs/docs/security/rate-limiting.md
@@ -51,7 +51,7 @@ async function main() {
 }
 
 main()
-  .catch(err => { console.error(err.stack); process.exit(1); });
+  .catch(err => { console.error(err); process.exit(1); });
 ```
 
 

--- a/packages/cli/src/generate/specs/app/src/index.ts
+++ b/packages/cli/src/generate/specs/app/src/index.ts
@@ -20,4 +20,4 @@ async function main() {
 }
 
 main()
-  .catch(err => { console.error(err.stack); process.exit(1); });
+  .catch(err => { console.error(err); process.exit(1); });

--- a/packages/cli/src/generate/templates/app/src/index.ts
+++ b/packages/cli/src/generate/templates/app/src/index.ts
@@ -20,4 +20,4 @@ async function main() {
 }
 
 main()
-  .catch(err => { console.error(err.stack); process.exit(1); });
+  .catch(err => { console.error(err); process.exit(1); });

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -26,4 +26,4 @@ async function main() {
 }
 
 main()
-  .catch(err => { console.error(err.stack); process.exit(1); });
+  .catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
<!--
Please read the contribution guidelines first. A PR without (robust) tests will not be approved.
-->
# Issue

See #1316

When an error is raised in the `src/index.ts` file (outside Foal controllers, hooks or services), the error is not completely displayed. In particular, when the database connection fails (due to an incorrect port, for example), the error displayed is obscure.

This is due to the `catch` handler, which does not completely display the error but only the stack trace.

# Solution and steps

- [x] Make the catch handler properly display the error.

# Result

**Before**
<img width="366" alt="Capture d’écran 2025-06-15 à 07 14 40" src="https://github.com/user-attachments/assets/47bfc18b-50ee-4e7f-93bb-37c976be86db" />

**After**
<img width="385" alt="Capture d’écran 2025-06-15 à 07 15 00" src="https://github.com/user-attachments/assets/0e9089ab-6a5d-4fc2-89d4-aa47efc13326" />

# Checklist

- [x] Add/update/check docs (code comments and docs/ folder).
- [x] Add/update/check tests.
- [x] Update/check the cli generators.
