### PR TITLE
feat(core): Add HTTP 422 response type

### DIFF
--- a/docs/docs/architecture/controllers.md
+++ b/docs/docs/architecture/controllers.md
@@ -291,6 +291,7 @@ Here are subclasses that you can use:
 | 404 | `HttpResponseNotFound` | no |
 | 405 | `HttpResponseMethodNotAllowed` | no |
 | 409 | `HttpResponseConflict` | no |
+| 422 | `HttpResponseUnprocessableContent` | no |
 | 429 | `HttpResponseTooManyRequests` | no |
 |  | **5XX Server errors** | |
 | 5XX | `HttpResponseServerError` | yes |

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/architecture/controllers.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/architecture/controllers.md
@@ -291,6 +291,7 @@ Here are subclasses that you can use:
 | 404 | `HttpResponseNotFound` | no |
 | 405 | `HttpResponseMethodNotAllowed` | no |
 | 409 | `HttpResponseConflict` | no |
+| 422 | `HttpResponseUnprocessableContent` | no |
 | 429 | `HttpResponseTooManyRequests` | no |
 |  | **5XX Server errors** | |
 | 5XX | `HttpResponseServerError` | yes |

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/architecture/controllers.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/architecture/controllers.md
@@ -296,6 +296,7 @@ Here are subclasses that you can use:
 | 404 | `HttpResponseNotFound` | no |
 | 405 | `HttpResponseMethodNotAllowed` | no |
 | 409 | `HttpResponseConflict` | no |
+| 422 | `HttpResponseUnprocessableContent` | no |
 | 429 | `HttpResponseTooManyRequests` | no |
 |  | **5XX Server errors** | |
 | 5XX | `HttpResponseServerError` | yes |

--- a/docs/i18n/id/docusaurus-plugin-content-docs/current/architecture/controllers.md
+++ b/docs/i18n/id/docusaurus-plugin-content-docs/current/architecture/controllers.md
@@ -291,6 +291,7 @@ Here are subclasses that you can use:
 | 404 | `HttpResponseNotFound` | no |
 | 405 | `HttpResponseMethodNotAllowed` | no |
 | 409 | `HttpResponseConflict` | no |
+| 422 | `HttpResponseUnprocessableContent` | no |
 | 429 | `HttpResponseTooManyRequests` | no |
 |  | **5XX Server errors** | |
 | 5XX | `HttpResponseServerError` | yes |

--- a/packages/core/src/core/http/http-responses.spec.ts
+++ b/packages/core/src/core/http/http-responses.spec.ts
@@ -23,6 +23,7 @@ import {
   HttpResponseSuccess,
   HttpResponseTooManyRequests,
   HttpResponseUnauthorized,
+  HttpResponseUnprocessableContent,
   isHttpResponse,
   isHttpResponseBadRequest,
   isHttpResponseClientError,
@@ -41,7 +42,8 @@ import {
   isHttpResponseServerError,
   isHttpResponseSuccess,
   isHttpResponseTooManyRequests,
-  isHttpResponseUnauthorized
+  isHttpResponseUnauthorized,
+  isHttpResponseUnprocessableContent
 } from './http-responses';
 
 describe('HttpResponse', () => {
@@ -794,6 +796,68 @@ describe('isHttpResponseMethodNotAllowed', () => {
     strictEqual(isHttpResponseMethodNotAllowed(response), false);
     strictEqual(isHttpResponseMethodNotAllowed(undefined), false);
     strictEqual(isHttpResponseMethodNotAllowed(null), false);
+  });
+
+});
+
+describe('HttpResponseUnprocessableContent', () => {
+
+  it('should inherit from HttpResponseClientError and HttpResponse', () => {
+    const httpResponse = new HttpResponseUnprocessableContent();
+    ok(httpResponse instanceof HttpResponse);
+    ok(httpResponse instanceof HttpResponseClientError);
+  });
+
+  it('should have the correct status.', () => {
+    const httpResponse = new HttpResponseUnprocessableContent();
+    strictEqual(httpResponse.statusCode, 422);
+    strictEqual(httpResponse.statusMessage, 'UNPROCESSABLE CONTENT');
+  });
+
+  it('should accept an optional body.', () => {
+    let httpResponse = new HttpResponseUnprocessableContent();
+    strictEqual(httpResponse.body, undefined);
+
+    const body = { foo: 'bar' };
+    httpResponse = new HttpResponseUnprocessableContent(body);
+    strictEqual(httpResponse.body, body);
+  });
+
+  it('should accept optional options.', () => {
+    let httpResponse = new HttpResponseUnprocessableContent();
+    strictEqual(httpResponse.stream, false);
+
+    httpResponse = new HttpResponseUnprocessableContent({}, { stream: true });
+    strictEqual(httpResponse.stream, true);
+  });
+
+  it('should allow specifying the required type for the body', () => {
+    type NumberResponse = HttpResponseUnprocessableContent<number>
+    type BodyOnlyAcceptsNumbers = NumberResponse['body'] extends number ? true : never
+    const isTrue: BodyOnlyAcceptsNumbers = true
+    strictEqual(isTrue, true)
+  });
+
+});
+
+describe('isHttpResponseUnprocessableContent', () => {
+
+  it('should return true if the given object is an instance of HttpResponseUnprocessableContent.', () => {
+    const response = new HttpResponseUnprocessableContent();
+    strictEqual(isHttpResponseUnprocessableContent(response), true);
+  });
+
+  it('should return true if the given object has an isHttpResponseUnprocessableContent property equal to true.', () => {
+    const response = { isHttpResponseUnprocessableContent: true };
+    strictEqual(isHttpResponseUnprocessableContent(response), true);
+  });
+
+  it('should return false if the given object is not an instance of HttpResponseUnprocessableContent and if it '
+      + 'has no property isHttpResponseUnprocessableContent.', () => {
+    const response = {};
+    strictEqual(isHttpResponseUnprocessableContent(response), false);
+    strictEqual(isHttpResponseUnprocessableContent(undefined), false);
+    strictEqual(isHttpResponseUnprocessableContent(null), false);
   });
 
 });

--- a/packages/core/src/core/http/http-responses.ts
+++ b/packages/core/src/core/http/http-responses.ts
@@ -819,6 +819,52 @@ export function isHttpResponseConflict(obj: any): obj is HttpResponseConflict {
 }
 
 /**
+ * Represent an HTTP response with the status 422 - UNPROCESSABLE CONTENT.
+ *
+ * @export
+ * @class HttpResponseUnprocessableContent
+ * @extends {HttpResponseClientError}
+ */
+export class HttpResponseUnprocessableContent<T = any> extends HttpResponseClientError<T> {
+  /**
+   * Property used internally by isHttpResponseUnprocessableContent.
+   *
+   * @memberof HttpResponseUnprocessableContent
+   */
+  readonly isHttpResponseUnprocessableContent = true;
+  readonly statusCode = 422;
+  readonly statusMessage = 'UNPROCESSABLE CONTENT';
+
+  /**
+   * Create an instance of HttpResponseUnprocessableContent.
+   * @param {*} [body] - Optional body of the response.
+   * @memberof HttpResponseUnprocessableContent
+   */
+  constructor(body?: T, options: { stream?: boolean } = {}) {
+    super(body, options);
+  }
+}
+
+/**
+ * Check if an object is an instance of HttpResponseUnprocessableContent.
+ *
+ * This function is a help when you have several packages using @foal/core.
+ * Npm can install the package several times, which leads to duplicate class
+ * definitions. If this is the case, the keyword `instanceof` may return false
+ * while the object is an instance of the class. This function fixes this
+ * problem.
+ *
+ * @export
+ * @param {*} obj - The object to check.
+ * @returns {obj is HttpResponseUnprocessableContent} - True if the error is an instance of HttpResponseUnprocessableContent.
+ * False otherwise.
+ */
+export function isHttpResponseUnprocessableContent(obj: any): obj is HttpResponseUnprocessableContent {
+  return obj instanceof HttpResponseUnprocessableContent ||
+   (typeof obj === 'object' && obj !== null && obj.isHttpResponseUnprocessableContent === true);
+}
+
+/**
  * Represent an HTTP response with the status 429 - TOO MANY REQUESTS.
  *
  * @export

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -107,6 +107,7 @@ export {
   HttpResponseSuccess,
   HttpResponseTooManyRequests,
   HttpResponseUnauthorized,
+  HttpResponseUnprocessableContent,
 
   IApiAbstractParameter,
   IApiAbstractSecurityScheme,
@@ -212,6 +213,7 @@ export {
   isHttpResponseSuccess,
   isHttpResponseTooManyRequests,
   isHttpResponseUnauthorized,
+  isHttpResponseUnprocessableContent,
 
   Logger,
   render,


### PR DESCRIPTION
## Problem
No HTTP 422 response type exists.

Fixes #1355.

## Solution
Create the new response type, add tests and update docs.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/FoalTS/foal/blob/master/.github/CONTRIBUTING.MD).
- [X] I have added or updated tests for any code changes.
- [X] I have updated documentation if needed, keeping it concise.
