### PR TITLE
feat(core): Add ValidateQuery hook

### DIFF
--- a/docs/docs/architecture/hooks.md
+++ b/docs/docs/architecture/hooks.md
@@ -22,7 +22,7 @@ They improve code readability and make unit testing easier.
 
 Foal provides a number of hooks to handle the most common scenarios.
 
-- `ValidateBody`, `ValidateHeader`, `ValidatePathParam`, `ValidateCookie` and `ValidateQueryParam` validate the format of the incoming HTTP requests (see [Validation](../common/validation-and-sanitization.md)).
+- `ValidateBody`, `ValidateHeader`, `ValidatePathParam`, `ValidateCookie`, `ValidateQueryParam` and `ValidateQuery` validate the format of the incoming HTTP requests (see [Validation](../common/validation-and-sanitization.md)).
 - `JWTRequired`, `JWTOptional`, `UseSessions` authenticate the user by filling the `ctx.user` property.
 - `PermissionRequired` restricts the route access to certain users.
 

--- a/docs/docs/common/validation-and-sanitization.md
+++ b/docs/docs/common/validation-and-sanitization.md
@@ -413,6 +413,75 @@ export class AppController {
 }
 ```
 
+#### ValidateQuery
+
+It validates the whole request query (`Context.request.query`) against a schema.
+
+*HTTP request*
+
+```
+GET /products?price=hello
+```
+
+*Controller (first example)*
+```typescript
+import { Get, ValidateQuery } from '@foal/core';
+
+export class AppController {
+  @Get('/products')
+  @ValidateQuery({
+    additionalProperties: false,
+    properties: {
+      price: { type: 'integer' },
+    },
+    required: [ 'price' ],
+    type: 'object'
+  })
+  readProducts() {
+    // ...
+  }
+}
+```
+
+*Controller (second example)*
+```typescript
+import { Get, ValidateQuery } from '@foal/core';
+
+export class AppController {
+  schema = {
+    additionalProperties: false,
+    properties: {
+      price: { type: 'integer' },
+    },
+    required: [ 'price' ],
+    type: 'object'
+  };
+
+  @Get('/products')
+  @ValidateQuery(controller => controller.schema)
+  readProducts() {
+    // ...
+  }
+}
+```
+
+*HTTP response (400 - BAD REQUEST)*
+```json
+{
+  "query": [
+    {
+      "instancePath": "/price",
+      "keyword": "type",
+      "message": "must be integer",
+      "params": {
+        "type": "integer"
+      },
+      "schemaPath": "#/properties/price/type"
+    }
+  ]
+}
+```
+
 ### Sanitization Example
 
 ```typescript

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current/architecture/hooks.md
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current/architecture/hooks.md
@@ -22,7 +22,7 @@ They improve code readability and make unit testing easier.
 
 Foal provides a number of hooks to handle the most common scenarios.
 
-- `ValidateBody`, `ValidateHeader`, `ValidatePathParam`, `ValidateCookie` and `ValidateQueryParam` validate the format of the incoming HTTP requests (see [Validation](../common/validation-and-sanitization.md)).
+- `ValidateBody`, `ValidateHeader`, `ValidatePathParam`, `ValidateCookie`, `ValidateQueryParam` and `ValidateQuery` validate the format of the incoming HTTP requests (see [Validation](../common/validation-and-sanitization.md)).
 - `Log` displays information on the request (see [Logging](../common/logging.md)).
 - `JWTRequired`, `JWTOptional`, `UseSessions` authenticate the user by filling the `ctx.user` property.
 - `PermissionRequired` restricts the route access to certain users.

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/architecture/hooks.md
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/architecture/hooks.md
@@ -22,7 +22,7 @@ They improve code readability and make unit testing easier.
 
 Foal provides a number of hooks to handle the most common scenarios.
 
-- `ValidateBody`, `ValidateHeader`, `ValidatePathParam`, `ValidateCookie` and `ValidateQueryParam` validate the format of the incoming HTTP requests (see [Validation](../common/validation-and-sanitization.md)).
+- `ValidateBody`, `ValidateHeader`, `ValidatePathParam`, `ValidateCookie`, `ValidateQueryParam` and `ValidateQuery` validate the format of the incoming HTTP requests (see [Validation](../common/validation-and-sanitization.md)).
 - `Log` displays information on the request (see [Logging](../common/logging.md)).
 - `JWTRequired`, `JWTOptional`, `UseSessions` authenticate the user by filling the `ctx.user` property.
 - `PermissionRequired` restricts the route access to certain users.

--- a/docs/i18n/id/docusaurus-plugin-content-docs/current/architecture/hooks.md
+++ b/docs/i18n/id/docusaurus-plugin-content-docs/current/architecture/hooks.md
@@ -22,7 +22,7 @@ They improve code readability and make unit testing easier.
 
 Foal provides a number of hooks to handle the most common scenarios.
 
-- `ValidateBody`, `ValidateHeader`, `ValidatePathParam`, `ValidateCookie` and `ValidateQueryParam` validate the format of the incoming HTTP requests (see [Validation](../common/validation-and-sanitization.md)).
+- `ValidateBody`, `ValidateHeader`, `ValidatePathParam`, `ValidateCookie`, `ValidateQueryParam` and `ValidateQuery` validate the format of the incoming HTTP requests (see [Validation](../common/validation-and-sanitization.md)).
 - `Log` displays information on the request (see [Logging](../common/logging.md)).
 - `JWTRequired`, `JWTOptional`, `UseSessions` authenticate the user by filling the `ctx.user` property.
 - `PermissionRequired` restricts the route access to certain users.

--- a/packages/core/src/common/validation/helpers/extract-properties.util.ts
+++ b/packages/core/src/common/validation/helpers/extract-properties.util.ts
@@ -1,0 +1,17 @@
+/**
+ * Extract the properties of a JSON schema object along with whether each of them is required.
+ *
+ * @export
+ * @param {object} schema - The JSON schema to extract the properties from.
+ * @returns {{ name: string, schema: any, required: boolean }[]} The extracted properties.
+ */
+export function extractProperties(schema: object): { name: string, schema: any, required: boolean }[] {
+  const properties = (schema as any).properties || {};
+  const required: string[] = (schema as any).required || [];
+
+  return Object.keys(properties).map(property => ({
+    name: property,
+    required: required.includes(property),
+    schema: properties[property],
+  }));
+}

--- a/packages/core/src/common/validation/helpers/index.ts
+++ b/packages/core/src/common/validation/helpers/index.ts
@@ -1,1 +1,3 @@
-export { isFunction } from './is-function.util';
+export { createObjectValidator } from "./validate-object.util";
+export { extractProperties } from "./extract-properties.util";
+export { isFunction } from "./is-function.util";

--- a/packages/core/src/common/validation/helpers/index.ts
+++ b/packages/core/src/common/validation/helpers/index.ts
@@ -1,3 +1,3 @@
-export { createObjectValidator } from "./validate-object.util";
-export { extractProperties } from "./extract-properties.util";
-export { isFunction } from "./is-function.util";
+export { createObjectValidator } from './validate-object.util';
+export { extractProperties } from './extract-properties.util';
+export { isFunction } from './is-function.util';

--- a/packages/core/src/common/validation/helpers/validate-object.util.ts
+++ b/packages/core/src/common/validation/helpers/validate-object.util.ts
@@ -1,0 +1,40 @@
+// 3p
+import { ValidateFunction } from 'ajv';
+
+// FoalTS
+import { OpenApi, ServiceManager } from '../../../core';
+import { getAjvInstance } from '../get-ajv-instance';
+import { isFunction } from './is-function.util';
+
+/**
+ * Create a function that validates a value against an AJV schema.
+ *
+ * The schema is compiled the first time the returned function is called and
+ * then cached for subsequent calls. This is the logic shared by hooks such as
+ * ValidateBody and ValidateQuery, which only differ in which part of the
+ * request they validate and how they report errors.
+ *
+ * @export
+ * @param {(object | ((controller: any) => object))} schema - Schema used to validate the value.
+ * @returns {(this: any, value: any, services: ServiceManager) => ValidateFunction['errors'] | null}
+ * A function returning the AJV errors if the value is not valid, otherwise null.
+ */
+export function createObjectValidator(
+  schema: object | ((controller: any) => object)
+): (this: any, value: any, services: ServiceManager) => ValidateFunction['errors'] | null {
+  let validateSchema: ValidateFunction|undefined;
+
+  return function validate(this: any, value: any, services: ServiceManager) {
+    if (!validateSchema) {
+      const ajvSchema = isFunction(schema) ? schema(this) : schema;
+      const components = services.get(OpenApi).getComponents(this);
+
+      validateSchema = getAjvInstance().compile({
+        ...ajvSchema,
+        components
+      });
+    }
+
+    return validateSchema(value) ? null : validateSchema.errors;
+  };
+}

--- a/packages/core/src/common/validation/index.ts
+++ b/packages/core/src/common/validation/index.ts
@@ -3,4 +3,5 @@ export { ValidateBody } from './validate-body.hook';
 export { ValidateCookie } from './validate-cookie.hook';
 export { ValidateHeader } from './validate-header.hook';
 export { ValidatePathParam } from './validate-path-param.hook';
+export { ValidateQuery } from './validate-query.hook';
 export { ValidateQueryParam } from './validate-query-param.hook';

--- a/packages/core/src/common/validation/validate-body.hook.ts
+++ b/packages/core/src/common/validation/validate-body.hook.ts
@@ -1,6 +1,3 @@
-// 3p
-import { ValidateFunction } from 'ajv';
-
 // FoalTS
 import {
   ApiRequestBody,
@@ -9,11 +6,9 @@ import {
   Hook,
   HookDecorator,
   HttpResponseBadRequest,
-  OpenApi,
   ServiceManager
 } from '../../core';
-import { getAjvInstance } from './get-ajv-instance';
-import { isFunction } from './helpers';
+import { createObjectValidator, isFunction } from './helpers';
 
 /**
  * Hook factory validating the body of the request against a AJV schema.
@@ -26,21 +21,12 @@ import { isFunction } from './helpers';
 export function ValidateBody(
   schema: object | ((controller: any) => object), options?: { openapi?: boolean }
 ): HookDecorator {
-  let validateSchema: ValidateFunction|undefined;
+  const validateObject = createObjectValidator(schema);
 
   function validate(this: any, ctx: Context, services: ServiceManager) {
-    if (!validateSchema) {
-      const ajvSchema = isFunction(schema) ? schema(this) : schema;
-      const components = services.get(OpenApi).getComponents(this);
-
-      validateSchema = getAjvInstance().compile({
-        ...ajvSchema,
-        components
-      });
-    }
-
-    if (!validateSchema(ctx.request.body)) {
-      return new HttpResponseBadRequest({ body: validateSchema.errors });
+    const errors = validateObject.call(this, ctx.request.body, services);
+    if (errors) {
+      return new HttpResponseBadRequest({ body: errors });
     }
   }
 

--- a/packages/core/src/common/validation/validate-query.hook.spec.ts
+++ b/packages/core/src/common/validation/validate-query.hook.spec.ts
@@ -1,0 +1,277 @@
+// std
+import { deepStrictEqual, notStrictEqual, ok, strictEqual } from 'assert';
+
+// FoalTS
+import {
+  Context,
+  getApiParameters,
+  getApiResponses,
+  getHookFunction,
+  HttpResponseBadRequest,
+  IApiSchema,
+  OpenApi,
+  ServiceManager
+} from '../../core';
+import { ValidateQuery } from './validate-query.hook';
+
+describe('ValidateQuery', () => {
+
+  const services = new ServiceManager();
+
+  const schema = {
+    properties: {
+      foo: { type: 'integer' }
+    },
+    type: 'object',
+  };
+
+  describe('should validate the request query and', () => {
+
+    describe('given schema is an object', () => {
+
+      it('should not return an HttpResponseBadRequest if ctx.request.query is validated '
+          + ' by ajv for the given schema.', () => {
+        const hook = getHookFunction(ValidateQuery(schema));
+        const ctx = new Context({});
+        ctx.request.query = {
+          foo: 3
+        };
+
+        const actual = hook(ctx, services);
+        strictEqual(actual instanceof HttpResponseBadRequest, false);
+      });
+
+      it('should return an HttpResponseBadRequest if ctx.request.query is not validated by '
+          + ' ajv for the given schema.', () => {
+        const hook = getHookFunction(ValidateQuery(schema));
+
+        function context(query: any) {
+          const ctx = new Context({});
+          ctx.request.query = query;
+          return ctx;
+        }
+
+        ok(hook(context(null), services) instanceof HttpResponseBadRequest);
+        ok(hook(context(undefined), services) instanceof HttpResponseBadRequest);
+        ok(hook(context('foo'), services) instanceof HttpResponseBadRequest);
+        ok(hook(context(3), services) instanceof HttpResponseBadRequest);
+        ok(hook(context(true), services) instanceof HttpResponseBadRequest);
+        ok(hook(context({ foo: 'a' }), services) instanceof HttpResponseBadRequest);
+      });
+
+      it('should return an HttpResponseBadRequest with a defined `query` property if '
+          + 'ctx.request.query is not validated by ajv.', () => {
+        const hook = getHookFunction(ValidateQuery(schema));
+        const ctx = new Context({});
+        ctx.request.query = { foo: 'a' };
+
+        const actual = hook(ctx, services);
+        if (!(actual instanceof HttpResponseBadRequest)) {
+          throw new Error('The hook should have returned an HttpResponseBadRequest object.');
+        }
+        deepStrictEqual(actual.body, {
+          query: [
+            {
+              instancePath: '/foo',
+              keyword: 'type',
+              message: 'must be integer',
+              params: { type: 'integer' },
+              schemaPath: '#/properties/foo/type',
+            }
+          ]
+        });
+      });
+
+      it('should use the OpenAPI components to validate the request query.', () => {
+        const services = new ServiceManager();
+        const openApi = services.get(OpenApi);
+
+        class ApiController {}
+        const controller = new ApiController();
+
+        openApi.addDocument(ApiController, {
+          components: {
+            schemas: {
+              query: schema as IApiSchema
+            }
+          },
+          info: {
+            title: 'Api',
+            version: '1.0.0',
+          },
+          openapi: '3.0.2',
+          paths: {},
+        }, [ controller ]);
+
+        const hook = getHookFunction(ValidateQuery({
+          $ref: '#/components/schemas/query'
+        })).bind(controller);
+        const ctx = new Context({});
+        ctx.request.query = {
+          foo: 'hello'
+        };
+
+        const actual = hook(ctx, services);
+        if (!(actual instanceof HttpResponseBadRequest)) {
+          throw new Error('The hook should have returned an HttpResponseBadRequest object.');
+        }
+        deepStrictEqual(actual.body, {
+          query: [
+            {
+              instancePath: '/foo',
+              keyword: 'type',
+              message: 'must be integer',
+              params: { type: 'integer' },
+              schemaPath: '#/components/schemas/query/properties/foo/type',
+            }
+          ]
+        });
+      });
+
+    });
+
+    describe('given schema is a function', () => {
+
+      it('should not return an HttpResponseBadRequest if ctx.request.query is validated '
+          + ' by ajv for the given schema.', () => {
+        const hook = getHookFunction(ValidateQuery(controller => controller.schema)).bind({ schema });
+        const ctx = new Context({});
+        ctx.request.query = {
+          foo: 3
+        };
+
+        const actual = hook(ctx, services);
+        strictEqual(actual instanceof HttpResponseBadRequest, false);
+      });
+
+      it('should return an HttpResponseBadRequest if ctx.request.query is not validated by '
+          + ' ajv for the given schema.', () => {
+        const hook = getHookFunction(ValidateQuery(controller => controller.schema)).bind({ schema });
+
+        function context(query: any) {
+          const ctx = new Context({});
+          ctx.request.query = query;
+          return ctx;
+        }
+
+        ok(hook(context(null), services) instanceof HttpResponseBadRequest);
+        ok(hook(context(undefined), services) instanceof HttpResponseBadRequest);
+        ok(hook(context('foo'), services) instanceof HttpResponseBadRequest);
+        ok(hook(context(3), services) instanceof HttpResponseBadRequest);
+        ok(hook(context(true), services) instanceof HttpResponseBadRequest);
+        ok(hook(context({ foo: 'a' }), services) instanceof HttpResponseBadRequest);
+      });
+
+      it('should return an HttpResponseBadRequest with a defined `query` property if '
+          + 'ctx.request.query is not validated by ajv.', () => {
+        const hook = getHookFunction(ValidateQuery(controller => controller.schema)).bind({ schema });
+        const ctx = new Context({});
+        ctx.request.query = { foo: 'a' };
+
+        const actual = hook(ctx, services);
+        ok(actual instanceof HttpResponseBadRequest);
+        notStrictEqual((actual as HttpResponseBadRequest).body, undefined);
+      });
+
+      it('should use the OpenAPI components to validate the request query.', () => {
+        const services = new ServiceManager();
+        const openApi = services.get(OpenApi);
+
+        class ApiController {
+          schema = {
+            $ref: '#/components/schemas/query'
+          };
+        }
+        const controller = new ApiController();
+
+        openApi.addDocument(ApiController, {
+          components: {
+            schemas: {
+              query: schema as IApiSchema
+            }
+          },
+          info: {
+            title: 'Api',
+            version: '1.0.0',
+          },
+          openapi: '3.0.2',
+          paths: {},
+        }, [ controller ]);
+
+        const hook = getHookFunction(ValidateQuery(controller => controller.schema)).bind(controller);
+        const ctx = new Context({});
+        ctx.request.query = {
+          foo: 'hello'
+        };
+
+        const actual = hook(ctx, services);
+        if (!(actual instanceof HttpResponseBadRequest)) {
+          throw new Error('The hook should have returned an HttpResponseBadRequest object.');
+        }
+        deepStrictEqual(actual.body, {
+          query: [
+            {
+              instancePath: '/foo',
+              keyword: 'type',
+              message: 'must be integer',
+              params: { type: 'integer' },
+              schemaPath: '#/components/schemas/query/properties/foo/type',
+            }
+          ]
+        });
+      });
+
+    });
+
+  });
+
+  describe('should define an API specification', () => {
+
+    it('unless options.openapi is false.', () => {
+      @ValidateQuery(schema, { openapi: false })
+      class Foobar {}
+
+      strictEqual(getApiParameters(Foobar), undefined);
+      strictEqual(getApiResponses(Foobar), undefined);
+    });
+
+    it('with one ApiParameter per property in the schema (object).', () => {
+      @ValidateQuery({
+        properties: {
+          bar: { type: 'string' },
+          foo: { type: 'integer' }
+        },
+        required: [ 'foo' ],
+        type: 'object'
+      })
+      class Foobar {}
+
+      const actual = getApiParameters(Foobar) || [];
+
+      deepStrictEqual(actual, [
+        { in: 'query', name: 'bar', schema: { type: 'string' } },
+        { in: 'query', name: 'foo', required: true, schema: { type: 'integer' } },
+      ]);
+    });
+
+    it('with no ApiParameter when the schema is a function.', () => {
+      @ValidateQuery((controller: Foobar) => controller.schema)
+      class Foobar {
+        schema = schema;
+      }
+
+      strictEqual(getApiParameters(Foobar), undefined);
+    });
+
+    it('with the proper API responses.', () => {
+      @ValidateQuery(schema)
+      class Foobar {}
+
+      deepStrictEqual(getApiResponses(Foobar), {
+        400: { description: 'Bad request.' }
+      });
+    });
+
+  });
+
+});

--- a/packages/core/src/common/validation/validate-query.hook.ts
+++ b/packages/core/src/common/validation/validate-query.hook.ts
@@ -1,0 +1,53 @@
+// FoalTS
+import {
+  ApiParameter,
+  ApiResponse,
+  Context,
+  Hook,
+  HookDecorator,
+  HttpResponseBadRequest,
+  IApiQueryParameter,
+  ServiceManager
+} from '../../core';
+import { createObjectValidator, extractProperties, isFunction } from './helpers';
+
+/**
+ * Hook factory validating the whole query of the request against a AJV schema.
+ *
+ * @export
+ * @param {(object | ((controller: any) => object))} schema - Schema used to validate the request query.
+ * @param {{ openapi?: boolean }} [options] - Options to add openapi metadata
+ * @returns {HookDecorator} - The hook.
+ */
+export function ValidateQuery(
+  schema: object | ((controller: any) => object), options?: { openapi?: boolean }
+): HookDecorator {
+  const validateObject = createObjectValidator(schema);
+
+  function validate(this: any, ctx: Context, services: ServiceManager) {
+    const errors = validateObject.call(this, ctx.request.query, services);
+    if (errors) {
+      return new HttpResponseBadRequest({ query: errors });
+    }
+  }
+
+  const openapi = [
+    // The schema properties can only be listed as individual OpenAPI parameters when the
+    // schema is a plain object. When it is a function, its shape depends on the controller
+    // instance and cannot be known while building the class/method decorators.
+    ...(isFunction(schema) ? [] : extractProperties(schema).map(property => {
+      const apiQueryParameter: IApiQueryParameter = { in: 'query', name: property.name };
+      if (property.required) {
+        apiQueryParameter.required = true;
+      }
+
+      return ApiParameter({
+        ...apiQueryParameter,
+        schema: property.schema
+      });
+    })),
+    ApiResponse(400, { description: 'Bad request.' })
+  ];
+
+  return Hook(validate, openapi, options);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export {
   ValidateCookie,
   ValidateHeader,
   ValidatePathParam,
+  ValidateQuery,
   ValidateQueryParam,
   PermissionRequired,
   IUserWithPermissions,

--- a/tests/docs-tests/src/tests/common/validation-and-sanitization.spec.ts
+++ b/tests/docs-tests/src/tests/common/validation-and-sanitization.spec.ts
@@ -15,6 +15,7 @@ import {
   ValidateCookie,
   ValidateHeader,
   ValidatePathParam,
+  ValidateQuery,
   ValidateQueryParam
 } from '@foal/core';
 import { ValidateBody as ValidateBodyFromClass} from '@foal/typestack';
@@ -344,6 +345,74 @@ describe('[Docs] Input Validation & Sanitization', () => {
 
           return request(app)
             .get('/products?authorization=xxx&a-number=hello')
+            .expect(400)
+            .expect(errors);
+        });
+
+      });
+
+      describe('ValidateQuery', () => {
+
+        const errors = {
+          query: [
+            {
+              instancePath: '/price',
+              keyword: 'type',
+              message: 'must be integer',
+              params: {
+                type: 'integer'
+              },
+              schemaPath: '#/properties/price/type'
+            }
+          ]
+        };
+
+        it('(first example)', async () => {
+          class AppController {
+            @Get('/products')
+            @ValidateQuery({
+              additionalProperties: false,
+              properties: {
+                price: { type: 'integer' },
+              },
+              required: [ 'price' ],
+              type: 'object'
+            })
+            readProducts() {
+              // ...
+            }
+          }
+
+          const app = await createApp(AppController);
+
+          return request(app)
+            .get('/products?price=hello')
+            .expect(400)
+            .expect(errors);
+        });
+
+        it('(second example)', async () => {
+          class AppController {
+            schema = {
+              additionalProperties: false,
+              properties: {
+                price: { type: 'integer' },
+              },
+              required: [ 'price' ],
+              type: 'object'
+            };
+
+            @Get('/products')
+            @ValidateQuery(controller => controller.schema)
+            readProducts() {
+              // ...
+            }
+          }
+
+          const app = await createApp(AppController);
+
+          return request(app)
+            .get('/products?price=hello')
             .expect(400)
             .expect(errors);
         });


### PR DESCRIPTION
## Problem
Leverages the schema validation approach from `ValidateBody` and applies it in a new `ValidateQuery` hook that targets `request.query`.

Addresses #1367.

## Solution
Refactor the `ValidateBody` hook and pull out the schema validation into a shared helper. Leverage that helper in the `ValidateBody` hook to preserve existing functionality.

Create a new `ValidateQuery` hook that leverages the same helper, add automated tests and update documentation.

Note: have made a first-pass at updating the docs but I'm aware that there may be gaps. Will wait for a maintainer to confirm.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/FoalTS/foal/blob/master/.github/CONTRIBUTING.MD).
- [X] I have added or updated tests for any code changes.
- [x] I have updated documentation if needed, keeping it concise. 
