### PR TITLE
fix(social): preserve non-JSON token endpoint errors

### DIFF
--- a/packages/social/src/abstract-provider.service.spec.ts
+++ b/packages/social/src/abstract-provider.service.spec.ts
@@ -13,6 +13,7 @@ import {
   createService,
   HttpResponseBadRequest,
   HttpResponseOK,
+  HttpResponseTooManyRequests,
   isHttpResponseOK,
   isHttpResponseRedirect,
   Post
@@ -137,6 +138,80 @@ describe('TokenError', () => {
     const error = new TokenError(err);
 
     strictEqual(error.error, err);
+  });
+
+  it('should preserve its one-argument message format.', () => {
+    const error = new TokenError('bad request');
+
+    strictEqual(
+      error.message,
+      `The authorization server returned an error. Impossible to get an access token.
+"bad request"`
+    );
+  });
+
+  describe('has a "fromResponse" method that', () => {
+
+    it('should retain a JSON error body and the HTTP status.', async () => {
+      const error = await TokenError.fromResponse(new Response(
+        JSON.stringify({ error: 'bad request' }),
+        { status: 400 }
+      ));
+
+      deepStrictEqual(error.error, { error: 'bad request' });
+      strictEqual(error.status, 400);
+      strictEqual(
+        error.message,
+        `The authorization server returned an error. Impossible to get an access token.
+{
+  "error": "bad request"
+}
+Status: 400`
+      );
+    });
+
+    it('should retain a text error body and the HTTP status.', async () => {
+      const error = await TokenError.fromResponse(new Response('rate limited', { status: 429 }));
+
+      strictEqual(error.error, 'rate limited');
+      strictEqual(error.status, 429);
+      strictEqual(
+        error.message,
+        `The authorization server returned an error. Impossible to get an access token.
+"rate limited"
+Status: 429`
+      );
+    });
+
+    it('should retain only the HTTP status if the error body is empty.', async () => {
+      const error = await TokenError.fromResponse(new Response(null, { status: 429 }));
+
+      strictEqual(error.error, undefined);
+      strictEqual(error.status, 429);
+      strictEqual(
+        error.message,
+        `The authorization server returned an error. Impossible to get an access token.
+Status: 429`
+      );
+    });
+
+    it('should retain only the HTTP status if the error body cannot be read.', async () => {
+      const response = {
+        status: 429,
+        text: async () => { throw new Error('unreadable'); }
+      } as unknown as Response;
+
+      const error = await TokenError.fromResponse(response);
+
+      strictEqual(error.error, undefined);
+      strictEqual(error.status, 429);
+      strictEqual(
+        error.message,
+        `The authorization server returned an error. Impossible to get an access token.
+Status: 429`
+      );
+    });
+
   });
 
 });
@@ -544,6 +619,39 @@ describe('AbstractProvider', () => {
         deepStrictEqual(error.error, {
           error: 'bad request'
         });
+        strictEqual(error.status, 400);
+      }
+    });
+
+    it('should throw a TokenError if the token endpoint returns a non-JSON error.', async () => {
+      class AppController {
+        @Post('/token')
+        token() {
+          return new HttpResponseTooManyRequests('rate limited');
+        }
+      }
+
+      server = (await createApp(AppController)).listen(3000);
+
+      const ctx = new Context({
+        cookies: {
+          [STATE_COOKIE_NAME]: 'xxx'
+        },
+        query: {
+          code: 'an_authorization_code',
+          state: 'xxx',
+        },
+      });
+
+      try {
+        await provider.getTokens(ctx);
+        throw new Error('getTokens should have thrown a TokenError.');
+      } catch (error: any) {
+        if (!(error instanceof TokenError)) {
+          throw error;
+        }
+        strictEqual(error.error, 'rate limited');
+        strictEqual(error.status, 429);
       }
     });
 

--- a/packages/social/src/abstract-provider.service.ts
+++ b/packages/social/src/abstract-provider.service.ts
@@ -90,10 +90,31 @@ export class AuthorizationError extends Error {
 export class TokenError extends Error {
   readonly name = 'TokenError';
 
-  constructor(readonly error: any) {
+  static async fromResponse(response: Response): Promise<TokenError> {
+    let body: string;
+
+    try {
+      body = await response.text();
+    } catch {
+      return new TokenError(undefined, response.status);
+    }
+
+    if (body.length === 0) {
+      return new TokenError(undefined, response.status);
+    }
+
+    try {
+      return new TokenError(JSON.parse(body), response.status);
+    } catch {
+      return new TokenError(body, response.status);
+    }
+  }
+
+  constructor(readonly error: any, readonly status?: number) {
     super(
-      'The authorization server returned an error. Impossible to get an access token.\n'
-      + JSON.stringify(error, null, 2)
+      'The authorization server returned an error. Impossible to get an access token.'
+      + (status !== undefined && error === undefined ? '' : '\n' + JSON.stringify(error, null, 2))
+      + (status === undefined ? '' : `\nStatus: ${status}`)
     );
   }
 }
@@ -364,13 +385,12 @@ export abstract class AbstractProvider<AuthParameters extends ObjectType, UserIn
       headers,
       method: 'POST',
     });
-    const body = await response.json();
 
     if (!response.ok) {
-      throw new TokenError(body);
+      throw await TokenError.fromResponse(response);
     }
 
-    return body;
+    return response.json();
   }
 
   /**


### PR DESCRIPTION
## Problem

A non-2xx token endpoint response with an empty or non-JSON body is parsed with `response.json()` before its status is checked. This throws a JSON parsing error instead of a `TokenError`, losing the HTTP status and any plain-text response details.

Fixes #1297.

## Solution

- create `TokenError` instances from JSON, text, empty, or unreadable error responses
- retain the HTTP status while preserving the existing one-argument constructor behavior
- leave successful token response parsing unchanged
- add direct and integration coverage for each error-body case

## Testing

- `npm test --workspace=@foal/social` with Node 22 (64 passing)
- `npm test --workspace=@foal/social` with Node 24 (64 passing)
- `npx lerna run build`
- `npm run lint`
- `git diff --check`

## Checklist

- [x] I have read the contribution guidelines.
- [x] I have added or updated tests for any code changes.
- [x] I have updated documentation if needed, keeping it concise.
